### PR TITLE
Fixup acceptable bundles

### DIFF
--- a/data/acceptable_tekton_bundles.yml
+++ b/data/acceptable_tekton_bundles.yml
@@ -503,6 +503,9 @@ task-bundles:
       effective_on: "2022-12-31T00:00:00Z"
       tag: "0.1"
   quay.io/redhat-appstudio-tekton-catalog/task-git-clone:
+    - digest: sha256:458f4853a01c3273bd76076ac1b015d5f901e70fb4b776f788b577adb25bf5f8
+      effective_on: "2023-08-17T00:00:00Z"
+      tag: "0.1"
     - digest: sha256:f4e37778cba00296606ddfbc1c58181330899cafcaa1ee41c75a7cf8bed312f0
       effective_on: "2023-02-23T00:00:00Z"
       tag: "0.1"
@@ -511,6 +514,9 @@ task-bundles:
       effective_on: "2022-12-01T00:00:00Z"
       tag: "0.1"
   quay.io/redhat-appstudio-tekton-catalog/task-init:
+    - digest: sha256:26586a7ef08c3e86dfdaf0a5cc38dd3d70c4c02db1331b469caaed0a0f5b3d86
+      effective_on: "2023-08-17T00:00:00Z"
+      tag: "0.1"
     - digest: sha256:1fd586c1114e0500533c0f5e9b9dd52958e52535fe0f28004b949666726e99e0
       effective_on: "2023-07-06T00:00:00Z"
       tag: "0.1"
@@ -559,10 +565,16 @@ task-bundles:
       effective_on: "2023-07-14T00:00:00Z"
       tag: "0.1"
   quay.io/redhat-appstudio-tekton-catalog/task-sanity-inspect-image:
+    - digest: sha256:b9ad0ed56be21c9e3c8e2e636275f92d887e57681c718cd36f117eb6fa547824
+      effective_on: "2023-08-17T00:00:00Z"
+      tag: "0.1"
     - digest: sha256:fd4efd9d12eea3a8d47532c4226e685618845d0ba95abb98e008020243d96301
       effective_on: "2023-04-15T00:00:00Z"
       tag: "0.1"
   quay.io/redhat-appstudio-tekton-catalog/task-sanity-label-check:
+    - digest: sha256:dd49667be76c81264a7fb28e3b43f72c527507e5691720c6262575255cb60689
+      effective_on: "2023-08-17T00:00:00Z"
+      tag: "0.1"
     - digest: sha256:534770bf7a7c10277ab5f9c1e7b766abbffb343cc864dd9545aecc5278257dc3
       effective_on: "2023-04-15T00:00:00Z"
       tag: "0.1"
@@ -616,6 +628,9 @@ task-bundles:
       effective_on: "2023-07-06T00:00:00Z"
       tag: "0.1"
   quay.io/redhat-appstudio-tekton-catalog/task-tkn-bundle:
+    - digest: sha256:063b00006cc5d8ef6af98245a30651da2207472d7673dc8ef348e170a46c2bef
+      effective_on: "2023-08-17T00:00:00Z"
+      tag: "0.1"
     - digest: sha256:3772f3993e5c4f06f499e6099c142330a14225912e7467573f3ae18f8d5a4b63
       effective_on: "2023-04-28T00:00:00Z"
       tag: "0.1"

--- a/data/acceptable_tekton_bundles.yml
+++ b/data/acceptable_tekton_bundles.yml
@@ -567,18 +567,18 @@ task-bundles:
       effective_on: "2023-04-15T00:00:00Z"
       tag: "0.1"
   quay.io/redhat-appstudio-tekton-catalog/task-sast-go:
+    - digest: sha256:fb3ee7e051c11ff688e5c4d7ed682dacd013d7c37c204869a3fcff9d03da200d
+      effective_on: "2023-08-17T00:00:00Z"
+      tag: "0.1"
     - digest: sha256:920477e041f79ab7efba912d89f38918f3a059ca3c82d1a9cb22c17724274fe6
       effective_on: "2023-07-24T00:00:00Z"
       tag: "0.1"
-    - digest: sha256:fb3ee7e051c11ff688e5c4d7ed682dacd013d7c37c204869a3fcff9d03da200d
-      effective_on: "2023-05-29T00:00:00Z"
-      tag: "0.1"
   quay.io/redhat-appstudio-tekton-catalog/task-sast-java-sec-check:
+    - digest: sha256:75d28da4b817885309bb8f71682e75cf9fbb2d4f0ed7988a94b4aa29dd458bd5
+      effective_on: "2023-08-17T00:00:00Z"
+      tag: "0.1"
     - digest: sha256:e601313247f30548c096b623eedbb83e3bec5ce54362f49090f8e3b46a82a5e6
       effective_on: "2023-07-24T00:00:00Z"
-      tag: "0.1"
-    - digest: sha256:75d28da4b817885309bb8f71682e75cf9fbb2d4f0ed7988a94b4aa29dd458bd5
-      effective_on: "2023-05-29T00:00:00Z"
       tag: "0.1"
   quay.io/redhat-appstudio-tekton-catalog/task-sast-snyk-check:
     - digest: sha256:2d3369bdbe3b5d37f6528d3048cb894e37c191c6db0395054b6b01d94d662118

--- a/hack/check-acceptable-tekton-bundles.sh
+++ b/hack/check-acceptable-tekton-bundles.sh
@@ -1,0 +1,58 @@
+#!/bin/env bash
+# Copyright 2023 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Checks if the latest entries in acceptable_tekton_bundles.yml are in fact the latest entries
+# in the registry for them.
+#
+set -o errexit
+set -o pipefail
+set -o nounset
+
+BUNDLES_FILE="$(git rev-parse --show-toplevel)/data/acceptable_tekton_bundles.yml"
+
+bundles="$(< "${BUNDLES_FILE}" \
+    yq '."task-bundles" + ."pipeline-bundles" | to_entries | map(.key + ":" + .value[0].tag + "@" + .value[0].digest) | .[]')"
+
+
+echo '🕵️ Looking for untracked acceptable bundles...'
+new_bundles=''
+for b in $bundles; do
+    digest="$(echo -n $b | cut -d '@' -f 2)"
+
+    repo="$(echo -n $b | cut -d '@' -f 1 | cut -d ':' -f 1)"
+    tag="$(echo -n $b | cut -d '@' -f 1 | cut -d ':' -f 2)"
+
+    new_digest="$(skopeo inspect --no-tags "docker://${repo}:$tag" | jq -r .Digest)"
+
+    if [[ "${new_digest}" == "${digest}" ]]; then
+        continue
+    fi
+
+    new_bundle="${repo}:${tag}@${new_digest}"
+    echo "🫢 ${new_bundle}"
+
+    new_bundles="${new_bundles} --bundle=${new_bundle}"  # Intentional leading white-space
+done
+
+if [[ -z "${new_bundles}" ]]; then
+    echo '🥳 Latest acceptable bundles are being tracked'
+    exit 0
+fi
+
+ec track bundle --input "${BUNDLES_FILE}" --replace ${new_bundles} > /dev/null
+
+git diff -- "${BUNDLES_FILE}"


### PR DESCRIPTION
Introduce a new script, `hack/check-acceptable-tekton-bundles.sh`, to check if the latest acceptable bundle records match the latest images in the registry.

The script generated most of the changes in `data/acceptable_tekton_bundles.yml`.

The sast-go and sast-java-sec-check tasks had a change that caused their definition to be equal to one of its previous versions. Because of this `ec track bundle` did not re-add entries for those bundles, as it is expected. The issue is that in this case, this behavior doesn't make sense as we want the old digest to be treated as the most up-to-date task definition. I manually fixed up those entries. `ec track bundle` should be smarter about this. This will be done in: https://issues.redhat.com/browse/HACBS-2394
