### PR TITLE
HACBS-2319 update source link for builtin rule set

### DIFF
--- a/antora/docs/modules/ROOT/templates/_rules.hbs
+++ b/antora/docs/modules/ROOT/templates/_rules.hbs
@@ -24,6 +24,13 @@
 * Code: `{{ packageInfo.shortName }}.{{ shortName }}`
 {{#if effectiveOn}}
 * Effective from: `{{ effectiveOn }}`{{/if}}
-* https://github.com/enterprise-contract/ec-policies/blob/main/{{ file }}#L{{ row }}[Source, window="_blank"]
+{{#if packageInfo.shortName}}
+    {{#if (isBuiltIn packageInfo.shortName)}}
+    * https://github.com/enterprise-contract/ec-cli/blob/main/docs/{{ file }}#L{{ row }}[Source, window="_blank"]
 
+    {{else}}
+    * https://github.com/enterprise-contract/ec-policies/blob/main/{{ file }}#L{{ row }}[Source, window="_blank"]
+
+    {{/if}}
+{{/if}}
 {{/each}}

--- a/antora/ec-policies-antora-extension/index.js
+++ b/antora/ec-policies-antora-extension/index.js
@@ -6,6 +6,11 @@ const opa = import("@zregvart/opa-inspect")
 // Helpers for handlebars templates
 const hbsHelpers = {
 
+  // Determines if value starts with 'builtin'
+  isBuiltIn: (a) => {
+    return a.startsWith("builtin")
+  },
+
   // Convert "foo" to "FOO"
   toUpper: (s) => {
     return s.toUpperCase()


### PR DESCRIPTION
This commit fixes source links for builtin rule collection entries. These source links now point to the correct locations within the ec-cli repository.