### PR TITLE
Add policies to validate GitHub certificates

### DIFF
--- a/policy/release/github_certificate.rego
+++ b/policy/release/github_certificate.rego
@@ -1,0 +1,123 @@
+#
+# METADATA
+# title: GitHub Certificate Checks
+# description: >-
+#   Verify attributes on the certificate involved in the image signature when using
+#   slsa-github-generator on GitHub Actions with Sigstore Fulcio
+#
+package policy.release.github_certificate
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+import data.lib
+
+# METADATA
+# title: GitHub Workflow Certificate Extensions
+# description: >-
+#   Check if the image signature certificate contains the expected GitHub
+#   extensions. These are the extensions that represent the GitHub workflow
+#   trigger, sha, name, repository, and ref.
+# custom:
+#   short_name: gh_workflow_extensions
+#   failure_msg: 'Missing extension %q'
+#
+warn contains result if {
+	some extension in [_TRIGGER, _SHA, _NAME, _REPOSITORY, _REF]
+	not _fulcio_extension_value(extension)
+	result := lib.result_helper(rego.metadata.chain(), [extension.name])
+}
+
+# METADATA
+# title: GitHub Workflow Repository
+# description: >-
+#   Check if the value of the GitHub Workflow Repository extension in the image
+#   signature certificate matches one of the allowed values. Use the rule data
+#   key "allowed_gh_workflow_repos" to specify the list of allowed values.
+#   An empty allow list, which is the default value, causes this check to succeeded.
+# custom:
+#   short_name: gh_workflow_repository
+#   failure_msg: 'Repository %q not in allowed list: %v'
+#
+deny contains result if {
+	result := _check_extension(rego.metadata.chain(), "allowed_gh_workflow_repos", _REPOSITORY)
+}
+
+# METADATA
+# title: GitHub Workflow Repository
+# description: >-
+#   Check if the value of the GitHub Workflow Ref extension in the image
+#   signature certificate matches one of the allowed values. Use the rule data
+#   key "allowed_gh_workflow_refs" to specify the list of allowed values.
+#   An empty allow list, which is the default value, causes this check to succeeded.
+# custom:
+#   short_name: gh_workflow_ref
+#   failure_msg: 'Ref %q not in allowed list: %v'
+#
+deny contains result if {
+	result := _check_extension(rego.metadata.chain(), "allowed_gh_workflow_refs", _REF)
+}
+
+# METADATA
+# title: GitHub Workflow Name
+# description: >-
+#   Check if the value of the GitHub Workflow Name extension in the image
+#   signature certificate matches one of the allowed values. Use the rule data
+#   key "allowed_gh_workflow_names" to specify the list of allowed values.
+#   An empty allow list, which is the default value, causes this check to succeeded.
+# custom:
+#   short_name: gh_workflow_name
+#   failure_msg: 'Name %q not in allowed list: %v'
+#
+deny contains result if {
+	result := _check_extension(rego.metadata.chain(), "allowed_gh_workflow_names", _NAME)
+}
+
+# METADATA
+# title: GitHub Workflow Trigger
+# description: >-
+#   Check if the value of the GitHub Workflow Trigger extension in the image
+#   signature certificate matches one of the allowed values. Use the rule data
+#   key "allowed_gh_workflow_triggers" to specify the list of allowed values.
+#   An empty allow list, which is the default value, causes this check to succeeded.
+# custom:
+#   short_name: gh_workflow_trigger
+#   failure_msg: 'Trigger %q not in allowed list: %v'
+#
+deny contains result if {
+	result := _check_extension(rego.metadata.chain(), "allowed_gh_workflow_triggers", _TRIGGER)
+}
+
+_check_extension(chain, key, extension) := result if {
+	value := _fulcio_extension_value(extension)
+	allowed := lib.rule_data(key)
+	count(allowed) > 0
+	not value in allowed
+	result := lib.result_helper(chain, [value, allowed])
+}
+
+_certs contains cert if {
+	some sig in input.image.signatures
+	cert := crypto.x509.parse_certificates(sig.certificate)[0]
+	cert.KeyUsage == 1
+	cert.ExtKeyUsage == [3]
+}
+
+_fulcio_extension_value(ext) := value if {
+	id := [1, 3, 6, 1, 4, 1, 57264, 1, ext.id]
+	some cert in _certs
+	some extension in cert.Extensions
+	extension.Id == id
+	value := base64.decode(extension.Value)
+}
+
+_TRIGGER := {"id": 2, "name": "GitHub Workflow Trigger"}
+
+_SHA := {"id": 3, "name": "GitHub Workflow SHA"}
+
+_NAME := {"id": 4, "name": "GitHub Workflow Name"}
+
+_REPOSITORY := {"id": 5, "name": "GitHub Workflow Repository"}
+
+_REF := {"id": 6, "name": "GitHub Workflow Ref"}

--- a/policy/release/github_certificate_test.rego
+++ b/policy/release/github_certificate_test.rego
@@ -1,0 +1,180 @@
+package policy.release.github_certificate
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+import data.lib
+
+test_all_good if {
+	signatures := [{"certificate": good_cert}]
+	lib.assert_empty(deny) with input.image.signatures as signatures
+	lib.assert_empty(warn) with input.image.signatures as signatures
+}
+
+test_at_least_one_good if {
+	signatures := [{"certificate": good_cert}, {"certificate": bad_cert}]
+	lib.assert_empty(deny) with input.image.signatures as signatures
+	lib.assert_empty(warn) with input.image.signatures as signatures
+}
+
+test_gh_workflow_repository_match if {
+	signatures := [{"certificate": good_cert}]
+	lib.assert_empty(deny) with input.image.signatures as signatures
+		with data.rule_data.allowed_gh_workflow_repos as ["spam", "lcarva/festoji", "eggs"]
+}
+
+test_gh_workflow_repository_mismatch if {
+	signatures := [{"certificate": good_cert}]
+	expected := {{
+		"code": "github_certificate.gh_workflow_repository",
+		"effective_on": "2022-01-01T00:00:00Z",
+		"msg": "Repository \"lcarva/festoji\" not in allowed list: [\"ec-cli\", \"ec-policies\"]",
+	}}
+	lib.assert_equal(deny, expected) with input.image.signatures as signatures
+		with data.rule_data.allowed_gh_workflow_repos as ["ec-cli", "ec-policies"]
+}
+
+test_gh_workflow_ref_match if {
+	signatures := [{"certificate": good_cert}]
+	lib.assert_empty(deny) with input.image.signatures as signatures
+		with data.rule_data.allowed_gh_workflow_refs as ["refs/heads/master", "refs/heads/main"]
+}
+
+test_gh_workflow_ref_mismatch if {
+	signatures := [{"certificate": good_cert}]
+	expected := {{
+		"code": "github_certificate.gh_workflow_ref",
+		"effective_on": "2022-01-01T00:00:00Z",
+		"msg": "Ref \"refs/heads/master\" not in allowed list: [\"refs/heads/prod\"]",
+	}}
+	lib.assert_equal(deny, expected) with input.image.signatures as signatures
+		with data.rule_data.allowed_gh_workflow_refs as ["refs/heads/prod"]
+}
+
+test_gh_workflow_name_match if {
+	signatures := [{"certificate": good_cert}]
+	lib.assert_empty(deny) with input.image.signatures as signatures
+		with data.rule_data.allowed_gh_workflow_names as ["Package"]
+}
+
+test_gh_workflow_name_mismatch if {
+	signatures := [{"certificate": good_cert}]
+	expected := {{
+		"code": "github_certificate.gh_workflow_name",
+		"effective_on": "2022-01-01T00:00:00Z",
+		"msg": "Name \"Package\" not in allowed list: [\"hackery\"]",
+	}}
+	lib.assert_equal(deny, expected) with input.image.signatures as signatures
+		with data.rule_data.allowed_gh_workflow_names as ["hackery"]
+}
+
+test_gh_workflow_trigger_match if {
+	signatures := [{"certificate": good_cert}]
+	lib.assert_empty(deny) with input.image.signatures as signatures
+		with data.rule_data.allowed_gh_workflow_triggers as ["push"]
+}
+
+test_gh_workflow_trigger_mismatch if {
+	signatures := [{"certificate": good_cert}]
+	expected := {{
+		"code": "github_certificate.gh_workflow_trigger",
+		"effective_on": "2022-01-01T00:00:00Z",
+		"msg": "Trigger \"push\" not in allowed list: [\"build\"]",
+	}}
+	lib.assert_equal(deny, expected) with input.image.signatures as signatures
+		with data.rule_data.allowed_gh_workflow_triggers as ["build"]
+}
+
+test_missing_extensions if {
+	expected := {
+		{
+			"code": "github_certificate.gh_workflow_extensions",
+			"effective_on": "2022-01-01T00:00:00Z",
+			"msg": "Missing extension \"GitHub Workflow Name\"",
+		},
+		{
+			"code": "github_certificate.gh_workflow_extensions",
+			"effective_on": "2022-01-01T00:00:00Z",
+			"msg": "Missing extension \"GitHub Workflow Ref\"",
+		},
+		{
+			"code": "github_certificate.gh_workflow_extensions",
+			"effective_on": "2022-01-01T00:00:00Z",
+			"msg": "Missing extension \"GitHub Workflow Repository\"",
+		},
+		{
+			"code": "github_certificate.gh_workflow_extensions",
+			"effective_on": "2022-01-01T00:00:00Z",
+			"msg": "Missing extension \"GitHub Workflow SHA\"",
+		},
+		{
+			"code": "github_certificate.gh_workflow_extensions",
+			"effective_on": "2022-01-01T00:00:00Z",
+			"msg": "Missing extension \"GitHub Workflow Trigger\"",
+		},
+	}
+	lib.assert_equal(warn, expected)
+	lib.assert_equal(warn, expected) with input as {}
+	lib.assert_equal(warn, expected) with input.image as {}
+	lib.assert_equal(warn, expected) with input.image.signatures as []
+	lib.assert_equal(warn, expected) with input.image.signatures as [{}]
+	lib.assert_equal(warn, expected) with input.image.signatures as [{"certificate": ""}]
+	lib.assert_equal(warn, expected) with input.image.signatures as [{"certificate": bad_cert}]
+}
+
+# This is a certificate used when signing an image on GitHub. It
+# contains all the expected Fulcio GitHub extensions.
+good_cert := `-----BEGIN CERTIFICATE-----
+MIIGgjCCBgigAwIBAgIUQNGRo7U3odD/NCO2AUOUZEHrrV4wCgYIKoZIzj0EAwMw
+NzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRl
+cm1lZGlhdGUwHhcNMjMwNjIzMjAwODM4WhcNMjMwNjIzMjAxODM4WjAAMFkwEwYH
+KoZIzj0CAQYIKoZIzj0DAQcDQgAEF9tc9f4G+uPc23aEzS519jAjnzavr4wL0Cx5
+Zs4Khd9kcHONFZE1JFHmUICjP6BafRZ3cWz8yv35paQVSV+DVKOCBScwggUjMA4G
+A1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUnDhg
+2f/e4XFEns+m+PltKUbHHf4wHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4Y
+ZD8wYAYDVR0RAQH/BFYwVIZSaHR0cHM6Ly9naXRodWIuY29tL2xjYXJ2YS9mZXN0
+b2ppLy5naXRodWIvd29ya2Zsb3dzL3BhY2thZ2UueWFtbEByZWZzL2hlYWRzL21h
+c3RlcjA5BgorBgEEAYO/MAEBBCtodHRwczovL3Rva2VuLmFjdGlvbnMuZ2l0aHVi
+dXNlcmNvbnRlbnQuY29tMBIGCisGAQQBg78wAQIEBHB1c2gwNgYKKwYBBAGDvzAB
+AwQoODQ4ZWRjNDUyY2NiYzZkNDJlYzU2YzI4MDdlZWYyZjQ5ZTc1NGM1ZTAVBgor
+BgEEAYO/MAEEBAdQYWNrYWdlMBwGCisGAQQBg78wAQUEDmxjYXJ2YS9mZXN0b2pp
+MB8GCisGAQQBg78wAQYEEXJlZnMvaGVhZHMvbWFzdGVyMDsGCisGAQQBg78wAQgE
+LQwraHR0cHM6Ly90b2tlbi5hY3Rpb25zLmdpdGh1YnVzZXJjb250ZW50LmNvbTBi
+BgorBgEEAYO/MAEJBFQMUmh0dHBzOi8vZ2l0aHViLmNvbS9sY2FydmEvZmVzdG9q
+aS8uZ2l0aHViL3dvcmtmbG93cy9wYWNrYWdlLnlhbWxAcmVmcy9oZWFkcy9tYXN0
+ZXIwOAYKKwYBBAGDvzABCgQqDCg4NDhlZGM0NTJjY2JjNmQ0MmVjNTZjMjgwN2Vl
+ZjJmNDllNzU0YzVlMB0GCisGAQQBg78wAQsEDwwNZ2l0aHViLWhvc3RlZDAxBgor
+BgEEAYO/MAEMBCMMIWh0dHBzOi8vZ2l0aHViLmNvbS9sY2FydmEvZmVzdG9qaTA4
+BgorBgEEAYO/MAENBCoMKDg0OGVkYzQ1MmNjYmM2ZDQyZWM1NmMyODA3ZWVmMmY0
+OWU3NTRjNWUwIQYKKwYBBAGDvzABDgQTDBFyZWZzL2hlYWRzL21hc3RlcjAZBgor
+BgEEAYO/MAEPBAsMCTE1OTA2OTgzMjApBgorBgEEAYO/MAEQBBsMGWh0dHBzOi8v
+Z2l0aHViLmNvbS9sY2FydmEwFwYKKwYBBAGDvzABEQQJDAc1MjcyOTMxMGIGCisG
+AQQBg78wARIEVAxSaHR0cHM6Ly9naXRodWIuY29tL2xjYXJ2YS9mZXN0b2ppLy5n
+aXRodWIvd29ya2Zsb3dzL3BhY2thZ2UueWFtbEByZWZzL2hlYWRzL21hc3RlcjA4
+BgorBgEEAYO/MAETBCoMKDg0OGVkYzQ1MmNjYmM2ZDQyZWM1NmMyODA3ZWVmMmY0
+OWU3NTRjNWUwFAYKKwYBBAGDvzABFAQGDARwdXNoMFQGCisGAQQBg78wARUERgxE
+aHR0cHM6Ly9naXRodWIuY29tL2xjYXJ2YS9mZXN0b2ppL2FjdGlvbnMvcnVucy81
+MzYwMTI1NjEzL2F0dGVtcHRzLzEwgYkGCisGAQQB1nkCBAIEewR5AHcAdQDdPTBq
+xscRMmMZHhyZZzcCokpeuN48rf+HinKALynujgAAAYjp34D6AAAEAwBGMEQCIEDf
+e5O+p+0QdfRbRY4U5hJG+REG3Xxci78SBp8iuJEpAiAI6in8wxrfiC8reu0+EoFc
+wX2Ep4RzIYkAy+p2Ga6JvTAKBggqhkjOPQQDAwNoADBlAjB+CXmTANUemgjXL2/X
+nVIP9B+/02qr8N3kBIPV91VvuCbSMv0mqFImYX+cRxsuVtYCMQDd2NVxH0x5ErBU
+s/UT5EA4t34N1UcRRHfF3YPLPzIvgEYdg0sn3qmgABlPCr1BOkY=
+-----END CERTIFICATE-----`
+
+# This is just a random certificate that does not contain any of
+# the Fulcio GitHub extensions.
+bad_cert := `-----BEGIN CERTIFICATE-----
+MIIB8TCCAXegAwIBAgIUBHcWnSa4N1K+z/dRDitfwGT6RUowCgYIKoZIzj0EAwMw
+MzETMBEGA1UECgwKZm9vYmFyLmRldjEcMBoGA1UEAwwTZm9vYmFyLWludGVybWVk
+aWF0ZTAeFw05MDAxMDEwMDAwMDBaFw00MDAxMDEwMDAwMDBaMAAwWTATBgcqhkjO
+PQIBBggqhkjOPQMBBwNCAARSG+kx7P0C96xegjJgg81uJrJf/G+yYLRKucwP3AMP
+Q1xFB+/8wdUqeTLZPI7AsmcGtvbT/Vr5GRPNT1NUSlFVo4GbMIGYMB0GA1UdDgQW
+BBTXA23F2RNNOlWky1b9MQ1AX3NfQzAfBgNVHSMEGDAWgBSRLp/yACH4u5DoQ1HD
+pNZpq/1mazAOBgNVHQ8BAf8EBAMCB4AwEwYDVR0lBAwwCgYIKwYBBQUHAwMwMQYD
+VR0RBCowKIYRaHR0cDovL2Zvb2Jhci5kZXagEwYKKwYBBAGDvzABB6AFDANGT08w
+CgYIKoZIzj0EAwMDaAAwZQIwWi7Kx/jf8O3riw+dLxK2p4+JPbH92aFrq3WozDex
+iXb1ZTM3FhaFFrM15gMKWlVhAjEAig8qoM7nW0cPq0x029VvJPjm4knz7ZvmnY3d
+VwmStvcPrB+2+tmxDfK1BKl1v5/Z
+-----END CERTIFICATE-----`


### PR DESCRIPTION
https://issues.redhat.com/browse/HACBS-2083

To try it out, create the policy below.

`policy.yaml`
```yaml
sources:
  - name: Default
    policy:
     # Using my fork while the change is not yet merged
      - github.com/lcarva/ec-policies//policy/lib?ref=HACBS-2083
      - github.com/lcarva/ec-policies//policy/release?ref=HACBS-2083
    data:
      - github.com/lcarva/ec-policies//data?ref=HACBS-2083
    ruleData:
      allowed_gh_workflow_repos: [lcarva/festoji]
      allowed_gh_workflow_refs: [refs/heads/master]
      allowed_gh_workflow_names: [Package]
      allowed_gh_workflow_triggers: [push]

configuration:
  include:
    - '@slsa1'
    - '@slsa2'
    - '@slsa3'
    - github_certificate
```

And run ec against an image built on GitHub:
```bash
EC_EXPERIMENTAL=1 ec validate image \
   --policy policy.yaml \
   --image quay.io/lucarval/festoji:latest \
   --output yaml \
   --certificate-identity-regexp '^https://github\.com' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
   --rekor-url 'https://rekor.sigstore.dev' \
   --info --show-successes
```

<details>

<summary>Click to see the output</summary>

```yaml
components:
- containerImage: quay.io/lucarval/festoji@sha256:6a6b100a8b143683f654fc30c4f6e40fcc7d18cf7db050792de6ad8a25e6eb33
  name: Unnamed
  signatures:
  - certificate: |
      -----BEGIN CERTIFICATE-----
      MIIGgjCCBgigAwIBAgIUQNGRo7U3odD/NCO2AUOUZEHrrV4wCgYIKoZIzj0EAwMw
      NzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRl
      cm1lZGlhdGUwHhcNMjMwNjIzMjAwODM4WhcNMjMwNjIzMjAxODM4WjAAMFkwEwYH
      KoZIzj0CAQYIKoZIzj0DAQcDQgAEF9tc9f4G+uPc23aEzS519jAjnzavr4wL0Cx5
      Zs4Khd9kcHONFZE1JFHmUICjP6BafRZ3cWz8yv35paQVSV+DVKOCBScwggUjMA4G
      A1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUnDhg
      2f/e4XFEns+m+PltKUbHHf4wHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4Y
      ZD8wYAYDVR0RAQH/BFYwVIZSaHR0cHM6Ly9naXRodWIuY29tL2xjYXJ2YS9mZXN0
      b2ppLy5naXRodWIvd29ya2Zsb3dzL3BhY2thZ2UueWFtbEByZWZzL2hlYWRzL21h
      c3RlcjA5BgorBgEEAYO/MAEBBCtodHRwczovL3Rva2VuLmFjdGlvbnMuZ2l0aHVi
      dXNlcmNvbnRlbnQuY29tMBIGCisGAQQBg78wAQIEBHB1c2gwNgYKKwYBBAGDvzAB
      AwQoODQ4ZWRjNDUyY2NiYzZkNDJlYzU2YzI4MDdlZWYyZjQ5ZTc1NGM1ZTAVBgor
      BgEEAYO/MAEEBAdQYWNrYWdlMBwGCisGAQQBg78wAQUEDmxjYXJ2YS9mZXN0b2pp
      MB8GCisGAQQBg78wAQYEEXJlZnMvaGVhZHMvbWFzdGVyMDsGCisGAQQBg78wAQgE
      LQwraHR0cHM6Ly90b2tlbi5hY3Rpb25zLmdpdGh1YnVzZXJjb250ZW50LmNvbTBi
      BgorBgEEAYO/MAEJBFQMUmh0dHBzOi8vZ2l0aHViLmNvbS9sY2FydmEvZmVzdG9q
      aS8uZ2l0aHViL3dvcmtmbG93cy9wYWNrYWdlLnlhbWxAcmVmcy9oZWFkcy9tYXN0
      ZXIwOAYKKwYBBAGDvzABCgQqDCg4NDhlZGM0NTJjY2JjNmQ0MmVjNTZjMjgwN2Vl
      ZjJmNDllNzU0YzVlMB0GCisGAQQBg78wAQsEDwwNZ2l0aHViLWhvc3RlZDAxBgor
      BgEEAYO/MAEMBCMMIWh0dHBzOi8vZ2l0aHViLmNvbS9sY2FydmEvZmVzdG9qaTA4
      BgorBgEEAYO/MAENBCoMKDg0OGVkYzQ1MmNjYmM2ZDQyZWM1NmMyODA3ZWVmMmY0
      OWU3NTRjNWUwIQYKKwYBBAGDvzABDgQTDBFyZWZzL2hlYWRzL21hc3RlcjAZBgor
      BgEEAYO/MAEPBAsMCTE1OTA2OTgzMjApBgorBgEEAYO/MAEQBBsMGWh0dHBzOi8v
      Z2l0aHViLmNvbS9sY2FydmEwFwYKKwYBBAGDvzABEQQJDAc1MjcyOTMxMGIGCisG
      AQQBg78wARIEVAxSaHR0cHM6Ly9naXRodWIuY29tL2xjYXJ2YS9mZXN0b2ppLy5n
      aXRodWIvd29ya2Zsb3dzL3BhY2thZ2UueWFtbEByZWZzL2hlYWRzL21hc3RlcjA4
      BgorBgEEAYO/MAETBCoMKDg0OGVkYzQ1MmNjYmM2ZDQyZWM1NmMyODA3ZWVmMmY0
      OWU3NTRjNWUwFAYKKwYBBAGDvzABFAQGDARwdXNoMFQGCisGAQQBg78wARUERgxE
      aHR0cHM6Ly9naXRodWIuY29tL2xjYXJ2YS9mZXN0b2ppL2FjdGlvbnMvcnVucy81
      MzYwMTI1NjEzL2F0dGVtcHRzLzEwgYkGCisGAQQB1nkCBAIEewR5AHcAdQDdPTBq
      xscRMmMZHhyZZzcCokpeuN48rf+HinKALynujgAAAYjp34D6AAAEAwBGMEQCIEDf
      e5O+p+0QdfRbRY4U5hJG+REG3Xxci78SBp8iuJEpAiAI6in8wxrfiC8reu0+EoFc
      wX2Ep4RzIYkAy+p2Ga6JvTAKBggqhkjOPQQDAwNoADBlAjB+CXmTANUemgjXL2/X
      nVIP9B+/02qr8N3kBIPV91VvuCbSMv0mqFImYX+cRxsuVtYCMQDd2NVxH0x5ErBU
      s/UT5EA4t34N1UcRRHfF3YPLPzIvgEYdg0sn3qmgABlPCr1BOkY=
      -----END CERTIFICATE-----
    chain:
    - |
      -----BEGIN CERTIFICATE-----
      MIICGjCCAaGgAwIBAgIUALnViVfnU0brJasmRkHrn/UnfaQwCgYIKoZIzj0EAwMw
      KjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0y
      MjA0MTMyMDA2MTVaFw0zMTEwMDUxMzU2NThaMDcxFTATBgNVBAoTDHNpZ3N0b3Jl
      LmRldjEeMBwGA1UEAxMVc2lnc3RvcmUtaW50ZXJtZWRpYXRlMHYwEAYHKoZIzj0C
      AQYFK4EEACIDYgAE8RVS/ysH+NOvuDZyPIZtilgUF9NlarYpAd9HP1vBBH1U5CV7
      7LSS7s0ZiH4nE7Hv7ptS6LvvR/STk798LVgMzLlJ4HeIfF3tHSaexLcYpSASr1kS
      0N/RgBJz/9jWCiXno3sweTAOBgNVHQ8BAf8EBAMCAQYwEwYDVR0lBAwwCgYIKwYB
      BQUHAwMwEgYDVR0TAQH/BAgwBgEB/wIBADAdBgNVHQ4EFgQU39Ppz1YkEZb5qNjp
      KFWixi4YZD8wHwYDVR0jBBgwFoAUWMAeX5FFpWapesyQoZMi0CrFxfowCgYIKoZI
      zj0EAwMDZwAwZAIwPCsQK4DYiZYDPIaDi5HFKnfxXx6ASSVmERfsynYBiX2X6SJR
      nZU84/9DZdnFvvxmAjBOt6QpBlc4J/0DxvkTCqpclvziL6BCCPnjdlIB3Pu3BxsP
      mygUY7Ii2zbdCdliiow=
      -----END CERTIFICATE-----
    - |
      -----BEGIN CERTIFICATE-----
      MIIB9zCCAXygAwIBAgIUALZNAPFdxHPwjeDloDwyYChAO/4wCgYIKoZIzj0EAwMw
      KjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0y
      MTEwMDcxMzU2NTlaFw0zMTEwMDUxMzU2NThaMCoxFTATBgNVBAoTDHNpZ3N0b3Jl
      LmRldjERMA8GA1UEAxMIc2lnc3RvcmUwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAAT7
      XeFT4rb3PQGwS4IajtLk3/OlnpgangaBclYpsYBr5i+4ynB07ceb3LP0OIOZdxex
      X69c5iVuyJRQ+Hz05yi+UF3uBWAlHpiS5sh0+H2GHE7SXrk1EC5m1Tr19L9gg92j
      YzBhMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRY
      wB5fkUWlZql6zJChkyLQKsXF+jAfBgNVHSMEGDAWgBRYwB5fkUWlZql6zJChkyLQ
      KsXF+jAKBggqhkjOPQQDAwNpADBmAjEAj1nHeXZp+13NWBNa+EDsDP8G1WWg1tCM
      WP/WHPqpaVo0jhsweNFZgSs0eE7wYI4qAjEA2WB9ot98sIkoF3vZYdd3/VtWB5b9
      TNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ
      -----END CERTIFICATE-----
    keyid: 9c3860d9ffdee171449ecfa6f8f96d2946c71dfe
    metadata:
      Fulcio Build Config Digest: 848edc452ccbc6d42ec56c2807eef2f49e754c5e
      Fulcio Build Config URI: https://github.com/lcarva/festoji/.github/workflows/package.yaml@refs/heads/master
      Fulcio Build Signer Digest: 848edc452ccbc6d42ec56c2807eef2f49e754c5e
      Fulcio Build Signer URI: https://github.com/lcarva/festoji/.github/workflows/package.yaml@refs/heads/master
      Fulcio Build Trigger: push
      Fulcio GitHub Workflow Name: Package
      Fulcio GitHub Workflow Ref: refs/heads/master
      Fulcio GitHub Workflow Repository: lcarva/festoji
      Fulcio GitHub Workflow SHA: 848edc452ccbc6d42ec56c2807eef2f49e754c5e
      Fulcio GitHub Workflow Trigger: push
      Fulcio Issuer: https://token.actions.githubusercontent.com
      Fulcio Issuer (V2): https://token.actions.githubusercontent.com
      Fulcio Run Invocation URI: https://github.com/lcarva/festoji/actions/runs/5360125613/attempts/1
      Fulcio Runner Environment: github-hosted
      Fulcio Source Repository Digest: 848edc452ccbc6d42ec56c2807eef2f49e754c5e
      Fulcio Source Repository Identifier: "159069832"
      Fulcio Source Repository Owner Identifier: "5272931"
      Fulcio Source Repository Owner URI: https://github.com/lcarva
      Fulcio Source Repository Ref: refs/heads/master
      Fulcio Source Repository URI: https://github.com/lcarva/festoji
      Issuer: CN=sigstore-intermediate,O=sigstore.dev
      Not After: "2023-06-23T20:18:38Z"
      Not Before: "2023-06-23T20:08:38Z"
      Serial Number: 40d191a3b537a1d0ff3423b60143946441ebad5e
      Subject Alternative Name: URIs:https://github.com/lcarva/festoji/.github/workflows/package.yaml@refs/heads/master
    sig: MEYCIQC4OxPKcp/1xNzKxb4e7klDW96N6GmSh2lySG/WUSuSeQIhAK6PhU8UeyEdLNUzBTH+Jw02QdRfwHvXpOVrN4oWEPJ3
  success: true
  successes:
  - metadata:
      code: builtin.attestation.signature_check
      title: Attestation signature check passed
    msg: Pass
  - metadata:
      code: builtin.attestation.syntax_check
      title: Attestation syntax check passed
    msg: Pass
  - metadata:
      code: builtin.image.signature_check
      title: Image signature check passed
    msg: Pass
  - metadata:
      code: github_certificate.gh_workflow_extensions
      description: Check if the image signature certificate contains the expected
        GitHub extensions. These are the extensions that represent the GitHub workflow
        trigger, sha, name, repository, and ref.
      title: GitHub Workflow Certificate Extensions
    msg: Pass
  - metadata:
      code: github_certificate.gh_workflow_name
      description: Check if the value of the GitHub Workflow Name extension in the
        image signature certificate matches one of the allowed values. Use the rule
        data key "allowed_gh_workflow_names" to specify the list of allowed values.
        An empty allow list, which is the default value, causes this check to succeeded.
      title: GitHub Workflow Name
    msg: Pass
  - metadata:
      code: github_certificate.gh_workflow_ref
      description: Check if the value of the GitHub Workflow Ref extension in the
        image signature certificate matches one of the allowed values. Use the rule
        data key "allowed_gh_workflow_refs" to specify the list of allowed values.
        An empty allow list, which is the default value, causes this check to succeeded.
      title: GitHub Workflow Repository
    msg: Pass
  - metadata:
      code: github_certificate.gh_workflow_repository
      description: Check if the value of the GitHub Workflow Repository extension
        in the image signature certificate matches one of the allowed values. Use
        the rule data key "allowed_gh_workflow_repos" to specify the list of allowed
        values. An empty allow list, which is the default value, causes this check
        to succeeded.
      title: GitHub Workflow Repository
    msg: Pass
  - metadata:
      code: github_certificate.gh_workflow_trigger
      description: Check if the value of the GitHub Workflow Trigger extension in
        the image signature certificate matches one of the allowed values. Use the
        rule data key "allowed_gh_workflow_triggers" to specify the list of allowed
        values. An empty allow list, which is the default value, causes this check
        to succeeded.
      title: GitHub Workflow Trigger
    msg: Pass
  - metadata:
      code: slsa_build_build_service.slsa_builder_id_accepted
      collections:
      - slsa2
      - slsa3
      depends_on:
      - attestation_type.known_attestation_type
      description: The attestation attribute predicate.builder.id is set to one of
        the values in the allowed_builder_ids rule data, e.g. "https://tekton.dev/chains/v2".
      title: SLSA Builder ID is known and accepted
    msg: Pass
  - metadata:
      code: slsa_build_build_service.slsa_builder_id_found
      collections:
      - slsa2
      - slsa3
      depends_on:
      - attestation_type.known_attestation_type
      description: The attestation attribute predicate.builder.id is set.
      title: SLSA Builder ID found
    msg: Pass
  - metadata:
      code: slsa_build_scripted_build.build_script_used
      collections:
      - slsa1
      - slsa2
      - slsa3
      depends_on:
      - attestation_type.known_attestation_type
      description: The attestation attribute predicate.buildConfig.tasks.steps is
        not empty of the pipeline task responsible for building the image.
      title: Build task contains steps
    msg: Pass
  - metadata:
      code: slsa_build_scripted_build.build_task_image_results_found
      collections:
      - slsa1
      - slsa2
      - slsa3
      depends_on:
      - attestation_type.known_attestation_type
      description: The attestations must contain a build task with the expected IMAGE_DIGEST
        and IMAGE_URL results.
      title: Build task set image digest and url task results
    msg: Pass
  - metadata:
      code: slsa_build_scripted_build.subject_build_task_matches
      collections:
      - slsa1
      - slsa2
      - slsa3
      depends_on:
      - attestation_type.known_attestation_type
      description: The subject of the attestations must match the IMAGE_DIGEST and
        IMAGE_URL values from the build task.
      title: Provenance subject matches build task image result
    msg: Pass
  - metadata:
      code: slsa_provenance_available.attestation_predicate_type_accepted
      collections:
      - minimal
      - slsa1
      - slsa2
      - slsa3
      depends_on:
      - attestation_type.known_attestation_type
      description: The predicateType field of the attestation must indicate the in-toto
        SLSA Provenance format was used to attest the PipelineRun.
      title: Expected attestation predicate type found
    msg: Pass
  - metadata:
      code: slsa_source_version_controlled.materials_format_okay
      collections:
      - minimal
      - slsa2
      - slsa3
      depends_on:
      - attestation_type.known_attestation_type
      description: 'At least one entry in the predicate.materials array of the attestation
        contains the expected attributes: uri and digest.sha1.'
      title: Materials have uri and digest
    msg: Pass
  - metadata:
      code: slsa_source_version_controlled.materials_include_git_sha
      collections:
      - minimal
      - slsa2
      - slsa3
      depends_on:
      - attestation_type.known_attestation_type
      description: Each entry in the predicate.materials array of the attestation
        includes a SHA1 digest which corresponds to a git commit.
      title: Materials include git commit shas
    msg: Pass
  - metadata:
      code: slsa_source_version_controlled.materials_uri_is_git_repo
      collections:
      - minimal
      - slsa2
      - slsa3
      depends_on:
      - attestation_type.known_attestation_type
      description: Each entry in the predicate.materials array of the attestation
        uses a git URI.
      title: Material uri is a git repo
    msg: Pass
ec-version: v0.1.1626-0058e37
effective-time: "2023-06-29T20:57:46.463658518Z"
key: ""
policy:
  configuration:
    include:
    - '@slsa1'
    - '@slsa2'
    - '@slsa3'
    - github_certificate
  rekorUrl: https://rekor.sigstore.dev
  sources:
  - data:
    - github.com/lcarva/ec-policies//data?ref=HACBS-2083
    name: Default
    policy:
    - github.com/lcarva/ec-policies//policy/lib?ref=HACBS-2083
    - github.com/lcarva/ec-policies//policy/release?ref=HACBS-2083
    ruleData:
      allowed_gh_workflow_names:
      - Package
      allowed_gh_workflow_refs:
      - refs/heads/master
      allowed_gh_workflow_repos:
      - lcarva/festoji
      allowed_gh_workflow_triggers:
      - push
success: true

```
</details>