### PR TITLE
Adopt the new input format for attestations

### DIFF
--- a/policy/release/attestation_task_bundle_test.rego
+++ b/policy/release/attestation_task_bundle_test.rego
@@ -3,10 +3,10 @@ package policy.release.attestation_task_bundle
 import data.lib
 
 mock_data(task) = d {
-	d := [{"predicate": {
+	d := [{"statement": {"predicate": {
 		"buildConfig": {"tasks": [task]},
 		"buildType": lib.pipelinerun_att_build_types[0],
-	}}]
+	}}}]
 }
 
 test_bundle_not_exists {
@@ -139,10 +139,10 @@ mock_attestation(bundles) = a {
 		}
 	]
 
-	a := [{"predicate": {
+	a := [{"statement": {"predicate": {
 		"buildConfig": {"tasks": tasks},
 		"buildType": lib.pipelinerun_att_build_types[0],
-	}}]
+	}}}]
 }
 
 task_bundles = {"reg.com/repo": [

--- a/policy/release/attestation_type.rego
+++ b/policy/release/attestation_type.rego
@@ -67,7 +67,8 @@ deny contains result if {
 #   - redhat
 #   effective_on: 2023-08-31T00:00:00Z
 deny contains result if {
-	some att in lib.pipelinerun_attestations
+	# Use input.attestations directly so we can detect the actual format in use.
+	some att in input.attestations
 	not att.statement
 	result := lib.result_helper(rego.metadata.chain(), [])
 }

--- a/policy/release/attestation_type_test.rego
+++ b/policy/release/attestation_type_test.rego
@@ -7,11 +7,10 @@ good_type := "https://in-toto.io/Statement/v0.1"
 bad_type := "https://in-toto.io/Statement/v0.0.9999999"
 
 mock_data(att_type) = d {
-	d := [{
+	d := [{"statement": {
 		"_type": att_type,
 		"predicate": {"buildType": lib.pipelinerun_att_build_types[0]},
-		"statement": {"_type": att_type, "predicate": {"buildType": lib.pipelinerun_att_build_types[0]}},
-	}]
+	}}]
 }
 
 test_allow_when_permitted {
@@ -32,22 +31,14 @@ test_deny_when_pipelinerun_attestation_founds {
 		"msg": "Missing pipelinerun attestation",
 	}}
 	attestations := [
-		{
+		{"statement": {
 			"_type": good_type,
 			"predicate": {"buildType": "tekton.dev/v1beta1/TaskRun"},
-			"statement": {
-				"_type": good_type,
-				"predicate": {"buildType": "tekton.dev/v1beta1/TaskRun"},
-			},
-		},
-		{
+		}},
+		{"statement": {
 			"_type": good_type,
 			"predicate": {"buildType": "spam/spam/eggs/spam"},
-			"statement": {
-				"_type": good_type,
-				"predicate": {"buildType": "spam/spam/eggs/spam"},
-			},
-		},
+		}},
 	]
 	lib.assert_equal_results(deny, expected) with input.attestations as attestations
 }

--- a/policy/release/buildah_build_task_test.rego
+++ b/policy/release/buildah_build_task_test.rego
@@ -43,12 +43,12 @@ test_task_not_named_buildah if {
 }
 
 test_missing_pipeline_run_attestations if {
-	attestation := {"predicate": {"buildType": "something/else"}}
+	attestation := {"statement": {"predicate": {"buildType": "something/else"}}}
 	lib.assert_empty(deny) with input.attestations as [attestation]
 }
 
 test_multiple_buildah_tasks if {
-	attestation := {"predicate": {
+	attestation := {"statement": {"predicate": {
 		"buildType": lib.pipelinerun_att_build_types[0],
 		"buildConfig": {"tasks": [
 			{
@@ -62,12 +62,12 @@ test_multiple_buildah_tasks if {
 				"invocation": {"parameters": {"DOCKERFILE": "two/Dockerfile"}},
 			},
 		]},
-	}}
+	}}}
 	lib.assert_empty(deny) with input.attestations as [attestation]
 }
 
 test_multiple_buildah_tasks_one_without_params if {
-	attestation := {"predicate": {
+	attestation := {"statement": {"predicate": {
 		"buildType": lib.pipelinerun_att_build_types[0],
 		"buildConfig": {"tasks": [
 			{
@@ -80,7 +80,7 @@ test_multiple_buildah_tasks_one_without_params if {
 				"ref": {"kind": "Task", "name": "buildah", "bundle": _bundle},
 			},
 		]},
-	}}
+	}}}
 	expected := {{
 		"code": "buildah_build_task.buildah_task_has_dockerfile_param",
 		"msg": "The DOCKERFILE param was not included in the buildah task(s): \"b2\"",
@@ -90,7 +90,7 @@ test_multiple_buildah_tasks_one_without_params if {
 }
 
 test_multiple_buildah_tasks_all_without_params if {
-	attestation := {"predicate": {
+	attestation := {"statement": {"predicate": {
 		"buildType": lib.pipelinerun_att_build_types[0],
 		"buildConfig": {"tasks": [
 			{
@@ -103,7 +103,7 @@ test_multiple_buildah_tasks_all_without_params if {
 				"ref": {"kind": "Task", "name": "buildah", "bundle": _bundle},
 			},
 		]},
-	}}
+	}}}
 	expected := {
 		{
 			"code": "buildah_build_task.buildah_task_has_dockerfile_param",
@@ -120,7 +120,7 @@ test_multiple_buildah_tasks_all_without_params if {
 }
 
 test_multiple_buildah_tasks_one_with_external_dockerfile if {
-	attestation := {"predicate": {
+	attestation := {"statement": {"predicate": {
 		"buildType": lib.pipelinerun_att_build_types[0],
 		"buildConfig": {"tasks": [
 			{
@@ -134,7 +134,7 @@ test_multiple_buildah_tasks_one_with_external_dockerfile if {
 				"ref": {"kind": "Task", "name": "buildah", "bundle": _bundle},
 			},
 		]},
-	}}
+	}}}
 	expected := {{
 		"code": "buildah_build_task.buildah_uses_local_dockerfile",
 		"msg": "DOCKERFILE param value (http://Dockerfile) is an external source",
@@ -143,14 +143,14 @@ test_multiple_buildah_tasks_one_with_external_dockerfile if {
 }
 
 _attestation(task_name, params) = attestation if {
-	attestation := {"predicate": {
+	attestation := {"statement": {"predicate": {
 		"buildType": lib.pipelinerun_att_build_types[0],
 		"buildConfig": {"tasks": [{
 			"name": "ignored",
 			"ref": {"kind": "Task", "name": task_name, "bundle": _bundle},
 			"invocation": params,
 		}]},
-	}}
+	}}}
 }
 
 _bundle := "registry.img/spam@sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb"

--- a/policy/release/external_parameters_test.rego
+++ b/policy/release/external_parameters_test.rego
@@ -11,7 +11,7 @@ test_success if {
 }
 
 test_pipeline_run_params_missing_params if {
-	provenance := json.remove(good_provenance, ["/predicate/buildDefinition/externalParameters/runSpec/params/0"])
+	provenance := json.remove(good_provenance, ["/statement/predicate/buildDefinition/externalParameters/runSpec/params/0"])
 	expected := {{
 		"code": "external_parameters.pipeline_run_params",
 		"msg": "PipelineRun params, {\"git-revision\", \"output-image\"}, do not match expectation, {\"git-repo\", \"git-revision\", \"output-image\"}.",
@@ -22,7 +22,7 @@ test_pipeline_run_params_missing_params if {
 test_pipeline_run_params_empty_values if {
 	provenance := json.patch(good_provenance, [{
 		"op": "add",
-		"path": "/predicate/buildDefinition/externalParameters/runSpec/params/0/value",
+		"path": "/statement/predicate/buildDefinition/externalParameters/runSpec/params/0/value",
 		"value": "",
 	}])
 	expected := {{
@@ -35,7 +35,7 @@ test_pipeline_run_params_empty_values if {
 test_restrict_shared_volumes_existing_pvc if {
 	provenance := json.patch(good_provenance, [{
 		"op": "add",
-		"path": "/predicate/buildDefinition/externalParameters/runSpec/workspaces/0",
+		"path": "/statement/predicate/buildDefinition/externalParameters/runSpec/workspaces/0",
 		"value": {"persistentVolumeClaim": {"claimName": "my-pvc"}},
 	}])
 	expected := {{
@@ -45,7 +45,7 @@ test_restrict_shared_volumes_existing_pvc if {
 	lib.assert_equal_results(deny, expected) with input.attestations as [provenance]
 }
 
-good_provenance := {
+good_provenance := {"statement": {
 	"predicateType": "https://slsa.dev/provenance/v1",
 	"predicate": {"buildDefinition": {
 		"buildType": "https://tekton.dev/chains/v2/slsa",
@@ -59,4 +59,4 @@ good_provenance := {
 			"workspaces": [{"volumeClaimTemplate": {"spec": {}}}],
 		}},
 	}},
-}
+}}

--- a/policy/release/hermetic_build_task_test.rego
+++ b/policy/release/hermetic_build_task_test.rego
@@ -16,16 +16,16 @@ test_not_hermetic_build if {
 
 	hermetic_not_true := json.patch(_good_attestation, [{
 		"op": "add",
-		"path": "/predicate/buildConfig/tasks/0/invocation/parameters/HERMETIC",
+		"path": "/statement/predicate/buildConfig/tasks/0/invocation/parameters/HERMETIC",
 		"value": "false",
 	}])
 	lib.assert_equal_results(expected, deny) with input.attestations as [hermetic_not_true]
 
-	hermetic_missing := json.remove(_good_attestation, ["/predicate/buildConfig/tasks/0/invocation/parameters/HERMETIC"])
+	hermetic_missing := json.remove(_good_attestation, ["/statement/predicate/buildConfig/tasks/0/invocation/parameters/HERMETIC"])
 	lib.assert_equal_results(expected, deny) with input.attestations as [hermetic_missing]
 }
 
-_good_attestation := {"predicate": {
+_good_attestation := {"statement": {"predicate": {
 	"buildType": lib.pipelinerun_att_build_types[0],
 	"buildConfig": {"tasks": [{
 		"results": [
@@ -35,4 +35,4 @@ _good_attestation := {"predicate": {
 		"ref": {"kind": "Task", "name": "any-task", "bundle": "reg.img/spam@sha256:abc"},
 		"invocation": {"parameters": {"HERMETIC": "true"}},
 	}]},
-}}
+}}}

--- a/policy/release/provenance_materials_test.rego
+++ b/policy/release/provenance_materials_test.rego
@@ -82,7 +82,7 @@ test_missing_materials if {
 		"steps": [{"entrypoint": "/bin/bash"}],
 	}]
 	good_attestation := _mock_attestation(tasks)
-	missing_materials := json.remove(good_attestation, ["/predicate/materials"])
+	missing_materials := json.remove(good_attestation, ["/statement/predicate/materials"])
 
 	expected := {{
 		"code": "provenance_materials.git_clone_source_matches_provenance",
@@ -163,12 +163,12 @@ _mock_attestation(original_tasks) = d if {
 		task := object.union(default_task, original_task)
 	]
 
-	d := {"predicate": {
+	d := {"statement": {"predicate": {
 		"buildType": lib.pipelinerun_att_build_types[0],
 		"buildConfig": {"tasks": tasks},
 		"materials": [{
 			"uri": sprintf("git+%s.git", [_git_url]),
 			"digest": {"sha1": _git_commit},
 		}],
-	}}
+	}}}
 }

--- a/policy/release/slsa_build_build_service_test.rego
+++ b/policy/release/slsa_build_build_service_test.rego
@@ -12,12 +12,12 @@ test_all_good if {
 test_slsa_builder_id_found if {
 	attestations := [
 		# Missing predicate.builder.id
-		{"predicate": {
+		{"statement": {"predicate": {
 			"builder": {},
 			"buildType": lib.pipelinerun_att_build_types[0],
-		}},
+		}}},
 		# Missing predicate.builder
-		{"predicate": {"buildType": lib.pipelinerun_att_build_types[0]}},
+		{"statement": {"predicate": {"buildType": lib.pipelinerun_att_build_types[0]}}},
 	]
 
 	expected := {{
@@ -38,8 +38,8 @@ test_accepted_slsa_builder_id if {
 }
 
 _mock_attestation(builder_id) = d if {
-	d := {"predicate": {
+	d := {"statement": {"predicate": {
 		"builder": {"id": builder_id},
 		"buildType": lib.pipelinerun_att_build_types[0],
-	}}
+	}}}
 }

--- a/policy/release/slsa_build_scripted_build_test.rego
+++ b/policy/release/slsa_build_scripted_build_test.rego
@@ -181,7 +181,7 @@ test_subject_with_tag_and_digest_is_good if {
 		"steps": [{"entrypoint": "/bin/bash"}],
 	}]
 
-	lib.assert_empty(deny) with input.attestations as [{
+	lib.assert_empty(deny) with input.attestations as [{"statement": {
 		"subject": [{
 			"name": "registry.io/repository/image",
 			"digest": {"sha256": "digest"},
@@ -190,7 +190,7 @@ test_subject_with_tag_and_digest_is_good if {
 			"buildType": lib.pipelinerun_att_build_types[0],
 			"buildConfig": {"tasks": tasks},
 		},
-	}]
+	}}]
 }
 
 test_subject_with_tag_and_digest_mismatch_tag_is_good if {
@@ -203,7 +203,7 @@ test_subject_with_tag_and_digest_mismatch_tag_is_good if {
 		"steps": [{"entrypoint": "/bin/bash"}],
 	}]
 
-	lib.assert_empty(deny) with input.attestations as [{
+	lib.assert_empty(deny) with input.attestations as [{"statement": {
 		"subject": [{
 			"name": "registry.io/repository/image:different",
 			"digest": {"sha256": "digest"},
@@ -212,7 +212,7 @@ test_subject_with_tag_and_digest_mismatch_tag_is_good if {
 			"buildType": lib.pipelinerun_att_build_types[0],
 			"buildConfig": {"tasks": tasks},
 		},
-	}]
+	}}]
 }
 
 test_subject_with_tag_and_digest_mismatch_digest_fails if {
@@ -230,7 +230,7 @@ test_subject_with_tag_and_digest_mismatch_digest_fails if {
 		"msg": "The attestation subject, \"registry.io/repository/image@sha256:unexpected\", does not match the build task image, \"registry.io/repository/image:tag@sha256:digest\"",
 	}}
 
-	lib.assert_equal_results(expected, deny) with input.attestations as [{
+	lib.assert_equal_results(expected, deny) with input.attestations as [{"statement": {
 		"subject": [{
 			"name": "registry.io/repository/image",
 			"digest": {"sha256": "unexpected"},
@@ -239,7 +239,7 @@ test_subject_with_tag_and_digest_mismatch_digest_fails if {
 			"buildType": lib.pipelinerun_att_build_types[0],
 			"buildConfig": {"tasks": tasks},
 		},
-	}]
+	}}]
 }
 
 _image_url := "some.image/foo:bar"
@@ -261,7 +261,7 @@ _mock_attestation(original_tasks) = d if {
 		task := object.union(default_task, original_task)
 	]
 
-	d := {
+	d := {"statement": {
 		"subject": [{
 			"name": _image_url,
 			"digest": {_image_digest_algorithm: _image_digest_value},
@@ -270,5 +270,5 @@ _mock_attestation(original_tasks) = d if {
 			"buildType": lib.pipelinerun_att_build_types[0],
 			"buildConfig": {"tasks": tasks},
 		},
-	}
+	}}
 }

--- a/policy/release/slsa_provenance_available_test.rego
+++ b/policy/release/slsa_provenance_available_test.rego
@@ -21,6 +21,9 @@ test_att_predicate_type {
 _mock_attestations(types) = attestations {
 	attestations := [attestation |
 		some type in types
-		attestation := {"predicateType": type, "predicate": {"buildType": lib.pipelinerun_att_build_types[0]}}
+		attestation := {"statement": {
+			"predicateType": type,
+			"predicate": {"buildType": lib.pipelinerun_att_build_types[0]},
+		}}
 	]
 }

--- a/policy/release/slsa_source_version_controlled_test.rego
+++ b/policy/release/slsa_source_version_controlled_test.rego
@@ -101,8 +101,8 @@ test_invalid_materials if {
 }
 
 _mock_attestation(materials) = d if {
-	d := {"predicate": {
+	d := {"statement": {"predicate": {
 		"buildType": lib.pipelinerun_att_build_types[0],
 		"materials": materials,
-	}}
+	}}}
 }

--- a/policy/release/step_image_registries_test.rego
+++ b/policy/release/step_image_registries_test.rego
@@ -7,10 +7,10 @@ good_image := "registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@s
 bad_image := "hackz.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:af7dd5b3b"
 
 mock_data(image_ref) = d {
-	d := [{"predicate": {
+	d := [{"statement": {"predicate": {
 		"buildType": lib.pipelinerun_att_build_types[0],
 		"buildConfig": {"tasks": [{"name": "mytask", "steps": [{"environment": {"image": image_ref}}]}]},
-	}}]
+	}}}]
 }
 
 test_image_registry_valid {

--- a/policy/release/tasks_test.rego
+++ b/policy/release/tasks_test.rego
@@ -92,10 +92,10 @@ test_no_tasks_present if {
 	}}
 
 	lib.assert_equal_results(deny, expected) with data["pipeline-required-tasks"] as _time_based_required_tasks
-		with input.attestations as [{"predicate": {
+		with input.attestations as [{"statement": {"predicate": {
 			"buildType": lib.pipelinerun_att_build_types[0],
 			"buildConfig": {"tasks": []},
-		}}]
+		}}}]
 }
 
 test_parameterized if {
@@ -146,20 +146,20 @@ test_missing_required_pipeline_data if {
 _attestations_with_tasks(names, add_tasks) = attestations if {
 	tasks := array.concat([t | t := _task(names[_])], add_tasks)
 
-	attestations := [{"predicate": {
+	attestations := [{"statement": {"predicate": {
 		"buildType": lib.pipelinerun_att_build_types[0],
 		"buildConfig": {"tasks": tasks},
 		"invocation": {"environment": {"labels": {"pipelines.openshift.io/runtime": "generic"}}},
-	}}]
+	}}}]
 }
 
 _attestations_with_tasks_no_label(names, add_tasks) = attestations if {
 	tasks := array.concat([t | t := _task(names[_])], add_tasks)
 
-	attestations := [{"predicate": {
+	attestations := [{"statement": {"predicate": {
 		"buildType": lib.pipelinerun_att_build_types[0],
 		"buildConfig": {"tasks": tasks},
-	}}]
+	}}}]
 }
 
 _task(name) = task if {

--- a/policy/release/test_test.rego
+++ b/policy/release/test_test.rego
@@ -178,13 +178,13 @@ test_unsupported_test_result {
 
 test_missing_wrong_attestation_type {
 	pr := lib.att_mock_helper_ref("some-result", {"result": "value"}, "task1", _bundle)
-	tr := object.union(pr, {"predicate": {"buildType": lib.taskrun_att_build_types[0]}})
+	tr := object.union(pr, {"statement": {"predicate": {"buildType": lib.taskrun_att_build_types[0]}}})
 	lib.assert_empty(deny) with input.attestations as [tr]
 }
 
 test_wrong_attestation_type {
 	pr := lib.att_mock_helper_ref(lib.task_test_result_name, {"result": "ERROR"}, "errored_1", _bundle)
-	tr := object.union(pr, {"predicate": {"buildType": lib.taskrun_att_build_types[0]}})
+	tr := object.union(pr, {"statement": {"predicate": {"buildType": lib.taskrun_att_build_types[0]}}})
 	lib.assert_empty(deny) with input.attestations as [tr]
 }
 


### PR DESCRIPTION
This change allows policy rules to be applied to either `input.attestations[].statement` or `input.attestations[]`. The first having higher precedence. At some point in the future, we'll drop support for the second. This is deferred to allow users to update the ec-cli version being used.

https://issues.redhat.com/browse/HACBS-2423