### PR TITLE
Update policies to use new name of tasks

### DIFF
--- a/data/required_tasks.yml
+++ b/data/required_tasks.yml
@@ -1,6 +1,22 @@
 ---
 pipeline-required-tasks:
   fbc:
+    - effective_on: "2023-04-28T00:00:00Z"
+      tasks:
+        - buildah
+        - clair-scan
+        - clamav-scan
+        - deprecated-image-check
+        - fbc-related-image-check
+        - fbc-validation
+        - git-clone
+        - init
+        - prefetch-dependencies
+        - inspect-image
+        - label-check
+        - sast-snyk-check
+        - sbom-json-check
+        - summary
     - effective_on: "2023-03-16T00:00:00Z"
       tasks:
         - buildah
@@ -18,6 +34,20 @@ pipeline-required-tasks:
         - sbom-json-check
         - summary
   generic:
+    - effective_on: "2023-04-28T00:00:00Z"
+      tasks:
+        - buildah
+        - clair-scan
+        - clamav-scan
+        - deprecated-image-check
+        - git-clone
+        - init
+        - prefetch-dependencies
+        - inspect-image
+        - label-check
+        - sast-snyk-check
+        - sbom-json-check
+        - summary
     - effective_on: "2023-04-15T00:00:00Z"
       tasks:
         - buildah
@@ -33,6 +63,20 @@ pipeline-required-tasks:
         - sbom-json-check
         - summary
   java:
+    - effective_on: "2023-04-28T00:00:00Z"
+      tasks:
+        - clair-scan
+        - clamav-scan
+        - deprecated-image-check
+        - git-clone
+        - init
+        - prefetch-dependencies
+        - s2i-java
+        - inspect-image
+        - label-check
+        - sast-snyk-check
+        - sbom-json-check
+        - summary
     - effective_on: "2023-03-16T00:00:00Z"
       tasks:
         - clair-scan
@@ -48,6 +92,20 @@ pipeline-required-tasks:
         - sbom-json-check
         - summary
   nodejs:
+    - effective_on: "2023-04-28T00:00:00Z"
+      tasks:
+        - clair-scan
+        - clamav-scan
+        - deprecated-image-check
+        - git-clone
+        - init
+        - prefetch-dependencies
+        - s2i-nodejs
+        - inspect-image
+        - label-check
+        - sast-snyk-check
+        - sbom-json-check
+        - summary
     - effective_on: "2023-03-16T00:00:00Z"
       tasks:
         - clair-scan
@@ -63,6 +121,17 @@ pipeline-required-tasks:
         - sbom-json-check
         - summary
 required-tasks:
+  - effective_on: "2023-04-28T00:00:00Z"
+    tasks:
+      - clair-scan
+      - clamav-scan
+      - git-clone
+      - init
+      - prefetch-dependencies
+      - inspect-image
+      - label-check
+      - sast-snyk-check
+      - summary
   - effective_on: "2023-03-16T00:00:00Z"
     tasks:
       - clair-scan

--- a/policy/lib/tekton/task_test.rego
+++ b/policy/lib/tekton/task_test.rego
@@ -178,8 +178,8 @@ _expected_latest := {
 		"git-clone",
 		"buildah",
 		"conftest-clair",
-		"sanity-label-check[POLICY_NAMESPACE=required_checks]",
-		"sanity-label-check[POLICY_NAMESPACE=optional_checks]",
+		"label-check[POLICY_NAMESPACE=required_checks]",
+		"label-check[POLICY_NAMESPACE=optional_checks]",
 	],
 }
 
@@ -189,8 +189,8 @@ _expected_current := {
 		"git-clone",
 		"buildah",
 		"not-required-in-future",
-		"sanity-label-check[POLICY_NAMESPACE=required_checks]",
-		"sanity-label-check[POLICY_NAMESPACE=optional_checks]",
+		"label-check[POLICY_NAMESPACE=required_checks]",
+		"label-check[POLICY_NAMESPACE=optional_checks]",
 	],
 }
 

--- a/policy/pipeline/required_tasks_test.rego
+++ b/policy/pipeline/required_tasks_test.rego
@@ -160,7 +160,7 @@ test_parameterized if {
 	with_wrong_parameter := [
 		{
 			"taskRef": {
-				"name": "sanity-label-check",
+				"name": "label-check",
 				"kind": "Task",
 				"bundle": _bundle,
 			},
@@ -168,7 +168,7 @@ test_parameterized if {
 		},
 		{
 			"taskRef": {
-				"name": "sanity-label-check",
+				"name": "label-check",
 				"kind": "Task",
 				"bundle": _bundle,
 			},
@@ -177,7 +177,7 @@ test_parameterized if {
 	]
 	pipeline := _pipeline_with_tasks_and_label({"git-clone", "buildah"}, [], with_wrong_parameter)
 
-	expected := _missing_default_tasks_violation({"sanity-label-check[POLICY_NAMESPACE=required_checks]"})
+	expected := _missing_default_tasks_violation({"label-check[POLICY_NAMESPACE=required_checks]"})
 	lib.assert_equal(expected, deny) with data["required-tasks"] as _time_based_required_tasks
 		with input as pipeline
 }
@@ -292,8 +292,8 @@ _time_based_pipeline_required_tasks_future_only := {"fbc": [{"tasks": _expected_
 _expected_required_tasks := {
 	"git-clone",
 	"buildah",
-	"sanity-label-check[POLICY_NAMESPACE=required_checks]",
-	"sanity-label-check[POLICY_NAMESPACE=optional_checks]",
+	"label-check[POLICY_NAMESPACE=required_checks]",
+	"label-check[POLICY_NAMESPACE=optional_checks]",
 }
 
 _expected_future_required_tasks := {
@@ -301,8 +301,8 @@ _expected_future_required_tasks := {
 	"buildah",
 	"buildah-future",
 	"conftest-clair",
-	"sanity-label-check[POLICY_NAMESPACE=required_checks]",
-	"sanity-label-check[POLICY_NAMESPACE=optional_checks]",
+	"label-check[POLICY_NAMESPACE=required_checks]",
+	"label-check[POLICY_NAMESPACE=optional_checks]",
 }
 
 _time_based_required_tasks := [
@@ -312,8 +312,8 @@ _time_based_required_tasks := [
 			"git-clone",
 			"buildah",
 			"conftest-clair",
-			"sanity-label-check[POLICY_NAMESPACE=required_checks]",
-			"sanity-label-check[POLICY_NAMESPACE=optional_checks]",
+			"label-check[POLICY_NAMESPACE=required_checks]",
+			"label-check[POLICY_NAMESPACE=optional_checks]",
 		],
 	},
 	{
@@ -326,8 +326,8 @@ _time_based_required_tasks := [
 			"git-clone",
 			"buildah",
 			"not-required-in-future",
-			"sanity-label-check[POLICY_NAMESPACE=required_checks]",
-			"sanity-label-check[POLICY_NAMESPACE=optional_checks]",
+			"label-check[POLICY_NAMESPACE=required_checks]",
+			"label-check[POLICY_NAMESPACE=optional_checks]",
 		],
 	},
 	{

--- a/policy/release/tasks_test.rego
+++ b/policy/release/tasks_test.rego
@@ -101,7 +101,7 @@ test_parameterized if {
 	with_wrong_parameter := [
 		{
 			"ref": {
-				"name": "sanity-label-check",
+				"name": "label-check",
 				"kind": "Task",
 				"bundle": _bundle,
 			},
@@ -109,7 +109,7 @@ test_parameterized if {
 		},
 		{
 			"ref": {
-				"name": "sanity-label-check",
+				"name": "label-check",
 				"kind": "Task",
 				"bundle": _bundle,
 			},
@@ -118,7 +118,7 @@ test_parameterized if {
 	]
 	attestations := _attestations_with_tasks({"git-clone", "buildah"}, with_wrong_parameter)
 
-	expected := _missing_tasks_violation({"sanity-label-check[POLICY_NAMESPACE=required_checks]"})
+	expected := _missing_tasks_violation({"label-check[POLICY_NAMESPACE=required_checks]"})
 	lib.assert_equal(deny, expected) with data["pipeline-required-tasks"] as _time_based_required_pipeline_tasks
 		with input.attestations as attestations
 }
@@ -204,16 +204,16 @@ _missing_tasks_warning(tasks) = warnings if {
 _expected_required_tasks := {
 	"git-clone",
 	"buildah",
-	"sanity-label-check[POLICY_NAMESPACE=required_checks]",
-	"sanity-label-check[POLICY_NAMESPACE=optional_checks]",
+	"label-check[POLICY_NAMESPACE=required_checks]",
+	"label-check[POLICY_NAMESPACE=optional_checks]",
 }
 
 _expected_future_required_tasks := {
 	"git-clone",
 	"buildah",
 	"conftest-clair",
-	"sanity-label-check[POLICY_NAMESPACE=required_checks]",
-	"sanity-label-check[POLICY_NAMESPACE=optional_checks]",
+	"label-check[POLICY_NAMESPACE=required_checks]",
+	"label-check[POLICY_NAMESPACE=optional_checks]",
 }
 
 _time_based_required_pipeline_tasks := {"generic": [
@@ -223,8 +223,8 @@ _time_based_required_pipeline_tasks := {"generic": [
 			"git-clone",
 			"buildah",
 			"conftest-clair",
-			"sanity-label-check[POLICY_NAMESPACE=required_checks]",
-			"sanity-label-check[POLICY_NAMESPACE=optional_checks]",
+			"label-check[POLICY_NAMESPACE=required_checks]",
+			"label-check[POLICY_NAMESPACE=optional_checks]",
 		],
 	},
 	{
@@ -237,8 +237,8 @@ _time_based_required_pipeline_tasks := {"generic": [
 			"git-clone",
 			"buildah",
 			"not-required-in-future",
-			"sanity-label-check[POLICY_NAMESPACE=required_checks]",
-			"sanity-label-check[POLICY_NAMESPACE=optional_checks]",
+			"label-check[POLICY_NAMESPACE=required_checks]",
+			"label-check[POLICY_NAMESPACE=optional_checks]",
 		],
 	},
 	{
@@ -254,8 +254,8 @@ _time_based_required_tasks := [
 			"git-clone",
 			"buildah",
 			"conftest-clair",
-			"sanity-label-check[POLICY_NAMESPACE=required_checks]",
-			"sanity-label-check[POLICY_NAMESPACE=optional_checks]",
+			"label-check[POLICY_NAMESPACE=required_checks]",
+			"label-check[POLICY_NAMESPACE=optional_checks]",
 		],
 	},
 	{
@@ -268,8 +268,8 @@ _time_based_required_tasks := [
 			"git-clone",
 			"buildah",
 			"not-required-in-future",
-			"sanity-label-check[POLICY_NAMESPACE=required_checks]",
-			"sanity-label-check[POLICY_NAMESPACE=optional_checks]",
+			"label-check[POLICY_NAMESPACE=required_checks]",
+			"label-check[POLICY_NAMESPACE=optional_checks]",
 		],
 	},
 	{


### PR DESCRIPTION
https://issues.redhat.com/browse/HACBS-2054

`sanity-label-check` -> `label-check`
`sanity-inspect-image` -> `inspect-image`

The task bundles are tracked to be required on 2023-04-28. So I used the same date when modifying the required tasks list.

The tests didn't need to be updated since all the data is mocked. I updated them anyways to avoid future confusion.