### PR TITLE
remove HACBS_TEST_OUTPUT result

### DIFF
--- a/policy/pipeline/required_tasks.rego
+++ b/policy/pipeline/required_tasks.rego
@@ -1,7 +1,7 @@
 #
 # METADATA
 # description: >-
-#   HACBS expects that certain Tekton tasks are executed during image builds.
+#   RHTAP expects that certain Tekton tasks are executed during image builds.
 #   This package includes policy rules to confirm that the pipeline definition
 #   includes the required Tekton tasks.
 #

--- a/policy/release/lib/attestations.rego
+++ b/policy/release/lib/attestations.rego
@@ -18,8 +18,6 @@ taskrun_att_build_types := [
 # with test_ is treated as though it was a test.)
 task_test_result_name := "TEST_OUTPUT"
 
-task_test_result_name_deprecated := "HACBS_TEST_OUTPUT"
-
 java_sbom_component_count_result_name := "SBOM_JAVA_COMPONENTS_COUNT"
 
 build_base_images_digests_result_name := "BASE_IMAGES_DIGESTS"
@@ -70,14 +68,7 @@ unmarshal(raw) = value {
 # (Don't call it test_results since test_ means a unit test)
 results_from_tests = results {
 	# First find results using the new task result name
-	_results := results_named(task_test_result_name)
-
-	# If some were found then return them
-	count(_results) > 0
-	results := _results
-} else = results {
-	# Try the older task result name, return it even if empty
-	results := results_named(task_test_result_name_deprecated)
+	results := results_named(task_test_result_name)
 }
 
 # Check for a task by name. Return the task if found

--- a/policy/release/lib/attestations_test.rego
+++ b/policy/release/lib/attestations_test.rego
@@ -163,7 +163,6 @@ test_att_mock_helper_ref {
 
 test_results_from_tests {
 	assert_equal("TEST_OUTPUT", lib.task_test_result_name)
-	assert_equal("HACBS_TEST_OUTPUT", lib.task_test_result_name_deprecated)
 
 	expected := {
 		"value": {"result": "SUCCESS", "foo": "bar"},
@@ -173,13 +172,8 @@ test_results_from_tests {
 
 	assert_equal([expected], results_from_tests) with input.attestations as [att_mock_helper_ref(lib.task_test_result_name, {"result": "SUCCESS", "foo": "bar"}, "mytask", bundles.acceptable_bundle_ref)]
 
-	assert_equal([expected], results_from_tests) with input.attestations as [att_mock_helper_ref(lib.task_test_result_name_deprecated, {"result": "SUCCESS", "foo": "bar"}, "mytask", bundles.acceptable_bundle_ref)]
-
 	# An edge case that may never happen
-	assert_equal([expected], results_from_tests) with input.attestations as [
-		att_mock_helper_ref(lib.task_test_result_name, {"result": "SUCCESS", "foo": "bar"}, "mytask", bundles.acceptable_bundle_ref),
-		att_mock_helper_ref(lib.task_test_result_name_deprecated, {"result": "SUCCESS", "baz": "quux"}, "myothertask", bundles.acceptable_bundle_ref),
-	]
+	assert_equal([expected], results_from_tests) with input.attestations as [att_mock_helper_ref(lib.task_test_result_name, {"result": "SUCCESS", "foo": "bar"}, "mytask", bundles.acceptable_bundle_ref)]
 }
 
 test_task_in_pipelinerun {


### PR DESCRIPTION
The result has been deprecated and now is removed.