### PR TITLE
Check if provided string is a valid JSON

### DIFF
--- a/policy/release/lib/attestations.rego
+++ b/policy/release/lib/attestations.rego
@@ -75,6 +75,7 @@ results_named(name) = results {
 # value is returned as is. This is helpful when interpreting certain values
 # in attestations created by Tekton Chains.
 unmarshal(raw) = value {
+	json.is_valid(raw)
 	value = json.unmarshal(raw)
 } else = raw
 

--- a/policy/release/lib/attestations_test.rego
+++ b/policy/release/lib/attestations_test.rego
@@ -289,3 +289,9 @@ test_task_not_succeeded {
 
 	not task_succeeded(task_name) with input.attestations as d
 }
+
+test_unmarshall_json {
+	assert_equal({"a": 1, "b": "c"}, unmarshal("{\"a\":1,\"b\":\"c\"}"))
+	assert_equal("not JSON", unmarshal("not JSON"))
+	assert_equal("", unmarshal(""))
+}


### PR DESCRIPTION
I could not create a unit test that would fail without `json.is_valid`, which is odd. I did test this with acceptance tests on https://github.com/enterprise-contract/ec-cli/pull/801 and it did help with that.