### PR TITLE
Set top-level token permissions on workflows

### DIFF
--- a/.github/workflows/enable-auto-merge.yaml
+++ b/.github/workflows/enable-auto-merge.yaml
@@ -14,10 +14,16 @@ name: Enable auto-merge
       - reopened
     branches:
       - main
+
+permissions:
+  pull-requests: read
+
 jobs:
   enable-auto-merge:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'rh-tap-build-team[bot]'
+    permissions:
+      pull-requests: write
     steps:
       - uses: alexwilson/enable-github-automerge-action@d7e0043317b5118a91776831707b9ed81deba951 # main
         with:

--- a/.github/workflows/pre-merge-ci.yaml
+++ b/.github/workflows/pre-merge-ci.yaml
@@ -12,6 +12,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   all-tests-and-checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It is recommended to set a read-level permission at the top level of the workflow. Then, if needed, add write-level permission at the job level. See https://github.com/orgs/enterprise-contract/security/risk