### PR TITLE
Allow more than one buildah task

### DIFF
--- a/policy/release/buildah_build_task.rego
+++ b/policy/release/buildah_build_task.rego
@@ -7,6 +7,7 @@
 package policy.release.buildah_build_task
 
 import future.keywords.contains
+import future.keywords.every
 import future.keywords.if
 import future.keywords.in
 
@@ -19,7 +20,7 @@ import data.lib
 #   the buildah task.
 # custom:
 #   short_name: buildah_task_has_dockerfile_param
-#   failure_msg: The DOCKERFILE param was not included in the buildah task
+#   failure_msg: 'The DOCKERFILE param was not included in the buildah task(s): %q'
 #   solution: >-
 #     Make sure the buildah task has a parameter named 'DOCKERFILE'.
 #   depends_on:
@@ -27,9 +28,10 @@ import data.lib
 #
 deny contains result if {
 	# Skip this rule if the buildah task is not present
-	buildah_task
-	not dockerfile_param
-	result := lib.result_helper(rego.metadata.chain(), [])
+	buildah_tasks
+	some buildah_task in buildah_tasks
+	not lib.tkn.task_param(buildah_task, "DOCKERFILE")
+	result := lib.result_helper_with_term(rego.metadata.chain(), [buildah_task.name], buildah_task.name)
 }
 
 # METADATA
@@ -46,6 +48,7 @@ deny contains result if {
 #   - attestation_type.known_attestation_type
 #
 deny contains result if {
+	some dockerfile_param in dockerfile_params
 	_not_allowed_prefix(dockerfile_param)
 	result := lib.result_helper(rego.metadata.chain(), [dockerfile_param])
 }
@@ -55,12 +58,13 @@ _not_allowed_prefix(search) if {
 	startswith(search, not_allowed[_])
 }
 
-buildah_task := task if {
+buildah_tasks contains task if {
 	some att in lib.pipelinerun_attestations
 	some task in lib.tkn.tasks(att)
 	"buildah" in lib.tkn.task_names(task)
 }
 
-dockerfile_param := param if {
+dockerfile_params contains param if {
+	some buildah_task in buildah_tasks
 	param := lib.tkn.task_param(buildah_task, "DOCKERFILE")
 }


### PR DESCRIPTION
Given that some projects might include the buildah task more than once, this opts to allow it and enforce the existing rules on all of them.

The message for missing parameters to the buildah task was modified to include all the tasks that miss their parameters.

The message for using non-local Dockerfile was not changed.

Ref. https://issues.redhat.com/browse/HACBS-2280