### PR TITLE
Add operator-framework/opm to allowed registries

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -5,6 +5,7 @@ rule_data:
   allowed_registry_prefixes:
   - registry.access.redhat.com/
   - registry.redhat.io/
+  - quay.io/operator-framework/opm
 
   allowed_step_image_registry_prefixes:
   - quay.io/redhat-appstudio/


### PR DESCRIPTION
This is needed in particular for FBC builds. As a short term
solution let's just add it to the default allowed list.

In the longer term there should be some thinking about what useful
defaults would be and how we might maintain different versions of
these lists, e.g. for RH internal use and for "5 clicks" users.