### PR TITLE
Check OLM bundle image's manifests has pinned refs

### DIFF
--- a/policy/lib/image.rego
+++ b/policy/lib/image.rego
@@ -28,6 +28,22 @@ parse(ref) = d {
 	}
 }
 
+# Formats the parsed reference as string
+str(d) = s1 {
+	d.repo != ""
+	d.digest != ""
+	d.tag != ""
+	s1 := sprintf("%s:%s@%s", [d.repo, d.tag, d.digest])
+} else = s2 {
+	d.repo != ""
+	d.digest != ""
+	s2 := sprintf("%s@%s", [d.repo, d.digest])
+} else = s3 {
+	d.repo != ""
+	d.tag != ""
+	s3 := sprintf("%s:%s", [d.repo, d.tag])
+}
+
 # equal_ref returns true if two image references point to the same image. The
 # algorithm first checks if the constituent parts repository, tag and digest are
 # all equal

--- a/policy/lib/image_test.rego
+++ b/policy/lib/image_test.rego
@@ -58,3 +58,9 @@ test_equal {
 	not equal_ref("registry.com/re/po@digest", "registry.com/different/po@digest")
 	not equal_ref("registry.com/re/po@digest", "registry.com/re/different@digest")
 }
+
+test_str {
+	lib.assert_equal("registry.io/repository:tag@digest", str({"repo": "registry.io/repository", "tag": "tag", "digest": "digest"}))
+	lib.assert_equal("registry.io/repository:tag", str({"repo": "registry.io/repository", "tag": "tag"}))
+	lib.assert_equal("registry.io/repository@digest", str({"repo": "registry.io/repository", "digest": "digest"}))
+}

--- a/policy/release/olm.rego
+++ b/policy/release/olm.rego
@@ -1,0 +1,121 @@
+#
+# METADATA
+# description: >-
+#   Checks for Operator Lifecycle Manager (OLM) bundles.
+#
+package policy.release.olm
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+import data.lib
+import data.lib.image
+
+olm_manifestv1 := "operators.operatorframework.io.bundle.manifests.v1"
+
+# METADATA
+# title: Unpinned images in OLM bundle
+# description: >-
+#   Checks the OLM bundle image for the presence of unpinned image references.
+#   Unpinned image pull refernces are references to images found in
+#   link:https://osbs.readthedocs.io/en/latest/users.html#pullspec-locations[varying
+#   locations] that do not contain a digest -- uniquely identifying the version of
+#   the image being pulled.
+# custom:
+#   short_name: unpinned_references
+#   failure_msg: The %q image reference is not pinned at %s.
+#   solution: >-
+#     Update the OLM bundle replacing the unpinned image reference with pinned image
+#     reference. Pinned image reference contains the image digest.
+#   collections:
+#   - redhat
+#
+deny contains result if {
+	manifestDir := input.image.config.Labels[olm_manifestv1]
+
+	some path, manifest in input.image.files
+
+	# only consider files in the manifest path as determined by the OLM manifest v1 label
+	startswith(path, manifestDir)
+
+	# only consider this API prefix, disregard the version
+	startswith(manifest.apiVersion, "operators.coreos.com/")
+
+	# only consider CSV manifests
+	manifest.kind == "ClusterServiceVersion"
+
+	some i in all_image_ref(manifest)
+	i.ref.digest == "" # unpinned image references have no digest
+
+	result := lib.result_helper_with_term(rego.metadata.chain(), [image.str(i.ref), i.path], image.str(i.ref))
+}
+
+_name(o) := n if {
+	n := o.name
+} else := "unnamed"
+
+# Finds all image references and their locations (paths). Returns all image
+# references (parsed into components) found in locations as specified by:
+# https://github.com/containerbuildsystem/operator-manifest/blob/f24cd9374f5ad9fed04f47701acffa16837d940e/README.md#pull-specifications
+# and https://osbs.readthedocs.io/en/latest/users.html#pullspec-locations
+all_image_ref(manifest) := [e |
+	# NOTE: use comprehensions in here, trying to set a value for `imgs` that
+	# could be undefined will lead to the whole block being undefined, i.e.
+	# don't do:
+	# [
+	#	{
+	#      "path": "manifest.metadata.annotations.containerImage",
+	#      "ref":image.parse(manifest.metadata.annotations.containerImage)
+	#   }
+	# ]
+	# as the components of manifest.metadata.annotations.containerImage could be undefined!
+	some imgs in [
+		[r |
+			some i, related in manifest.spec.relatedImages
+			r := {"path": sprintf("spec.relatedImages[%d].image", [i]), "ref": image.parse(related.image)}
+		],
+		[r |
+			manifest.metadata.annotations.containerImage
+			r := {"path": "annotations.containerImage", "ref": image.parse(manifest.metadata.annotations.containerImage)}
+		],
+		[r |
+			some _, values in walk(manifest)
+			some key, val in values.metadata.annotations
+			some annotation in regex.split("(,|;|\\n|\\s+)", val)
+			ref := image.parse(trim_space(annotation))
+			ref.repo # ones that are parsed as image reference, detected by having "repo" property set
+			r := {"path": sprintf("annotations[%q]", [key]), "ref": ref}
+		],
+		[r |
+			some d, deployment in manifest.spec.install.spec.deployments
+			some c, container in deployment.spec.template.spec.containers
+			ref := image.parse(container.image)
+			r := {"path": sprintf("spec.install.spec.deployments[%d (%q)].spec.template.spec.containers[%d (%q)].image", [d, _name(deployment), c, _name(container)]), "ref": ref}
+		],
+		[r |
+			some d, deployment in manifest.spec.install.spec.deployments
+			some c, initContainer in deployment.spec.template.spec.initContainers
+			ref := image.parse(initContainer.image)
+			r := {"path": sprintf("spec.install.spec.deployments[%d (%q)].spec.template.spec.initContainers[%d (%q)].image", [d, _name(deployment), c, _name(initContainer)]), "ref": ref}
+		],
+		[r |
+			some d, deployment in manifest.spec.install.spec.deployments
+			some c, container in deployment.spec.template.spec.containers
+			some e in container.env
+			startswith(e.name, "RELATED_IMAGE_")
+			ref := image.parse(e.value)
+			r := {"path": sprintf("spec.install.spec.deployments[%d (%q)].spec.template.spec.containers[%d (%q)].env[%q]", [d, _name(deployment), c, _name(container), e.name]), "ref": ref}
+		],
+		[r |
+			some d, deployment in manifest.spec.install.spec.deployments
+			some c, initContainer in deployment.spec.template.spec.initContainers
+			some e in initContainer.env
+			startswith(e.name, "RELATED_IMAGE_")
+			ref := image.parse(e.value)
+			r := {"path": sprintf("spec.install.spec.deployments[%d (%q)].spec.template.spec.initContainers[%d (%q)].env[%q]", [d, _name(deployment), c, _name(initContainer), e.name]), "ref": ref}
+		],
+	]
+	some i in imgs
+	e := {"ref": i.ref, "path": i.path}
+]

--- a/policy/release/olm_test.rego
+++ b/policy/release/olm_test.rego
@@ -1,0 +1,92 @@
+package policy.release.olm
+
+import future.keywords.if
+
+import data.lib
+
+pinned := "registry.io/repository/image@sha256:cafe"
+
+pinned2 := "registry.io/repository/image2@sha256:cafe"
+
+pinned_ref = {"digest": "sha256:cafe", "repo": "registry.io/repository/image", "tag": ""}
+
+pinned_ref2 = {"digest": "sha256:cafe", "repo": "registry.io/repository/image2", "tag": ""}
+
+manifest := {
+	"apiVersion": "operators.coreos.com/v1alpha1",
+	"kind": "ClusterServiceVersion",
+	"metadata": {"annotations": {
+		"containerImage": pinned,
+		"enclosurePicture": sprintf("%s,  %s", [pinned, pinned2]),
+	}},
+	"spec": {
+		"relatedImages": [{"image": pinned}],
+		"install": {"spec": {"deployments": [{
+			"metadata": {"annotations": {"docket": sprintf("%s\n  %s", [pinned, pinned2])}},
+			"spec": {"template": {
+				"metadata": {"name": "c1"},
+				"spec": {
+					"containers": [{
+						"name": "c1",
+						"image": pinned,
+						"env": [{"name": "RELATED_IMAGE_C1", "value": pinned}],
+					}],
+					"initContainers": [{
+						"name": "i1",
+						"image": pinned,
+						"env": [{"name": "RELATED_IMAGE_E1", "value": pinned}],
+					}],
+				},
+			}},
+		}]}},
+	},
+	"not-metadata": {"annotations": {"something": pinned2}},
+	"metadata-without-annotations": {"metadata": {}},
+	"metadata-with-empty-annotations": {"metadata": {"annotations": {}}},
+}
+
+test_all_image_ref if {
+	lib.assert_equal(
+		[
+			{"path": "spec.relatedImages[0].image", "ref": pinned_ref},
+			{"path": "annotations.containerImage", "ref": pinned_ref},
+			{"path": "annotations[\"containerImage\"]", "ref": pinned_ref},
+			{"path": "annotations[\"enclosurePicture\"]", "ref": pinned_ref},
+			{"path": "annotations[\"enclosurePicture\"]", "ref": pinned_ref2},
+			{"path": "annotations[\"docket\"]", "ref": pinned_ref},
+			{"path": "annotations[\"docket\"]", "ref": pinned_ref2},
+			{"path": "spec.install.spec.deployments[0 (\"unnamed\")].spec.template.spec.containers[0 (\"c1\")].image", "ref": pinned_ref},
+			{"path": "spec.install.spec.deployments[0 (\"unnamed\")].spec.template.spec.initContainers[0 (\"i1\")].image", "ref": pinned_ref},
+			{"path": "spec.install.spec.deployments[0 (\"unnamed\")].spec.template.spec.containers[0 (\"c1\")].env[\"RELATED_IMAGE_C1\"]", "ref": pinned_ref},
+			{"path": "spec.install.spec.deployments[0 (\"unnamed\")].spec.template.spec.initContainers[0 (\"i1\")].env[\"RELATED_IMAGE_E1\"]", "ref": pinned_ref},
+		],
+		all_image_ref(manifest),
+	)
+}
+
+test_all_good if {
+	lib.assert_empty(deny) with input.image.files as {"manifests/csv.yaml": manifest}
+		with input.image.config.Labels as {olm_manifestv1: "manifests/"}
+}
+
+test_all_good_custom_dir if {
+	lib.assert_empty(deny) with input.image.files as {"other/csv.yaml": manifest}
+		with input.image.config.Labels as {olm_manifestv1: "other/"}
+}
+
+test_related_img_unpinned if {
+	unpinned_manifest = json.patch(manifest, [{
+		"op": "replace",
+		"path": "/spec/install/spec/deployments/0/spec/template/spec/containers/0/env/0/value",
+		"value": "registry.io/repository:tag",
+	}])
+
+	expected = {{
+		"code": "olm.unpinned_references",
+		"msg": `The "registry.io/repository:tag" image reference is not pinned at spec.install.spec.deployments[0 ("unnamed")].spec.template.spec.containers[0 ("c1")].env["RELATED_IMAGE_C1"].`,
+		"term": "registry.io/repository:tag",
+	}}
+
+	lib.assert_equal_results(deny, expected) with input.image.files as {"manifests/csv.yaml": unpinned_manifest}
+		with input.image.config.Labels as {olm_manifestv1: "manifests/"}
+}


### PR DESCRIPTION
Given the content of the OLM bundle image manifest files in input and the presence of the `operators.operatorframework.io.bundle.manifests.v1` label on the image this checks if all the references mentioned in the Python checker[1] are pinned, i.e. they contain the digest.

Ref. https://issues.redhat.com/browse/HACBS-2379

[1] https://github.com/containerbuildsystem/operator-manifest#pull-specifications