### PR TITLE
Add one more higher precedence rule data key

### DIFF
--- a/policy/lib/rule_data.rego
+++ b/policy/lib/rule_data.rego
@@ -36,6 +36,7 @@ rule_data_defaults := {
 }
 
 # Returns the "first found" of the following:
+#   data.rule_data__configuration__[key_name]
 #   data.rule_data_custom[key_name]
 #   data.rule_data[key_name]
 #   rule_data_defaults[key_name]
@@ -43,11 +44,21 @@ rule_data_defaults := {
 # And falls back to an empty list if the key is not found anywhere.
 #
 rule_data(key_name) := value {
+	# Expected to be defined under `configuration.rule_data` in the
+	# ECP configuration data being used when EC is run.
+	value := data.rule_data__configuration__[key_name]
+} else := value {
+	# Expected to be defined in a users custom data source accessed
+	# via an oci bundle or (more likely) a git url.
 	value := data.rule_data_custom[key_name]
 } else := value {
+	# Expected to be defined in a default data source accessed via
+	# an oci bundle or a maybe a git url. See data/rule_data.yml.
 	value := data.rule_data[key_name]
 } else := value {
+	# Default values defined in this file. See above.
 	value := rule_data_defaults[key_name]
 } else := value {
+	# If the key is not found, default to an empty list
 	value := []
 }

--- a/policy/lib/rule_data_test.rego
+++ b/policy/lib/rule_data_test.rego
@@ -5,19 +5,22 @@ import data.lib
 test_rule_data {
 	lib.assert_equal(
 		[
+			40, # key0 value comes from data.rule_data__configuration__
 			30, # key1 value comes from data.rule_data_custom
 			20, # key2 value comes from data.rule_data
 			10, # key3 value comes from lib.rule_data_defaults
 			[], # key4 value is not defined
 		],
 		[
+			lib.rule_data("key0"),
 			lib.rule_data("key1"),
 			lib.rule_data("key2"),
 			lib.rule_data("key3"),
 			lib.rule_data("key4"),
 		],
-	) with data.rule_data_custom as {"key1": 30}
-		with data.rule_data as {"key1": 20, "key2": 20}
+	) with data.rule_data__configuration__ as {"key0": 40}
+		with data.rule_data_custom as {"key0": 30, "key1": 30}
+		with data.rule_data as {"key0": 20, "key1": 20, "key2": 20}
 		with lib.rule_data_defaults as {"key3": 10}
 }
 


### PR DESCRIPTION
The plan is that EC will create a data file using data found in the ECP CR. This provides a convenient way for a user to specify some custom data without needing to create a data source.

JIRA: HACBS-2042