### PR TITLE
Allow Rego files to originate from any content

### DIFF
--- a/antora/ec-policies-antora-extension/index.js
+++ b/antora/ec-policies-antora-extension/index.js
@@ -128,7 +128,7 @@ const helpers = {
           const file = a.location.file
           const row = a.location.row
 
-          const packageShortName = a.path[3].value
+          const packageShortName = helpers.toJoinedPath(a.path.slice(3, a.path.length-1), '_')
           const packageShortNamespace = a.path[2].value
           const packagePath = helpers.toDottedPath(a.path.slice(1, a.path.length-1))
           const pkgAnnotation = packageAnnotations[packagePath] || {}


### PR DESCRIPTION
This allows us to have `.rego` files for the purpose of generating data
for the documentation in any component.

Also includes [Allow package names with more than 3 parts](https://github.com/enterprise-contract/ec-policies/commit/3c3d00a02226f2cccac9e483ba79d76e8ea4cae8)

Ref. https://issues.redhat.com/browse/HACBS-2162