### PR TITLE
Revise rule titles and short names

### DIFF
--- a/policy/release/attestation_task_bundle.rego
+++ b/policy/release/attestation_task_bundle.rego
@@ -16,12 +16,12 @@ import data.lib
 import data.lib.bundles
 
 # METADATA
-# title: Task bundle was not used or is not defined
+# title: Tasks defined using bundle references
 # description: >-
 #   Check for existence of a task bundle. Enforcing this rule will
 #   fail the contract if the task is not called from a bundle.
 # custom:
-#   short_name: disallowed_task_reference
+#   short_name: tasks_defined_in_bundle
 #   failure_msg: Pipeline task '%s' does not contain a bundle reference
 #   collections:
 #   - minimal
@@ -32,11 +32,11 @@ deny[result] {
 }
 
 # METADATA
-# title: Task bundle reference is empty
+# title: Task bundle references not empty
 # description: >-
 #   Check for a valid task bundle reference being used.
 # custom:
-#   short_name: empty_task_bundle_reference
+#   short_name: task_ref_bundles_not_empty
 #   failure_msg: Pipeline task '%s' uses an empty bundle image reference
 #   collections:
 #   - minimal
@@ -47,12 +47,12 @@ deny[result] {
 }
 
 # METADATA
-# title: Unpinned task bundle reference
+# title: Task bundle references pinned to digest
 # description: >-
 #   Check if the Tekton Bundle used for the Tasks in the Pipeline definition
 #   is pinned to a digest.
 # custom:
-#   short_name: unpinned_task_bundle
+#   short_name: task_ref_bundles_pinned
 #   failure_msg: Pipeline task '%s' uses an unpinned task bundle reference '%s'
 #   solution: >-
 #     Specify the task bundle reference with a full digest rather than a tag.
@@ -63,12 +63,12 @@ warn[result] {
 }
 
 # METADATA
-# title: Task bundle is out of date
+# title: Task bundles are latest versions
 # description: >-
 #   For each Task in the SLSA Provenance attestation, check if the Tekton Bundle used is
 #   the most recent xref:acceptable_bundles.adoc#_task_bundles[acceptable bundle].
 # custom:
-#   short_name: out_of_date_task_bundle
+#   short_name: task_ref_bundles_current
 #   failure_msg: Pipeline task '%s' uses an out of date task bundle '%s'
 #
 warn[result] {
@@ -77,13 +77,13 @@ warn[result] {
 }
 
 # METADATA
-# title: Task bundle is not acceptable
+# title: Task bundles are in acceptable bundles list
 # description: >-
 #   For each Task in the SLSA Provenance attestation, check if the Tekton Bundle used is
 #   an xref:acceptable_bundles.adoc#_task_bundles[acceptable bundle] given the tracked
 #   effective_on date.
 # custom:
-#   short_name: unacceptable_task_bundle
+#   short_name: task_ref_bundles_acceptable
 #   failure_msg: Pipeline task '%s' uses an unacceptable task bundle '%s'
 #
 deny[result] {
@@ -92,11 +92,12 @@ deny[result] {
 }
 
 # METADATA
-# title: Missing required data
+# title: An acceptable Tekton bundles list was provided
 # description: >-
-#   The policy rules in this package require the task-bundles data to be provided.
+#   The policy rules in this package require the acceptable Tekton task bundles
+#   rule data to be provided.
 # custom:
-#   short_name: missing_required_data
+#   short_name: acceptable_bundles_provided
 #   failure_msg: Missing required task-bundles data
 deny[result] {
 	bundles.missing_task_bundles_data

--- a/policy/release/attestation_task_bundle_test.rego
+++ b/policy/release/attestation_task_bundle_test.rego
@@ -18,7 +18,7 @@ test_bundle_not_exists {
 
 	expected_msg := "Pipeline task 'my-task' does not contain a bundle reference"
 	lib.assert_equal(deny, {{
-		"code": "attestation_task_bundle.disallowed_task_reference",
+		"code": "attestation_task_bundle.tasks_defined_in_bundle",
 		"collections": ["minimal"],
 		"msg": expected_msg,
 		"effective_on": "2022-01-01T00:00:00Z",
@@ -37,7 +37,7 @@ test_bundle_not_exists_empty_string {
 
 	expected_msg := sprintf("Pipeline task '%s' uses an empty bundle image reference", [name])
 	lib.assert_equal(deny, {{
-		"code": "attestation_task_bundle.empty_task_bundle_reference",
+		"code": "attestation_task_bundle.task_ref_bundles_not_empty",
 		"collections": ["minimal"],
 		"msg": expected_msg,
 		"effective_on": "2022-01-01T00:00:00Z",
@@ -59,7 +59,7 @@ test_bundle_unpinned {
 
 	expected_msg := sprintf("Pipeline task '%s' uses an unpinned task bundle reference '%s'", [name, image])
 	lib.assert_equal(warn, {{
-		"code": "attestation_task_bundle.unpinned_task_bundle",
+		"code": "attestation_task_bundle.task_ref_bundles_pinned",
 		"msg": expected_msg,
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with input.attestations as d
@@ -97,12 +97,12 @@ test_acceptable_bundle_out_of_date_past {
 
 	lib.assert_equal(warn, {
 		{
-			"code": "attestation_task_bundle.out_of_date_task_bundle",
+			"code": "attestation_task_bundle.task_ref_bundles_current",
 			"effective_on": "2022-01-01T00:00:00Z",
 			"msg": "Pipeline task 'task-run-0' uses an out of date task bundle 'reg.com/repo@sha256:bcd'",
 		},
 		{
-			"code": "attestation_task_bundle.out_of_date_task_bundle",
+			"code": "attestation_task_bundle.task_ref_bundles_current",
 			"effective_on": "2022-01-01T00:00:00Z",
 			"msg": "Pipeline task 'task-run-1' uses an out of date task bundle 'reg.com/repo@sha256:cde'",
 		},
@@ -120,16 +120,16 @@ test_acceptable_bundle_expired {
 		with data["task-bundles"] as task_bundles
 
 	lib.assert_equal(deny, {{
-		"code": "attestation_task_bundle.unacceptable_task_bundle",
+		"code": "attestation_task_bundle.task_ref_bundles_acceptable",
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Pipeline task 'task-run-0' uses an unacceptable task bundle 'reg.com/repo@sha256:def'",
 	}}) with input.attestations as attestations
 		with data["task-bundles"] as task_bundles
 }
 
-test_missing_required_data {
+test_acceptable_bundles_provided {
 	expected := {{
-		"code": "attestation_task_bundle.missing_required_data",
+		"code": "attestation_task_bundle.acceptable_bundles_provided",
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Missing required task-bundles data",
 	}}

--- a/policy/release/attestation_type.rego
+++ b/policy/release/attestation_type.rego
@@ -12,12 +12,12 @@ import future.keywords.in
 import data.lib
 
 # METADATA
-# title: Unknown attestation type found
+# title: Known attestation type found
 # description: >-
 #   A sanity check to confirm the attestation found for the image has a known
 #   attestation type.
 # custom:
-#   short_name: unknown_att_type
+#   short_name: known_attestation_type
 #   failure_msg: Unknown attestation type '%s'
 #   collections:
 #   - minimal
@@ -30,11 +30,11 @@ deny contains result if {
 }
 
 # METADATA
-# title: Missing pipelinerun attestation
+# title: PipelineRun attestation found
 # description: >-
 #   At least one PipelineRun attestation must be present.
 # custom:
-#   short_name: missing_pipelinerun_attestation
+#   short_name: pipelinerun_attestation_found
 #   failure_msg: Missing pipelinerun attestation
 #   collections:
 #   - minimal

--- a/policy/release/attestation_type_test.rego
+++ b/policy/release/attestation_type_test.rego
@@ -17,16 +17,16 @@ test_allow_when_permitted {
 test_deny_when_not_permitted {
 	expected_msg := sprintf("Unknown attestation type '%s'", [bad_type])
 	lib.assert_equal(deny, {{
-		"code": "attestation_type.unknown_att_type",
+		"code": "attestation_type.known_attestation_type",
 		"collections": ["minimal"],
 		"msg": expected_msg,
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with input.attestations as mock_data(bad_type)
 }
 
-test_deny_when_missing_pipelinerun_attestations {
+test_deny_when_pipelinerun_attestation_founds {
 	expected := {{
-		"code": "attestation_type.missing_pipelinerun_attestation",
+		"code": "attestation_type.pipelinerun_attestation_found",
 		"collections": ["minimal"],
 		"msg": "Missing pipelinerun attestation",
 		"effective_on": "2022-01-01T00:00:00Z",

--- a/policy/release/base_image_registries.rego
+++ b/policy/release/base_image_registries.rego
@@ -14,14 +14,15 @@ import future.keywords.in
 import data.lib
 
 # METADATA
-# title: Restrict registry of base images
+# title: Base image comes from permitted registry
 # description: >-
 #   The base images used when building a container image must come from a known set
-#   of trusted registries to reduce potential supply chain attacks. This policy
-#   defines trusted registries as registries that are fully maintained by Red Hat
-#   and only contain content produced by Red Hat.
+#   of trusted registries to reduce potential supply chain attacks. By default this
+#   policy defines trusted registries as registries that are fully maintained by Red
+#   Hat and only contain content produced by Red Hat. The list of permitted registries
+#   can be customized by setting the `allowed_registry_prefixes` list in the rule data.
 # custom:
-#   short_name: disallowed_base_image
+#   short_name: base_image_permitted
 #   failure_msg: Base image %q is from a disallowed registry
 #   collections:
 #   - minimal
@@ -33,12 +34,13 @@ deny contains result if {
 }
 
 # METADATA
-# title: Base images must be provided
+# title: Base image task result was provided
 # description: >-
 #   The attestation must provide the expected information about which base images
-#   were used during the build process.
+#   were used during the build process. The base image information is expected to
+#   be found in a task result called `BASE_IMAGES_DIGESTS`.
 # custom:
-#   short_name: base_images_missing
+#   short_name: base_image_info_found
 #   failure_msg: Base images result is missing
 #   collections:
 #   - minimal
@@ -54,12 +56,12 @@ deny contains result if {
 }
 
 # METADATA
-# title: Missing rule data
+# title: Allowed base image registry prefixes list was provided
 # description: >-
-#   The policy rules in this package require the allowed_registry_prefixes
+#   The policy rules in this package require the `allowed_registry_prefixes`
 #   rule data to be provided.
 # custom:
-#   short_name: missing_rule_data
+#   short_name: allowed_registries_provided
 #   failure_msg: Missing required allowed_registry_prefixes rule data
 #   collections:
 #   - minimal

--- a/policy/release/base_image_registries_test.rego
+++ b/policy/release/base_image_registries_test.rego
@@ -42,13 +42,13 @@ test_unacceptable_base_images {
 	)]
 	expected := {
 		{
-			"code": "base_image_registries.disallowed_base_image",
+			"code": "base_image_registries.base_image_permitted",
 			"collections": ["minimal"],
 			"effective_on": "2022-01-01T00:00:00Z",
 			"msg": "Base image \"docker.io/busybox:latest@sha256:bcd\" is from a disallowed registry",
 		},
 		{
-			"code": "base_image_registries.disallowed_base_image",
+			"code": "base_image_registries.base_image_permitted",
 			"collections": ["minimal"],
 			"effective_on": "2022-01-01T00:00:00Z",
 			"msg": "Base image \"registry.redhat.ioo/spam:latest@sha256:def\" is from a disallowed registry",
@@ -65,7 +65,7 @@ test_missing_result {
 		"registry.img/unacceptable@sha256:012",
 	)]
 	expected := {{
-		"code": "base_image_registries.base_images_missing",
+		"code": "base_image_registries.base_image_info_found",
 		"collections": ["minimal"],
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Base images result is missing",
@@ -73,9 +73,9 @@ test_missing_result {
 	lib.assert_equal(deny, expected) with input.attestations as attestations
 }
 
-test_missing_rule_data {
+test_allowed_registries_provided {
 	expected := {{
-		"code": "base_image_registries.missing_rule_data",
+		"code": "base_image_registries.allowed_registries_provided",
 		"collections": ["minimal"],
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Missing required allowed_registry_prefixes rule data",

--- a/policy/release/buildah_build_task.rego
+++ b/policy/release/buildah_build_task.rego
@@ -13,12 +13,14 @@ import future.keywords.in
 import data.lib
 
 # METADATA
-# title: Dockerfile param not included
+# title: Buildah task has Dockerfile param defined
 # description: >-
-#   This policy verifies that there is a dockerfile parameter
+#   This policy verifies that a DOCKERFILE parameter was provided to
+#   the buildah task.
 # custom:
-#   short_name: dockerfile_param_not_included
-#   failure_msg: DOCKERFILE param is not included in the task
+#   short_name: buildah_task_has_dockerfile_param
+#   failure_msg: The DOCKERFILE param was not included in the buildah task
+#
 deny contains result if {
 	# Skip this rule if the buildah task is not present
 	buildah_task
@@ -27,12 +29,14 @@ deny contains result if {
 }
 
 # METADATA
-# title: Dockerfile param external source
+# title: Buildah task uses a local Dockerfile
 # description: >-
-#   This policy verifies that the dockerfile is not an external source
+#   This policy verifies that the Dockerfile used in the buildah task is not
+#   fetched from an external source
 # custom:
-#   short_name: dockerfile_param_external_source
+#   short_name: buildah_uses_local_dockerfile
 #   failure_msg: DOCKERFILE param value (%s) is an external source
+#
 deny contains result if {
 	_not_allowed_prefix(dockerfile_param)
 	result := lib.result_helper(rego.metadata.chain(), [dockerfile_param])

--- a/policy/release/buildah_build_task_test.rego
+++ b/policy/release/buildah_build_task_test.rego
@@ -13,7 +13,7 @@ test_good_dockerfile_param if {
 
 test_dockerfile_param_https_source if {
 	expected := {{
-		"code": "buildah_build_task.dockerfile_param_external_source",
+		"code": "buildah_build_task.buildah_uses_local_dockerfile",
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "DOCKERFILE param value (https://Dockerfile) is an external source",
 	}}
@@ -23,7 +23,7 @@ test_dockerfile_param_https_source if {
 
 test_dockerfile_param_http_source if {
 	expected := {{
-		"code": "buildah_build_task.dockerfile_param_external_source",
+		"code": "buildah_build_task.buildah_uses_local_dockerfile",
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "DOCKERFILE param value (http://Dockerfile) is an external source",
 	}}
@@ -31,11 +31,11 @@ test_dockerfile_param_http_source if {
 	lib.assert_equal(expected, deny) with input.attestations as [attestation]
 }
 
-test_dockerfile_param_not_included if {
+test_buildah_task_has_dockerfile_param if {
 	expected := {{
-		"code": "buildah_build_task.dockerfile_param_not_included",
+		"code": "buildah_build_task.buildah_task_has_dockerfile_param",
 		"effective_on": "2022-01-01T00:00:00Z",
-		"msg": "DOCKERFILE param is not included in the task",
+		"msg": "The DOCKERFILE param was not included in the buildah task",
 	}}
 	lib.assert_equal(expected, deny) with input.attestations as [_attestation("buildah", {})]
 }

--- a/policy/release/cve.rego
+++ b/policy/release/cve.rego
@@ -5,6 +5,7 @@
 #   This package is responsible for verifying a CVE scan was performed during
 #   the build pipeline, and that the image under test does not contain CVEs
 #   of certain security levels.
+#
 package policy.release.cve
 
 import future.keywords.contains
@@ -14,7 +15,7 @@ import future.keywords.in
 import data.lib
 
 # METADATA
-# title: Found CVE vulnerabilities
+# title: Blocking CVE check
 # description: >-
 #   The SLSA Provenance attestation for the image is inspected to ensure CVEs
 #   of certain security levels have not been detected. If detected, this policy
@@ -23,17 +24,18 @@ import data.lib
 #   "restrict_cve_security_levels". The available levels are critical, high,
 #    medium, and low.
 # custom:
-#   short_name: found_cve_vulnerabilities
+#   short_name: cve_blockers
 #   failure_msg: Found %d CVE vulnerabilities of %s security level
 #   collections:
 #   - minimal
+#
 deny contains result if {
 	some level, amount in _non_zero_levels("restrict_cve_security_levels")
 	result := lib.result_helper_with_term(rego.metadata.chain(), [amount, level], level)
 }
 
 # METADATA
-# title: Found non-blocking CVE vulnerabilities
+# title: Non-blocking CVE check
 # description: >-
 #   The SLSA Provenance attestation for the image is inspected to ensure CVEs
 #   of certain security levels have not been detected. If detected, this policy
@@ -42,28 +44,30 @@ deny contains result if {
 #   "warn_cve_security_levels". The available levels are critical, high,
 #    medium, and low.
 # custom:
-#   short_name: found_non_blocking_cve_vulnerabilities
+#   short_name: cve_warnings
 #   failure_msg: Found %d non-blocking CVE vulnerabilities of %s security level
 #   collections:
 #   - minimal
+#
 warn contains result if {
 	some level, amount in _non_zero_levels("warn_cve_security_levels")
 	result := lib.result_helper_with_term(rego.metadata.chain(), [amount, level], level)
 }
 
 # METADATA
-# title: Missing CVE scan results
+# title: CVE scan results found
 # description: >-
 #   The clair-scan task results have not been found in the SLSA Provenance
 #   attestation of the build pipeline.
 # custom:
-#   short_name: missing_cve_scan_results
-#   failure_msg: CVE scan results not found
+#   short_name: cve_results_found
+#   failure_msg: Clair CVE scan results were not found
 #   solution: >-
 #     Make sure there is a successful task in the build pipeline that runs a
 #     Clair scan and creates a task result called `CLAIR_SCAN_RESULT`.
 #   collections:
 #   - minimal
+#
 deny contains result if {
 	not _vulnerabilities
 	result := lib.result_helper(rego.metadata.chain(), [])

--- a/policy/release/cve_test.rego
+++ b/policy/release/cve_test.rego
@@ -36,14 +36,14 @@ test_failure if {
 	)]
 	expected := {
 		{
-			"code": "cve.found_cve_vulnerabilities",
+			"code": "cve.cve_blockers",
 			"term": "critical",
 			"collections": ["minimal"],
 			"effective_on": "2022-01-01T00:00:00Z",
 			"msg": "Found 1 CVE vulnerabilities of critical security level",
 		},
 		{
-			"code": "cve.found_cve_vulnerabilities",
+			"code": "cve.cve_blockers",
 			"term": "high",
 			"collections": ["minimal"],
 			"effective_on": "2022-01-01T00:00:00Z",
@@ -62,14 +62,14 @@ test_failure_with_rule_data if {
 	)]
 	expected := {
 		{
-			"code": "cve.found_cve_vulnerabilities",
+			"code": "cve.cve_blockers",
 			"term": "spam",
 			"collections": ["minimal"],
 			"effective_on": "2022-01-01T00:00:00Z",
 			"msg": "Found 1 CVE vulnerabilities of spam security level",
 		},
 		{
-			"code": "cve.found_cve_vulnerabilities",
+			"code": "cve.cve_blockers",
 			"term": "bacon",
 			"collections": ["minimal"],
 			"effective_on": "2022-01-01T00:00:00Z",
@@ -99,14 +99,14 @@ test_warn_with_rule_data if {
 	)]
 	expected := {
 		{
-			"code": "cve.found_non_blocking_cve_vulnerabilities",
+			"code": "cve.cve_warnings",
 			"term": "medium",
 			"collections": ["minimal"],
 			"effective_on": "2022-01-01T00:00:00Z",
 			"msg": "Found 20 non-blocking CVE vulnerabilities of medium security level",
 		},
 		{
-			"code": "cve.found_non_blocking_cve_vulnerabilities",
+			"code": "cve.cve_warnings",
 			"term": "low",
 			"collections": ["minimal"],
 			"effective_on": "2022-01-01T00:00:00Z",
@@ -125,10 +125,10 @@ test_missing_cve_scan_result if {
 		_bundle,
 	)]
 	expected := {{
-		"code": "cve.missing_cve_scan_results",
+		"code": "cve.cve_results_found",
 		"collections": ["minimal"],
 		"effective_on": "2022-01-01T00:00:00Z",
-		"msg": "CVE scan results not found",
+		"msg": "Clair CVE scan results were not found",
 	}}
 	lib.assert_equal(deny, expected) with input.attestations as attestations
 }
@@ -141,10 +141,10 @@ test_missing_cve_scan_vulnerabilities if {
 		_bundle,
 	)]
 	expected := {{
-		"code": "cve.missing_cve_scan_results",
+		"code": "cve.cve_results_found",
 		"collections": ["minimal"],
 		"effective_on": "2022-01-01T00:00:00Z",
-		"msg": "CVE scan results not found",
+		"msg": "Clair CVE scan results were not found",
 	}}
 	lib.assert_equal(deny, expected) with input.attestations as attestations
 }

--- a/policy/release/hermetic_build_task.rego
+++ b/policy/release/hermetic_build_task.rego
@@ -14,14 +14,15 @@ import data.lib
 import data.lib.tkn
 
 # METADATA
-# title: hermetic_build_task
+# title: Build task called with hermetic param set
 # description: >-
 #   This policy verifies the build task in the PipelineRun attestation
 #   was invoked with the proper parameters to make the build process
 #   hermetic.
 # custom:
-#   short_name: build_task_not_hermetic
-#   failure_msg: Build task was not invoked with hermetic parameter
+#   short_name: build_task_hermetic
+#   failure_msg: Build task was not invoked with the hermetic parameter set
+#
 deny contains result if {
 	hermetic_build != "true"
 	result := lib.result_helper(rego.metadata.chain(), [])

--- a/policy/release/hermetic_build_task_test.rego
+++ b/policy/release/hermetic_build_task_test.rego
@@ -10,9 +10,9 @@ test_hermetic_build if {
 
 test_not_hermetic_build if {
 	expected := {{
-		"code": "hermetic_build_task.build_task_not_hermetic",
+		"code": "hermetic_build_task.build_task_hermetic",
 		"effective_on": "2022-01-01T00:00:00Z",
-		"msg": "Build task was not invoked with hermetic parameter",
+		"msg": "Build task was not invoked with the hermetic parameter set",
 	}}
 
 	hermetic_not_true := json.patch(_good_attestation, [{

--- a/policy/release/java.rego
+++ b/policy/release/java.rego
@@ -16,14 +16,16 @@ import future.keywords.in
 import data.lib
 
 # METADATA
-# title: Prevent Java builds from depending on foreign dependencies
+# title: Java builds have no foreign dependencies
 # description: >-
 #   The SBOM_JAVA_COMPONENTS_COUNT TaskResult finds dependencies that have
 #   originated from foreign repositories, i.e. ones that are not rebuilt or
-#   redhat.
+#   provided by Red Hat. This rule uses the `allowed_java_component_sources`
+#   rule data.
 # custom:
-#   short_name: java_foreign_dependencies
+#   short_name: no_foreign_dependencies
 #   failure_msg: Found Java dependencies from '%s', expecting to find only from '%s'
+#
 deny contains result if {
 	allowed := {a | some a in lib.rule_data("allowed_java_component_sources")}
 	foreign := _java_component_sources - allowed
@@ -32,13 +34,14 @@ deny contains result if {
 }
 
 # METADATA
-# title: Missing rule data
+# title: Trusted Java dependency source list was provided
 # description: >-
-#   The policy rules in this package require the allowed_java_component_sources
+#   The policy rules in this package require the `allowed_java_component_sources`
 #   rule data to be provided.
 # custom:
-#   short_name: missing_rule_data
+#   short_name: trusted_dependencies_source_list_provided
 #   failure_msg: Missing required allowed_java_component_sources rule data
+#
 deny contains result if {
 	count(lib.rule_data("allowed_java_component_sources")) == 0
 	result := lib.result_helper(rego.metadata.chain(), [])

--- a/policy/release/java_test.rego
+++ b/policy/release/java_test.rego
@@ -20,16 +20,16 @@ test_has_foreign {
 		_bundle,
 	)]
 	expected := {{
-		"code": "java.java_foreign_dependencies",
+		"code": "java.no_foreign_dependencies",
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Found Java dependencies from 'central', expecting to find only from 'rebuilt,redhat'",
 	}}
 	lib.assert_equal(deny, expected) with input.attestations as attestations
 }
 
-test_missing_rule_data {
+test_trusted_dependency_source_list_provided {
 	expected := {{
-		"code": "java.missing_rule_data",
+		"code": "java.trusted_dependencies_source_list_provided",
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Missing required allowed_java_component_sources rule data",
 	}}

--- a/policy/release/provenance_materials.rego
+++ b/policy/release/provenance_materials.rego
@@ -15,11 +15,11 @@ import data.lib
 import data.lib.tkn
 
 # METADATA
-# title: Task git-clone missing
+# title: Git clone task found
 # description: >-
-#   The attestation must contain a git-clone task with the expected commit and url results.
+#   The attestation must contain a git-clone task with `commit` and `url` task results.
 # custom:
-#   short_name: missing_git_clong_task
+#   short_name: git_clone_task_found
 #   failure_msg: Task git-clone not found
 #   collections:
 #   - minimal
@@ -31,12 +31,12 @@ deny contains result if {
 }
 
 # METADATA
-# title: Git repo materials mismatch
+# title: Git clone source matches materials provenance
 # description: >-
 #   The result of the git-clone task must be included in the materials section of the SLSA
 #   provenance attestation.
 # custom:
-#   short_name: git_repo_materials_mismatch
+#   short_name: git_clone_source_matches_provenance
 #   failure_msg: Entry in materials for the git repo %q and commit %q not found
 #   collections:
 #   - minimal

--- a/policy/release/provenance_materials_test.rego
+++ b/policy/release/provenance_materials_test.rego
@@ -43,7 +43,7 @@ test_missing_git_clone_task if {
 	}]
 
 	expected := {{
-		"code": "provenance_materials.missing_git_clong_task",
+		"code": "provenance_materials.git_clone_task_found",
 		"collections": ["minimal"],
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Task git-clone not found",
@@ -67,7 +67,7 @@ test_scattered_results if {
 	]
 
 	expected := {{
-		"code": "provenance_materials.missing_git_clong_task",
+		"code": "provenance_materials.git_clone_task_found",
 		"collections": ["minimal"],
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Task git-clone not found",
@@ -89,7 +89,7 @@ test_missing_materials if {
 	missing_materials := json.remove(good_attestation, ["/predicate/materials"])
 
 	expected := {{
-		"code": "provenance_materials.git_repo_materials_mismatch",
+		"code": "provenance_materials.git_clone_source_matches_provenance",
 		"collections": ["minimal"],
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Entry in materials for the git repo \"git+https://gitforge/repo.git\" and commit \"9d25f3b6ab8cfba5d2d68dc8d062988534a63e87\" not found",
@@ -108,7 +108,7 @@ test_commit_mismatch if {
 	}]
 
 	expected := {{
-		"code": "provenance_materials.git_repo_materials_mismatch",
+		"code": "provenance_materials.git_clone_source_matches_provenance",
 		"collections": ["minimal"],
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Entry in materials for the git repo \"git+https://gitforge/repo.git\" and commit \"b10a8c637a91f427576eb0a4f39f1766c7987385\" not found",
@@ -127,7 +127,7 @@ test_url_mismatch if {
 	}]
 
 	expected := {{
-		"code": "provenance_materials.git_repo_materials_mismatch",
+		"code": "provenance_materials.git_clone_source_matches_provenance",
 		"collections": ["minimal"],
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Entry in materials for the git repo \"git+https://shady/repo.git\" and commit \"9d25f3b6ab8cfba5d2d68dc8d062988534a63e87\" not found",
@@ -146,7 +146,7 @@ test_commit_and_url_mismatch if {
 	}]
 
 	expected := {{
-		"code": "provenance_materials.git_repo_materials_mismatch",
+		"code": "provenance_materials.git_clone_source_matches_provenance",
 		"collections": ["minimal"],
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Entry in materials for the git repo \"git+https://shady/repo.git\" and commit \"b10a8c637a91f427576eb0a4f39f1766c7987385\" not found",

--- a/policy/release/slsa_build_build_service.rego
+++ b/policy/release/slsa_build_build_service.rego
@@ -19,11 +19,11 @@ import future.keywords.in
 import data.lib
 
 # METADATA
-# title: Builder ID exists
+# title: SLSA Builder ID found
 # description: >-
 #   The attestation attribute predicate.builder.id is set.
 # custom:
-#   short_name: missing_builder_id
+#   short_name: slsa_builder_id_found
 #   failure_msg: Builder ID not set in attestation
 #   collections:
 #   - slsa2
@@ -36,13 +36,13 @@ deny contains result if {
 }
 
 # METADATA
-# title: Build service used
+# title: SLSA Builder ID is known and accepted
 # description: >-
 #   The attestation attribute predicate.builder.id is set to one
-#   of the values in data.rule_data.allowed_builder_ids, e.g.
+#   of the values in the allowed_builder_ids rule data, e.g.
 #   "https://tekton.dev/chains/v2".
 # custom:
-#   short_name: unexpected_builder_id
+#   short_name: slsa_builder_id_accepted
 #   failure_msg: Builder ID %q is unexpected
 #   collections:
 #   - slsa2

--- a/policy/release/slsa_build_build_service_test.rego
+++ b/policy/release/slsa_build_build_service_test.rego
@@ -9,7 +9,7 @@ test_all_good if {
 	lib.assert_empty(deny) with input.attestations as [_mock_attestation(builder_id)]
 }
 
-test_missing_builder_id if {
+test_slsa_builder_id_found if {
 	attestations := [
 		# Missing predicate.builder.id
 		{"predicate": {
@@ -21,7 +21,7 @@ test_missing_builder_id if {
 	]
 
 	expected := {{
-		"code": "slsa_build_build_service.missing_builder_id",
+		"code": "slsa_build_build_service.slsa_builder_id_found",
 		"collections": ["slsa2", "slsa3"],
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Builder ID not set in attestation",
@@ -30,10 +30,10 @@ test_missing_builder_id if {
 	lib.assert_equal(expected, deny) with input.attestations as attestations
 }
 
-test_unexpected_builder_id if {
+test_accepted_slsa_builder_id if {
 	builder_id := "https://notket.ved/sniahc/2v"
 	expected := {{
-		"code": "slsa_build_build_service.unexpected_builder_id",
+		"code": "slsa_build_build_service.slsa_builder_id_accepted",
 		"collections": ["slsa2", "slsa3"],
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Builder ID \"https://notket.ved/sniahc/2v\" is unexpected",

--- a/policy/release/slsa_build_scripted_build.rego
+++ b/policy/release/slsa_build_scripted_build.rego
@@ -26,7 +26,7 @@ import data.lib.tkn
 #   The attestation attribute predicate.buildConfig.tasks.steps is not
 #   empty of the pipeline task responsible for building the image.
 # custom:
-#   short_name: empty_build_task
+#   short_name: build_script_used
 #   failure_msg: Build task %q does not contain any steps
 #   collections:
 #   - slsa1
@@ -41,12 +41,12 @@ deny contains result if {
 }
 
 # METADATA
-# title: Build task missing
+# title: Build task set image digest and url task results
 # description: >-
 #   The attestations must contain a build task with the expected
 #   IMAGE_DIGEST and IMAGE_URL results.
 # custom:
-#   short_name: missing_build_task
+#   short_name: build_task_image_results_found
 #   failure_msg: Build task not found
 #   collections:
 #   - slsa1
@@ -60,12 +60,12 @@ deny contains result if {
 }
 
 # METADATA
-# title: Mismatch subject
+# title: Provenance subject matches build task image result
 # description: >-
 #   The subject of the attestations must match the IMAGE_DIGEST and
 #   IMAGE_URL values from the build task.
 # custom:
-#   short_name: subject_build_task_mismatch
+#   short_name: subject_build_task_matches
 #   failure_msg: The attestation subject, %q, does not match the build task image, %q
 #   collections:
 #   - slsa1

--- a/policy/release/slsa_build_scripted_build_test.rego
+++ b/policy/release/slsa_build_scripted_build_test.rego
@@ -38,7 +38,7 @@ test_scattered_results if {
 	]
 
 	expected := {{
-		"code": "slsa_build_scripted_build.missing_build_task",
+		"code": "slsa_build_scripted_build.build_task_image_results_found",
 		"collections": ["slsa1", "slsa2", "slsa3"],
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Build task not found",
@@ -58,7 +58,7 @@ test_missing_task_steps if {
 	}]
 
 	expected := {{
-		"code": "slsa_build_scripted_build.empty_build_task",
+		"code": "slsa_build_scripted_build.build_script_used",
 		"collections": ["slsa1", "slsa2", "slsa3"],
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Build task \"buildah\" does not contain any steps",
@@ -78,7 +78,7 @@ test_empty_task_steps if {
 	}]
 
 	expected := {{
-		"code": "slsa_build_scripted_build.empty_build_task",
+		"code": "slsa_build_scripted_build.build_script_used",
 		"collections": ["slsa1", "slsa2", "slsa3"],
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Build task \"buildah\" does not contain any steps",
@@ -98,7 +98,7 @@ test_results_missing_value_url if {
 	}]
 
 	expected := {{
-		"code": "slsa_build_scripted_build.missing_build_task",
+		"code": "slsa_build_scripted_build.build_task_image_results_found",
 		"collections": ["slsa1", "slsa2", "slsa3"],
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Build task not found",
@@ -118,7 +118,7 @@ test_results_missing_value_digest if {
 	}]
 
 	expected := {{
-		"code": "slsa_build_scripted_build.missing_build_task",
+		"code": "slsa_build_scripted_build.build_task_image_results_found",
 		"collections": ["slsa1", "slsa2", "slsa3"],
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Build task not found",
@@ -138,7 +138,7 @@ test_results_empty_value_url if {
 	}]
 
 	expected := {{
-		"code": "slsa_build_scripted_build.missing_build_task",
+		"code": "slsa_build_scripted_build.build_task_image_results_found",
 		"collections": ["slsa1", "slsa2", "slsa3"],
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Build task not found",
@@ -158,7 +158,7 @@ test_results_empty_value_digest if {
 	}]
 
 	expected := {{
-		"code": "slsa_build_scripted_build.missing_build_task",
+		"code": "slsa_build_scripted_build.build_task_image_results_found",
 		"collections": ["slsa1", "slsa2", "slsa3"],
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Build task not found",
@@ -178,7 +178,7 @@ test_subject_mismatch if {
 	}]
 
 	expected := {{
-		"code": "slsa_build_scripted_build.subject_build_task_mismatch",
+		"code": "slsa_build_scripted_build.subject_build_task_matches",
 		"collections": ["slsa1", "slsa2", "slsa3"],
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "The attestation subject, \"some.image/foo:bar@sha256:123\", does not match the build task image, \"some.image/foo:bar@sha256:anotherdigest\"",
@@ -242,7 +242,7 @@ test_subject_with_tag_and_digest_mismatch_digest_fails if {
 	}]
 
 	expected := {{
-		"code": "slsa_build_scripted_build.subject_build_task_mismatch",
+		"code": "slsa_build_scripted_build.subject_build_task_matches",
 		"collections": ["slsa1", "slsa2", "slsa3"],
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "The attestation subject, \"registry.io/repository/image@sha256:unexpected\", does not match the build task image, \"registry.io/repository/image:tag@sha256:digest\"",

--- a/policy/release/slsa_provenance_available.rego
+++ b/policy/release/slsa_provenance_available.rego
@@ -19,12 +19,12 @@ import future.keywords.in
 import data.lib
 
 # METADATA
-# title: Attestation predicate type
+# title: Expected attestation predicate type found
 # description: >-
 #   The predicateType field of the attestation must indicate the in-toto SLSA Provenance format
 #   was used to attest the PipelineRun.
 # custom:
-#   short_name: unexpected_predicate_type
+#   short_name: attestation_predicate_type_accepted
 #   failure_msg: Attestation predicate type %q is not an expected type (%s)
 #   collections:
 #   - minimal

--- a/policy/release/slsa_provenance_available_test.rego
+++ b/policy/release/slsa_provenance_available_test.rego
@@ -9,10 +9,10 @@ test_expected_predicate_type {
 	lib.assert_empty(deny) with input.attestations as attestations
 }
 
-test_unexpected_predicate_type {
+test_att_predicate_type {
 	attestations := _mock_attestations(["spam"])
 	expected_deny := {{
-		"code": "slsa_provenance_available.unexpected_predicate_type",
+		"code": "slsa_provenance_available.attestation_predicate_type_accepted",
 		"collections": ["minimal", "slsa1", "slsa2", "slsa3"],
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Attestation predicate type \"spam\" is not an expected type (https://slsa.dev/provenance/v0.2)",

--- a/policy/release/slsa_source_version_controlled.rego
+++ b/policy/release/slsa_source_version_controlled.rego
@@ -33,12 +33,12 @@ import future.keywords.in
 import data.lib
 
 # METADATA
-# title: Material format
+# title: Materials have uri and digest
 # description: >-
 #   At least one entry in the predicate.materials array of the attestation contains
 #   the expected attributes: uri and digest.sha1.
 # custom:
-#   short_name: missing_materials
+#   short_name: materials_format_okay
 #   failure_msg: No materials match expected format
 #   collections:
 #   - minimal
@@ -52,12 +52,12 @@ deny contains result if {
 }
 
 # METADATA
-# title: Material from a git repository
+# title: Material uri is a git repo
 # description: >-
 #   Each entry in the predicate.materials array of the attestation uses
 #   a git URI.
 # custom:
-#   short_name: material_non_git_uri
+#   short_name: materials_uri_is_git_repo
 #   failure_msg: Material URI %q is not a git URI
 #   collections:
 #   - minimal
@@ -71,13 +71,13 @@ deny contains result if {
 }
 
 # METADATA
-# title: Material with git commit digest
+# title: Materials include git commit shas
 # description: >-
 #   Each entry in the predicate.materials array of the attestation includes
 #   a SHA1 digest which corresponds to a git commit.
 # custom:
-#   short_name: material_without_git_commit
-#   failure_msg: Material digest %q is not a git commit
+#   short_name: materials_include_git_sha
+#   failure_msg: Material digest %q is not a git commit sha
 #   collections:
 #   - minimal
 #   - slsa2

--- a/policy/release/slsa_source_version_controlled_test.rego
+++ b/policy/release/slsa_source_version_controlled_test.rego
@@ -33,13 +33,13 @@ test_non_git_uri if {
 
 	expected := {
 		{
-			"code": "slsa_source_version_controlled.material_non_git_uri",
+			"code": "slsa_source_version_controlled.materials_uri_is_git_repo",
 			"collections": ["minimal", "slsa2", "slsa3"],
 			"effective_on": "2022-01-01T00:00:00Z",
 			"msg": "Material URI \"ggit+https://example/repo\" is not a git URI",
 		},
 		{
-			"code": "slsa_source_version_controlled.material_non_git_uri",
+			"code": "slsa_source_version_controlled.materials_uri_is_git_repo",
 			"collections": ["minimal", "slsa2", "slsa3"],
 			"effective_on": "2022-01-01T00:00:00Z",
 			"msg": "Material URI \"svn+https://exmaple/other-repo.git\" is not a git URI",
@@ -70,22 +70,22 @@ test_non_git_commit if {
 
 	expected := {
 		{
-			"code": "slsa_source_version_controlled.material_without_git_commit",
+			"code": "slsa_source_version_controlled.materials_include_git_sha",
 			"collections": ["minimal", "slsa2", "slsa3"],
 			"effective_on": "2022-01-01T00:00:00Z",
-			"msg": "Material digest \"g9ef4c1f9273718b2421b2c076f09786ede5982c\" is not a git commit",
+			"msg": "Material digest \"g9ef4c1f9273718b2421b2c076f09786ede5982c\" is not a git commit sha",
 		},
 		{
-			"code": "slsa_source_version_controlled.material_without_git_commit",
+			"code": "slsa_source_version_controlled.materials_include_git_sha",
 			"collections": ["minimal", "slsa2", "slsa3"],
 			"effective_on": "2022-01-01T00:00:00Z",
-			"msg": "Material digest \"1d2d2f924e986ac86fdf7b36c94bcdf32beec15\" is not a git commit",
+			"msg": "Material digest \"1d2d2f924e986ac86fdf7b36c94bcdf32beec15\" is not a git commit sha",
 		},
 		{
-			"code": "slsa_source_version_controlled.material_without_git_commit",
+			"code": "slsa_source_version_controlled.materials_include_git_sha",
 			"collections": ["minimal", "slsa2", "slsa3"],
 			"effective_on": "2022-01-01T00:00:00Z",
-			"msg": "Material digest \"36d89a3cadcdf269110757df1074b4ef45fe641ee\" is not a git commit",
+			"msg": "Material digest \"36d89a3cadcdf269110757df1074b4ef45fe641ee\" is not a git commit sha",
 		},
 	}
 
@@ -103,7 +103,7 @@ test_invalid_materials if {
 	]
 
 	expected := {{
-		"code": "slsa_source_version_controlled.missing_materials",
+		"code": "slsa_source_version_controlled.materials_format_okay",
 		"collections": ["minimal", "slsa2", "slsa3"],
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "No materials match expected format",

--- a/policy/release/step_image_registries.rego
+++ b/policy/release/step_image_registries.rego
@@ -14,13 +14,13 @@ import future.keywords.in
 import data.lib
 
 # METADATA
-# title: Task steps ran on container images that are disallowed
+# title: Task steps ran on permitted container images
 # description: >-
 #   Enterprise Contract has a list of allowed registry prefixes. Each step in each
 #   each TaskRun must run on a container image with a url that matches one of the
 #   prefixes in the list.
 # custom:
-#   short_name: disallowed_task_step_image
+#   short_name: task_step_images_permitted
 #   failure_msg: Step %d in task '%s' has disallowed image ref '%s'
 #   collections:
 #   - minimal
@@ -35,12 +35,12 @@ deny contains result if {
 }
 
 # METADATA
-# title: Missing rule data
+# title: Permitted step image registry prefix list provided
 # description: >-
 #   The policy rules in this package require the allowed_step_image_registry_prefixes
 #   rule data to be provided.
 # custom:
-#   short_name: missing_rule_data
+#   short_name: step_image_registry_prefix_list_provided
 #   failure_msg: Missing required allowed_step_image_registry_prefixes rule data
 #   collections:
 #   - minimal

--- a/policy/release/step_image_registries_test.rego
+++ b/policy/release/step_image_registries_test.rego
@@ -20,16 +20,16 @@ test_image_registry_valid {
 test_attestation_type_invalid {
 	expected_msg := sprintf("Step 0 in task 'mytask' has disallowed image ref '%s'", [bad_image])
 	lib.assert_equal(deny, {{
-		"code": "step_image_registries.disallowed_task_step_image",
+		"code": "step_image_registries.task_step_images_permitted",
 		"collections": ["minimal"],
 		"msg": expected_msg,
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with input.attestations as mock_data(bad_image)
 }
 
-test_missing_rule_data {
+test_step_image_registry_prefix_list_found {
 	expected := {{
-		"code": "step_image_registries.missing_rule_data",
+		"code": "step_image_registries.step_image_registry_prefix_list_provided",
 		"collections": ["minimal"],
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Missing required allowed_step_image_registry_prefixes rule data",

--- a/policy/release/tasks.rego
+++ b/policy/release/tasks.rego
@@ -22,12 +22,12 @@ import data.lib
 import data.lib.tkn
 
 # METADATA
-# title: No tasks run
+# title: Pipeline run includes at least one task
 # description: >-
 #   This policy enforces that at least one Task is present in the PipelineRun
 #   attestation.
 # custom:
-#   short_name: tasks_missing
+#   short_name: pipeline_has_tasks
 #   failure_msg: No tasks found in PipelineRun attestation
 #   collections:
 #   - minimal
@@ -39,12 +39,12 @@ deny contains result if {
 }
 
 # METADATA
-# title: Missing required task
+# title: All required tasks were included in the pipeline
 # description: >-
 #   This policy enforces that the required set of tasks are included
 #   in the PipelineRun attestation.
 # custom:
-#   short_name: missing_required_task
+#   short_name: required_tasks_found
 #   failure_msg: Required task %q is missing
 deny contains result if {
 	some required_task in _missing_tasks(current_required_tasks)
@@ -55,11 +55,11 @@ deny contains result if {
 }
 
 # METADATA
-# title: Missing required pipeline tasks warning
+# title: Required tasks list for pipeline was provided
 # description: >-
 #   This policy warns if a task list does not exist in the required_tasks.yaml file
 # custom:
-#   short_name: missing_required_pipeline_task_warning
+#   short_name: pipeline_required_tasks_list_provided
 #   failure_msg: Required tasks do not exist for pipeline
 warn contains result if {
 	not required_pipeline_task_data
@@ -67,12 +67,12 @@ warn contains result if {
 }
 
 # METADATA
-# title: Missing future required task
+# title: Future required tasks were found
 # description: >-
 #   This policy warns when a task that will be required in the future
 #   was not included in the PipelineRun attestation.
 # custom:
-#   short_name: missing_future_required_task
+#   short_name: future_required_tasks_found
 #   failure_msg: Task %q is missing and will be required in the future
 warn contains result if {
 	some required_task in _missing_tasks(latest_required_tasks)
@@ -84,11 +84,11 @@ warn contains result if {
 }
 
 # METADATA
-# title: Missing required tasks data
+# title: Required tasks list was provided
 # description: >-
 #   The policy rules in this package require the required-tasks data to be provided.
 # custom:
-#   short_name: missing_required_data
+#   short_name: required_tasks_list_provided
 #   failure_msg: Missing required task-bundles data
 deny contains result if {
 	tkn.missing_required_tasks_data

--- a/policy/release/tasks_test.rego
+++ b/policy/release/tasks_test.rego
@@ -25,7 +25,7 @@ test_required_tasks_met_no_label if {
 
 test_required_tasks_warning_no_label if {
 	attestations := _attestations_with_tasks_no_label(_expected_required_tasks, [])
-	expected := {{"code": "tasks.missing_required_pipeline_task_warning", "effective_on": "2022-01-01T00:00:00Z", "msg": "Required tasks do not exist for pipeline"}}
+	expected := {{"code": "tasks.pipeline_required_tasks_list_provided", "effective_on": "2022-01-01T00:00:00Z", "msg": "Required tasks do not exist for pipeline"}}
 	lib.assert_equal(expected, warn) with data["pipeline-required-tasks"] as _time_based_required_pipeline_tasks
 		with input.attestations as attestations
 }
@@ -84,7 +84,7 @@ test_current_equal_latest_also if {
 
 test_no_tasks_present if {
 	expected := {{
-		"code": "tasks.tasks_missing",
+		"code": "tasks.pipeline_has_tasks",
 		"collections": ["minimal"],
 		"msg": "No tasks found in PipelineRun attestation",
 		"effective_on": "2022-01-01T00:00:00Z",
@@ -123,10 +123,10 @@ test_parameterized if {
 		with input.attestations as attestations
 }
 
-test_missing_required_tasks_data if {
+test_required_tasks_founds_data if {
 	attestations := _attestations_with_tasks(_expected_required_tasks, [])
 	expected := {{
-		"code": "tasks.missing_required_data",
+		"code": "tasks.required_tasks_list_provided",
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Missing required task-bundles data",
 	}}
@@ -137,7 +137,7 @@ test_missing_required_tasks_data if {
 test_missing_required_pipeline_data if {
 	attestations := _attestations_with_tasks(_expected_required_tasks, [])
 	expected := {{
-		"code": "tasks.missing_required_pipeline_task_warning",
+		"code": "tasks.pipeline_required_tasks_list_provided",
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Required tasks do not exist for pipeline",
 	}}
@@ -181,7 +181,7 @@ _missing_tasks_violation(tasks) = errors if {
 	errors := {error |
 		some task in tasks
 		error := {
-			"code": "tasks.missing_required_task",
+			"code": "tasks.required_tasks_found",
 			"msg": sprintf("Required task %q is missing", [task]),
 			"term": task,
 			"effective_on": "2022-01-01T00:00:00Z",
@@ -193,7 +193,7 @@ _missing_tasks_warning(tasks) = warnings if {
 	warnings := {warning |
 		some task in tasks
 		warning := {
-			"code": "tasks.missing_future_required_task",
+			"code": "tasks.future_required_tasks_found",
 			"effective_on": "2022-01-01T00:00:00Z",
 			"msg": sprintf("Task %q is missing and will be required in the future", [task]),
 			"term": task,

--- a/policy/release/test.rego
+++ b/policy/release/test.rego
@@ -11,13 +11,13 @@ import data.lib
 import future.keywords.in
 
 # METADATA
-# title: No test data found
+# title: Test data found in task results
 # description: >-
-#   None of the tasks in the pipeline included a HACBS_TEST_OUTPUT
+#   Fails if none of the tasks in the pipeline included a HACBS_TEST_OUTPUT
 #   task result, which is where Enterprise Contract expects to find
 #   test result data.
 # custom:
-#   short_name: test_data_missing
+#   short_name: test_data_found
 #   failure_msg: No test data found
 #
 deny[result] {
@@ -29,12 +29,12 @@ deny[result] {
 }
 
 # METADATA
-# title: Test data is missing the results key
+# title: Test data includes results key
 # description: >-
-#   Each test result is expected to have a 'results' key. In at least
-#   one of the HACBS_TEST_OUTPUT task results this key was not present.
+#   Each test result is expected to have a 'results' key. The check fails if
+#   in at least one of the HACBS_TEST_OUTPUT task results this key was not present.
 # custom:
-#   short_name: test_results_missing
+#   short_name: test_results_found
 #   failure_msg: Found tests without results
 #
 deny[result] {
@@ -44,12 +44,13 @@ deny[result] {
 }
 
 # METADATA
-# title: Unsupported result in test data
+# title: No unsupported test result values found
 # description: >-
-#   This policy expects a set of known/supported results in the test data
-#   It is a failure if we encounter a result that is not supported.
+#   This policy expects all test results to be one of a set of known/supported
+#   values. It is a failure if we encounter a result in the test data that is
+#   not supported.
 # custom:
-#   short_name: test_result_unsupported
+#   short_name: test_results_known
 #   failure_msg: Test '%s' has unsupported result '%s'
 #
 deny[result] {
@@ -70,14 +71,14 @@ deny[result] {
 }
 
 # METADATA
-# title: Test result is FAILURE or ERROR
+# title: All required tests passed
 # description: >-
 #   Enterprise Contract requires that all the tests in the test results
 #   have a successful result. A successful result is one that isn't a
 #   "FAILURE" or "ERROR". This will fail if any of the tests failed and
 #   the failure message will list the names of the failing tests.
 # custom:
-#   short_name: test_result_failures
+#   short_name: required_tests_passed
 #   failure_msg: "Test %q did not complete successfully"
 #
 deny[result] {
@@ -86,11 +87,11 @@ deny[result] {
 }
 
 # METADATA
-# title: Test was skipped
+# title: No tests were skipped
 # description: >-
 #   Reports any test that has its result set to "SKIPPED".
 # custom:
-#   short_name: test_result_skipped
+#   short_name: no_skipped_tests
 #   failure_msg: "Test %q was skipped"
 #
 warn[result] {
@@ -99,11 +100,11 @@ warn[result] {
 }
 
 # METADATA
-# title: Test returned a warning
+# title: No tests produced warnings
 # description: >-
 #   Reports any test that has its result set to "WARNING".
 # custom:
-#   short_name: test_result_warning
+#   short_name: no_test_warnings
 #   failure_msg: "Test %q returned a warning"
 #
 warn[result] {

--- a/policy/release/test_test.rego
+++ b/policy/release/test_test.rego
@@ -7,7 +7,7 @@ mock_empty_data := [lib.att_mock_helper_ref("NOT_HACBS_TEST_OUTPUT", {}, "task1"
 
 test_needs_non_empty_data {
 	lib.assert_equal(deny, {{
-		"code": "test.test_data_missing",
+		"code": "test.test_data_found",
 		"msg": "No test data found",
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with input.attestations as mock_empty_data
@@ -18,7 +18,7 @@ mock_without_results_data := [lib.att_mock_helper_ref(lib.hacbs_test_task_result
 
 test_needs_tests_with_results {
 	lib.assert_equal(deny, {{
-		"code": "test.test_results_missing",
+		"code": "test.test_results_found",
 		"msg": "Found tests without results",
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with input.attestations as mock_without_results_data
@@ -31,7 +31,7 @@ mock_without_results_data_mixed := [
 
 test_needs_tests_with_results_mixed {
 	lib.assert_equal(deny, {{
-		"code": "test.test_results_missing",
+		"code": "test.test_results_found",
 		"msg": "Found tests without results",
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with input.attestations as mock_without_results_data_mixed
@@ -47,7 +47,7 @@ mock_a_failing_test := [lib.att_mock_helper_ref(lib.hacbs_test_task_result_name,
 
 test_failure_data {
 	lib.assert_equal(deny, {{
-		"code": "test.test_result_failures",
+		"code": "test.required_tests_passed",
 		"msg": "Test \"failed_1\" did not complete successfully",
 		"term": "failed_1",
 		"effective_on": "2022-01-01T00:00:00Z",
@@ -58,7 +58,7 @@ mock_an_errored_test := [lib.att_mock_helper_ref(lib.hacbs_test_task_result_name
 
 test_error_data {
 	lib.assert_equal(deny, {{
-		"code": "test.test_result_failures",
+		"code": "test.required_tests_passed",
 		"msg": "Test \"errored_1\" did not complete successfully",
 		"term": "errored_1",
 		"effective_on": "2022-01-01T00:00:00Z",
@@ -70,13 +70,13 @@ mock_mixed_data := array.concat(mock_a_failing_test, mock_an_errored_test)
 test_mix_data {
 	lib.assert_equal(deny, {
 		{
-			"code": "test.test_result_failures",
+			"code": "test.required_tests_passed",
 			"msg": "Test \"failed_1\" did not complete successfully",
 			"term": "failed_1",
 			"effective_on": "2022-01-01T00:00:00Z",
 		},
 		{
-			"code": "test.test_result_failures",
+			"code": "test.required_tests_passed",
 			"msg": "Test \"errored_1\" did not complete successfully",
 			"term": "errored_1",
 			"effective_on": "2022-01-01T00:00:00Z",
@@ -92,7 +92,7 @@ test_skipped_is_not_deny {
 test_skipped_is_warning {
 	skipped_test := [lib.att_mock_helper_ref(lib.hacbs_test_task_result_name, {"result": "SKIPPED"}, "skipped_1", _bundle)]
 	lib.assert_equal(warn, {{
-		"code": "test.test_result_skipped",
+		"code": "test.no_skipped_tests",
 		"msg": "Test \"skipped_1\" was skipped",
 		"term": "skipped_1",
 		"effective_on": "2022-01-01T00:00:00Z",
@@ -102,7 +102,7 @@ test_skipped_is_warning {
 test_warning_is_warning {
 	warning_test := [lib.att_mock_helper_ref(lib.hacbs_test_task_result_name, {"result": "WARNING"}, "warning_1", _bundle)]
 	lib.assert_equal(warn, {{
-		"code": "test.test_result_warning",
+		"code": "test.no_test_warnings",
 		"msg": "Test \"warning_1\" returned a warning",
 		"term": "warning_1",
 		"effective_on": "2022-01-01T00:00:00Z",
@@ -124,25 +124,25 @@ test_mixed_statuses {
 
 	lib.assert_equal(deny, {
 		{
-			"code": "test.test_result_failures",
+			"code": "test.required_tests_passed",
 			"msg": "Test \"error_1\" did not complete successfully",
 			"term": "error_1",
 			"effective_on": "2022-01-01T00:00:00Z",
 		},
 		{
-			"code": "test.test_result_failures",
+			"code": "test.required_tests_passed",
 			"msg": "Test \"error_2\" did not complete successfully",
 			"term": "error_2",
 			"effective_on": "2022-01-01T00:00:00Z",
 		},
 		{
-			"code": "test.test_result_failures",
+			"code": "test.required_tests_passed",
 			"msg": "Test \"failure_1\" did not complete successfully",
 			"term": "failure_1",
 			"effective_on": "2022-01-01T00:00:00Z",
 		},
 		{
-			"code": "test.test_result_failures",
+			"code": "test.required_tests_passed",
 			"msg": "Test \"failure_2\" did not complete successfully",
 			"term": "failure_2",
 			"effective_on": "2022-01-01T00:00:00Z",
@@ -151,25 +151,25 @@ test_mixed_statuses {
 
 	lib.assert_equal(warn, {
 		{
-			"code": "test.test_result_skipped",
+			"code": "test.no_skipped_tests",
 			"msg": "Test \"skipped_1\" was skipped",
 			"term": "skipped_1",
 			"effective_on": "2022-01-01T00:00:00Z",
 		},
 		{
-			"code": "test.test_result_skipped",
+			"code": "test.no_skipped_tests",
 			"msg": "Test \"skipped_2\" was skipped",
 			"term": "skipped_2",
 			"effective_on": "2022-01-01T00:00:00Z",
 		},
 		{
-			"code": "test.test_result_warning",
+			"code": "test.no_test_warnings",
 			"msg": "Test \"warning_1\" returned a warning",
 			"term": "warning_1",
 			"effective_on": "2022-01-01T00:00:00Z",
 		},
 		{
-			"code": "test.test_result_warning",
+			"code": "test.no_test_warnings",
 			"msg": "Test \"warning_2\" returned a warning",
 			"term": "warning_2",
 			"effective_on": "2022-01-01T00:00:00Z",
@@ -186,10 +186,10 @@ test_unsupported_test_result {
 	]
 
 	lib.assert_equal(deny, {
-		{"code": "test.test_result_unsupported", "msg": "Test 'error_1' has unsupported result 'EROR'", "effective_on": "2022-01-01T00:00:00Z", "term": "error_1"},
-		{"code": "test.test_result_unsupported", "msg": "Test 'failure_1' has unsupported result 'FAIL'", "effective_on": "2022-01-01T00:00:00Z", "term": "failure_1"},
-		{"code": "test.test_result_unsupported", "msg": "Test 'skipped_1' has unsupported result 'SKIPED'", "effective_on": "2022-01-01T00:00:00Z", "term": "skipped_1"},
-		{"code": "test.test_result_unsupported", "msg": "Test 'success_1' has unsupported result 'SUCESS'", "effective_on": "2022-01-01T00:00:00Z", "term": "success_1"},
+		{"code": "test.test_results_known", "msg": "Test 'error_1' has unsupported result 'EROR'", "effective_on": "2022-01-01T00:00:00Z", "term": "error_1"},
+		{"code": "test.test_results_known", "msg": "Test 'failure_1' has unsupported result 'FAIL'", "effective_on": "2022-01-01T00:00:00Z", "term": "failure_1"},
+		{"code": "test.test_results_known", "msg": "Test 'skipped_1' has unsupported result 'SKIPED'", "effective_on": "2022-01-01T00:00:00Z", "term": "skipped_1"},
+		{"code": "test.test_results_known", "msg": "Test 'success_1' has unsupported result 'SUCESS'", "effective_on": "2022-01-01T00:00:00Z", "term": "success_1"},
 	}) with input.attestations as test_results
 }
 


### PR DESCRIPTION
The idea is that the title and name should describe what is being checked, rather than describe the failure condition. This means the title text makes more sense when used in the UI if the rule is passing or if the rule is failing.

I'm also changing the short name for consistency, even though the short name is not as exposed via the web UI.

JIRA: [HACBS-2095](https://issues.redhat.com/browse/HACBS-2095)