### PR TITLE
Fix auto-merge permission

### DIFF
--- a/.github/workflows/enable-auto-merge.yaml
+++ b/.github/workflows/enable-auto-merge.yaml
@@ -16,14 +16,14 @@ name: Enable auto-merge
       - main
 
 permissions:
-  pull-requests: read
+  contents: read
 
 jobs:
   enable-auto-merge:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'rh-tap-build-team[bot]'
     permissions:
-      pull-requests: write
+      contents: write
     steps:
       - uses: alexwilson/enable-github-automerge-action@253948b2e2433d985bbbebe7887ca347e1e1b1ec # main
         with:


### PR DESCRIPTION
The permission required is `contents` and not `pull-requests`.