### PR TITLE
Add policy rule to check deprecated att format

### DIFF
--- a/policy/release/attestation_type.rego
+++ b/policy/release/attestation_type.rego
@@ -52,3 +52,22 @@ deny contains result if {
 	count(lib.pipelinerun_attestations) == 0
 	result := lib.result_helper(rego.metadata.chain(), [])
 }
+
+# METADATA
+# title: Deprecated policy attestation format
+# description: >-
+#   The Enterprise Contract CLI now places the attestation data in a different location.
+#   This check fails if the expected new format is not found.
+# custom:
+#   short_name: deprecated_policy_attestation_format
+#   failure_msg: Deprecated policy attestation format found
+#   solution: Use a newer version of the Enterprise Contract CLI.
+#   collections:
+#   - minimal
+#   - redhat
+#   effective_on: 2023-08-31T00:00:00Z
+deny contains result if {
+	some att in lib.pipelinerun_attestations
+	not att.statement
+	result := lib.result_helper(rego.metadata.chain(), [])
+}

--- a/policy/release/attestation_type_test.rego
+++ b/policy/release/attestation_type_test.rego
@@ -7,7 +7,11 @@ good_type := "https://in-toto.io/Statement/v0.1"
 bad_type := "https://in-toto.io/Statement/v0.0.9999999"
 
 mock_data(att_type) = d {
-	d := [{"_type": att_type, "predicate": {"buildType": lib.pipelinerun_att_build_types[0]}}]
+	d := [{
+		"_type": att_type,
+		"predicate": {"buildType": lib.pipelinerun_att_build_types[0]},
+		"statement": {"_type": att_type, "predicate": {"buildType": lib.pipelinerun_att_build_types[0]}},
+	}]
 }
 
 test_allow_when_permitted {
@@ -31,11 +35,31 @@ test_deny_when_pipelinerun_attestation_founds {
 		{
 			"_type": good_type,
 			"predicate": {"buildType": "tekton.dev/v1beta1/TaskRun"},
+			"statement": {
+				"_type": good_type,
+				"predicate": {"buildType": "tekton.dev/v1beta1/TaskRun"},
+			},
 		},
 		{
 			"_type": good_type,
 			"predicate": {"buildType": "spam/spam/eggs/spam"},
+			"statement": {
+				"_type": good_type,
+				"predicate": {"buildType": "spam/spam/eggs/spam"},
+			},
 		},
 	]
+	lib.assert_equal_results(deny, expected) with input.attestations as attestations
+}
+
+test_deny_deprecated_policy_attestation_format {
+	expected := {{
+		"code": "attestation_type.deprecated_policy_attestation_format",
+		"msg": "Deprecated policy attestation format found",
+	}}
+	attestations := [{
+		"_type": good_type,
+		"predicate": {"buildType": lib.pipelinerun_att_build_types[0]},
+	}]
 	lib.assert_equal_results(deny, expected) with input.attestations as attestations
 }


### PR DESCRIPTION
In HACBS-2390, EC CLI is modified to provide attestations in a different format. In order to warn users in advance, a new policy rule checks if the old format is still being used. The policy rule changes from a warning to a violation on 2023-09-31, allowing users to adopt the new format in about two months. By then, it is expected that all policy rules, including the ones defined in this repo, have been updated to support the new format.