### PR TITLE
Make sure the partial template is matched

### DIFF
--- a/antora/ec-policies-antora-extension/index.js
+++ b/antora/ec-policies-antora-extension/index.js
@@ -290,22 +290,22 @@ module.exports.register = function() {
     //
     const navPartials = [
       {
-          name: 'release_policy_nav.adoc',
+          name: '/release_policy_nav.adoc',
           template: Handlebars.compile,
           collections: {rulesCollection: releaseCollections, pipelineCollection: pipelineCollections, releaseAnnotations: releaseAnnotations}
       },
       {
-          name: 'pipeline_policy_nav.adoc',
+          name: '/pipeline_policy_nav.adoc',
           template: Handlebars.compile,
           collections: {pipelineAnnotations: pipelineAnnotations}
       },
       {
-          name: 'task_policy_nav.adoc',
+          name: '/task_policy_nav.adoc',
           template: Handlebars.compile,
           collections: {taskAnnotations: taskAnnotations}
       },
       {
-          name: 'build_task_policy_nav.adoc',
+          name: '/build_task_policy_nav.adoc',
           template: Handlebars.compile,
           collections: {buildTaskAnnotations: buildTaskAnnotations}
       },


### PR DESCRIPTION
The `task_policy_nav.adoc` and `build_task_policy_nav.adoc` both end with `task_policy_nav.adoc`. This makes the template matching match from the path separator (`/`) to make the template matching exact.

Solves:
```
 [07:53:03.996] WARN (asciidoctor): skipping reference to missing attribute: anchor
    file: antora/docs/modules/ROOT/nav.adoc
    source: https://github.com/enterprise-contract/ec-policies.git (branch: main | start path: antora/docs)
[07:53:04.000] WARN (asciidoctor): skipping reference to missing attribute: title
    file: antora/docs/modules/ROOT/nav.adoc
    source: https://github.com/enterprise-contract/ec-policies.git (branch: main | start path: antora/docs)
```