### PR TITLE
Update description to not require a link

### DIFF
--- a/policy/pipeline/task_bundle.rego
+++ b/policy/pipeline/task_bundle.rego
@@ -62,12 +62,8 @@ warn contains result if {
 # METADATA
 # title: Task bundle is out of date
 # description: >-
-#   Check if the Tekton Bundle used for the Tasks in the Pipeline definition
-#   is the most recent acceptable one. See the list of acceptable
-#   task bundles at xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles] or look at
-#   xref:attachment$acceptable_tekton_bundles.yml[data/acceptable_tekton_bundles.yml]
-#   in this git repository. The meaning of an acceptable bundle is explained in
-#   xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles]
+#   For each Task in the Pipeline definition, check if the Tekton Bundle used is
+#   the most recent xref:acceptable_bundles.adoc#_task_bundles[acceptable bundle].
 # custom:
 #   short_name: out_of_date_task_bundle
 #   failure_msg: Pipeline task '%s' uses an out of date task bundle '%s'
@@ -80,12 +76,9 @@ warn contains result if {
 # METADATA
 # title: Task bundle is not acceptable
 # description: >-
-#   Check if the Tekton Bundle used for the Tasks in the Pipeline definition
-#   are acceptable given the tracked effective_on date. See the list of acceptable
-#   task bundles at xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles] or look at
-#   xref:attachment$acceptable_tekton_bundles.yml[data/acceptable_tekton_bundles.yml]
-#   in this git repository. The meaning of an acceptable bundle is explained in
-#   xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles]
+#   For each Task in the Pipeline definition, check if the Tekton Bundle used is an
+#   xref:acceptable_bundles.adoc#_task_bundles[acceptable bundle] given the tracked
+#   effective_on date.
 # custom:
 #   short_name: unacceptable_task_bundle
 #   failure_msg: Pipeline task '%s' uses an unacceptable task bundle '%s'

--- a/policy/release/attestation_task_bundle.rego
+++ b/policy/release/attestation_task_bundle.rego
@@ -65,12 +65,8 @@ warn[result] {
 # METADATA
 # title: Task bundle is out of date
 # description: >-
-#   Check if the Tekton Bundle used for the Tasks in the attestation
-#   is the most recent acceptable one. See the list of acceptable
-#   task bundles at xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles] or look at
-#   xref:attachment$acceptable_tekton_bundles.yml[data/acceptable_tekton_bundles.yml]
-#   in this git repository. The meaning of an acceptable bundle is explained in
-#   xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles]
+#   For each Task in the SLSA Provenance attestation, check if the Tekton Bundle used is
+#   the most recent xref:acceptable_bundles.adoc#_task_bundles[acceptable bundle].
 # custom:
 #   short_name: out_of_date_task_bundle
 #   failure_msg: Pipeline task '%s' uses an out of date task bundle '%s'
@@ -83,12 +79,9 @@ warn[result] {
 # METADATA
 # title: Task bundle is not acceptable
 # description: >-
-#   Check if the Tekton Bundle used for the Tasks in the attestation
-#   are acceptable given the tracked effective_on date. See the list of acceptable
-#   task bundles at xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles] or look at
-#   xref:attachment$acceptable_tekton_bundles.yml[data/acceptable_tekton_bundles.yml]
-#   in this git repository. The meaning of an acceptable bundle is explained in
-#   xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles]
+#   For each Task in the SLSA Provenance attestation, check if the Tekton Bundle used is
+#   an xref:acceptable_bundles.adoc#_task_bundles[acceptable bundle] given the tracked
+#   effective_on date.
 # custom:
 #   short_name: unacceptable_task_bundle
 #   failure_msg: Pipeline task '%s' uses an unacceptable task bundle '%s'

--- a/policy/release/tasks.rego
+++ b/policy/release/tasks.rego
@@ -11,8 +11,6 @@
 #   the name of the task. For example: ``name[PARAM=val]``. Only single parameter
 #   is supported, to assert multiple parameters repeat the required task
 #   definition for each parameter seperately.
-#   The Tasks must be loaded from an acceptable Tekton Bundle.
-#   See xref:release_policy.adoc#attestation_task_bundle_package[Task bundle checks].
 #
 package policy.release.tasks
 
@@ -59,7 +57,7 @@ deny contains result if {
 # METADATA
 # title: Missing required pipeline tasks warning
 # description: >-
-#   This policy warns if a task list does not exist in the acceptable_bundles.yaml file
+#   This policy warns if a task list does not exist in the required_tasks.yaml file
 # custom:
 #   short_name: missing_required_pipeline_task_warning
 #   failure_msg: Required tasks do not exist for pipeline

--- a/policy/release/test.rego
+++ b/policy/release/test.rego
@@ -5,10 +5,6 @@
 #   to a set of tests and that those tests all passed. This package
 #   includes a set of rules to verify that.
 #
-#   The test result data must be reported by a Tekton Task that has been loaded
-#   from an acceptable Tekton Bundle.
-#   See xref:release_policy.adoc#attestation_task_bundle_package[Task bundle checks].
-#
 package policy.release.test
 
 import data.lib


### PR DESCRIPTION
Some policy rules include asciidoc links in their description. The docs building process replaces them with the correct link markup. However, the description is used in other contexts which are agnostic to our building process, e.g. `ec validate image --info`.

In https://issues.redhat.com/browse/HACBS-2102, a change to the ec-cli is being made to remove such asciidoc markup and leave only the text behind.

This change updates the wording of the description to still make sense if a given part of the text is not a link.

This also removes some outdated references to acceptable bundles. (Not all policy rules that check tasks require them to come from acceptable bundles.)