### PR TITLE
SLSA source correlation check

### DIFF
--- a/policy/lib/rule_data.rego
+++ b/policy/lib/rule_data.rego
@@ -33,6 +33,14 @@ rule_data_defaults := {
 	# Valid levels: "critical", "high", "medium", and "low"
 	"restrict_cve_security_levels": ["critical", "high"],
 	"warn_cve_security_levels": [],
+	# Used in policy/release/slsa_source_correlated.rego
+	# According to https://pip.pypa.io/en/latest/topics/vcs-support/#vcs-support
+	# and https://spdx.dev/spdx-specification-20-web-version/#h.49x2ik5
+	"supported_vcs": ["git", "hg", "bzr", "svn"],
+	# Used in policy/release/slsa_source_correlated.rego
+	# Supported digests in DigestSet of SLSA Provenance v1.0
+	# See https://github.com/in-toto/attestation/blob/main/spec/v1/digest_set.md
+	"supported_digests": ["sha256", "sha224", "sha384", "sha512", "sha512_224", "sha512_256", "sha3_224", "sha3_256", "sha3_384", "sha3_512", "shake128", "shake256", "blake2b", "blake2s", "ripemd160", "sm3", "gost", "sha1", "md5", "gitCommit", "gitTree", "gitBlob", "gitTag"],
 }
 
 # Returns the "first found" of the following:

--- a/policy/release/slsa_source_correlated.rego
+++ b/policy/release/slsa_source_correlated.rego
@@ -1,0 +1,149 @@
+#
+# METADATA
+# title: SLSA - Verification model - Source
+# description: >-
+#   SLSA v1 verification model states:
+#
+#   "...artifacts are verified to ensure they meet the producer defined
+#   expectations of where the package source code was retrieved from..."
+#
+#   This package correlates the provided source code reference with the source
+#   code referenced in the attestation.
+#
+package policy.release.slsa_source_correlated
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+import data.lib
+
+# opa fmt will transform "\u0000" into "\x00" which subsequently can't be parsed
+# by OPA, see https://github.com/open-policy-agent/opa/issues/6220
+nul := base64.decode("AA==")
+
+# METADATA
+# title: Expected source code reference
+# description: >-
+#   Warn if the expected source code reference is not provided.
+# custom:
+#   short_name: expected_source_code_reference
+#   failure_msg: Expected source code reference was not provided for verification
+#   solution: >-
+#     Provide the expected source code reference in inputs.
+warn contains result if {
+	source := object.get(input, ["image", "source"], {})
+	count(source) == 0
+
+	result := lib.result_helper(rego.metadata.chain(), [])
+}
+
+# METADATA
+# title: Source reference
+# description: >-
+#   Attestation contains source reference.
+# custom:
+#   short_name: attested_source_code_reference
+#   failure_msg: The attested material contains no source code reference
+#   solution: >-
+#     Check that the attestation creation process includes the source code reference
+#     in the predicate.materials for SLSA Provenance v0.2, or in
+#     predicate.buildDefinition.resolvedDependencies for SLSA Provenance v1.0
+#     attestations. Check that the Version Control System prefix is the list of the
+#     supported VCS types in rule data (`supported_vcs` key).
+#   collections:
+#   - minimal
+#   - slsa1
+#   - slsa2
+#   - slsa3
+#   - redhat
+#   depends_on:
+#   - attestation_type.known_attestation_type
+#
+deny contains result if {
+	count(_source_references) == 0
+
+	result := lib.result_helper(rego.metadata.chain(), [])
+}
+
+# METADATA
+# title: Expected source code reference
+# description: >-
+#   Verify that the provided source code reference is the one being attested.
+# custom:
+#   short_name: expected_source_code_reference
+#   failure_msg: The expected source code reference %q is not attested
+#   solution: >-
+#     The source code reference in the attestation doesn't match the expected and
+#     provided source code reference. Make sure that the provided source code
+#     reference is correct, and if it is make sure that the build process is
+#     configured to retrieve the source code from the appropriate source code
+#     repository. Make sure that the source code reference is pointing to a
+#     explicit revision not to a symbolic identifier, e.g. a branch or tag name.
+#   collections:
+#   - minimal
+#   - slsa1
+#   - slsa2
+#   - slsa3
+#   - redhat
+#   depends_on:
+#   - attestation_type.known_attestation_type
+#
+deny contains result if {
+	count(_source_references) > 0
+
+	some vcs_type, vcs_info in input.image.source
+
+	# e.g. git+https://github.com/...
+	expected_vcs_uri := sprintf("%s+%s", [vcs_type, vcs_info.url])
+	expected_revision := vcs_info.revision
+	expected_sources := {
+		sprintf("%s@sha1:%s", [expected_vcs_uri, expected_revision]),
+		sprintf("%s@gitCommit:%s", [expected_vcs_uri, crypto.sha1(sprintf("commit %d%s%s", [count(expected_revision), nul, expected_revision]))]),
+	}
+
+	# TODO: this is rather loose, this checks that the expected source is
+	# one of the attested sources, thus allowing also the inclusion of
+	# unexpected source
+	count(expected_sources & _source_references) == 0
+
+	some attested_source in _source_references
+
+	result := lib.result_helper_with_term(rego.metadata.chain(), [sprintf("%s@%s", [expected_vcs_uri, expected_revision])], attested_source)
+}
+
+# SLSA Provenance v0.2
+_source_references contains ref if {
+	some att in lib.pipelinerun_attestations
+	some material in att.predicate.materials
+	some digest_alg in object.keys(material.digest)
+	some supported_vcs_type in lib.rule_data("supported_vcs")
+
+	# the material.uri is a kind of vcs_type, lets us ignore other, non-vcs, materials
+	startswith(material.uri, sprintf("%s+", [supported_vcs_type]))
+
+	# make sure the digest algorithm is supported
+	digest_alg in lib.rule_data("supported_digests")
+
+	# note, the digest_alg is not compared, it is expected that the value
+	# matches the expected reference
+	ref := sprintf("%s@%s:%s", [material.uri, digest_alg, material.digest[digest_alg]])
+}
+
+# SLSA Provenance v1.0
+_source_references contains ref if {
+	some att in lib.pipelinerun_slsa_provenance_v1
+	some resolvedDependency in att.predicate.buildDefinition.resolvedDependencies
+	some digest_alg in object.keys(resolvedDependency.digest)
+	some supported_vcs_type in lib.rule_data("supported_vcs")
+
+	# the material.uri is a kind of vcs_type, lets us ignore other, non-vcs, materials
+	startswith(resolvedDependency.uri, sprintf("%s+", [supported_vcs_type]))
+
+	# make sure the digest algorithm is supported
+	digest_alg in lib.rule_data("supported_digests")
+
+	# note, the digest_alg is not compared, it is expected that the value
+	# matches the expected reference
+	ref := sprintf("%s@%s:%s", [resolvedDependency.uri, digest_alg, resolvedDependency.digest[digest_alg]])
+}

--- a/policy/release/slsa_source_correlated_test.rego
+++ b/policy/release/slsa_source_correlated_test.rego
@@ -1,0 +1,189 @@
+package policy.release.slsa_source_correlated
+
+import future.keywords.in
+
+import data.lib
+
+test_warn_missing_source_code_happy_day {
+	lib.assert_empty(warn) with input.image as {"source": {"something": "here"}}
+}
+
+test_warn_missing_expected_source_code_reference {
+	expected := {{
+		"code": "slsa_source_correlated.expected_source_code_reference",
+		"msg": "Expected source code reference was not provided for verification",
+	}}
+	lib.assert_equal_results(warn, expected) with input as {}
+	lib.assert_equal_results(warn, expected) with input.image as {}
+	lib.assert_equal_results(warn, expected) with input.image as {"source": {}}
+}
+
+test_deny_material_code_reference {
+	# no source materials
+	lib.assert_equal_results(deny, {{"code": "slsa_source_correlated.attested_source_code_reference", "msg": "The attested material contains no source code reference"}}) with input.image as expected
+		with input.attestations as [_material_attestation([]), _resolvedDependencies_attestation([])]
+
+	# unsupported scm SLSA Provenance v0.2
+	lib.assert_equal_results(deny, {{"code": "slsa_source_correlated.attested_source_code_reference", "msg": "The attested material contains no source code reference"}}) with input.image as expected
+		with input.attestations as [_source_material_attestation("xyz+https://some.repository", "ref")]
+
+	# unsupported scm SLSA Provenance v1.0
+	lib.assert_equal_results(deny, {{"code": "slsa_source_correlated.attested_source_code_reference", "msg": "The attested material contains no source code reference"}}) with input.image as expected
+		with input.attestations as [_source_resolvedDependencies_attestation("xyz+https://some.repository", "ref")]
+}
+
+test_deny_expected_source_code_reference_happy_day {
+	# one material matches expected SLSA Provenance v0.2
+	lib.assert_empty(deny) with input.image as expected
+		with input.attestations as [_source_material_attestation("git+https://git.repository", "ref")]
+
+	# one material matches expected SLSA Provenance v1.0
+	lib.assert_empty(deny) with input.image as expected
+		with input.attestations as [_source_resolvedDependencies_attestation("git+https://git.repository", "ref")]
+
+	dependencies := [
+		{
+			"uri": "registry.io/repository/image",
+			"digest": {"sha256": "cafe"},
+		},
+		{
+			"uri": "git+https://git.repository",
+			"digest": {"sha1": "ref"},
+		},
+		{
+			"uri": "registry.io/repository/image2",
+			"digest": {"sha256": "dada"},
+		},
+	]
+
+	# more than one material, one matches expected the others are unrelated
+	lib.assert_empty(deny) with input.image as expected
+		with input.attestations as [
+			_material_attestation(dependencies),
+			_resolvedDependencies_attestation(dependencies),
+		]
+
+	# more than one material, one matches expected the other doesn't, this is,
+	# currently not a failure SLSA Provenance v0.2
+	#
+	# TODO: most likely we want to distinguish what source was built from what
+	# source references were used by the build
+	lib.assert_empty(deny) with input.image as expected
+		with input.attestations as [_source_material_attestation("git+https://git.repository", "ref"), _source_material_attestation("git+https://unexpected.repository", "unexpected")]
+
+	# more than one material, one matches expected the other doesn't, this is,
+	# currently not a failure SLSA Provenance v1.0
+	#
+	# TODO: most likely we want to distinguish what source was built from what
+	# source references were used by the build
+	lib.assert_empty(deny) with input.image as expected
+		with input.attestations as [_source_resolvedDependencies_attestation("git+https://git.repository", "ref"), _source_material_attestation("git+https://unexpected.repository", "unexpected")]
+
+	# the `gitCommit` support as digest algorithm in SLSA Provenance v1.0
+	lib.assert_empty(deny) with input.image as expected
+		with input.attestations as [_resolvedDependencies_attestation([{
+			"uri": "git+https://git.repository",
+			"digest": {"gitCommit": "ec74e6310316babc451947a1a749a233e8da0585"}, # printf 'commit 3\0ref' | sha1sum
+			"name": "inputs/result",
+		}])]
+}
+
+test_deny_expected_source_code_reference_v02 {
+	# different scm SLSA Provenance v0.2
+	lib.assert_equal_results(deny, {{"code": "slsa_source_correlated.expected_source_code_reference", "msg": "The expected source code reference \"git+https://git.repository@ref\" is not attested", "term": "svn+https://git.repository@sha1:ref"}}) with input.image as expected
+		with input.attestations as [_source_material_attestation("svn+https://git.repository", "ref")]
+
+	# different repository SLSA Provenance v0.2
+	lib.assert_equal_results(deny, {{"code": "slsa_source_correlated.expected_source_code_reference", "msg": "The expected source code reference \"git+https://git.repository@ref\" is not attested", "term": "git+https://unexpected.repository@sha1:ref"}}) with input.image as expected
+		with input.attestations as [_source_material_attestation("git+https://unexpected.repository", "ref")]
+
+	# different revision SLSA Provenance v0.2
+	lib.assert_equal_results(deny, {{"code": "slsa_source_correlated.expected_source_code_reference", "msg": "The expected source code reference \"git+https://git.repository@ref\" is not attested", "term": "git+https://git.repository@sha1:unexpected"}}) with input.image as expected
+		with input.attestations as [_source_material_attestation("git+https://git.repository", "unexpected")]
+
+	# multiple mismatches SLSA Provenance v0.2
+	lib.assert_equal_results(deny, {{"code": "slsa_source_correlated.expected_source_code_reference", "msg": "The expected source code reference \"git+https://git.repository@ref\" is not attested", "term": "git+https://git.repository@sha1:unexpected"}, {"code": "slsa_source_correlated.expected_source_code_reference", "msg": "The expected source code reference \"git+https://git.repository@ref\" is not attested", "term": "git+https://unexpected.repository@sha1:ref"}, {"code": "slsa_source_correlated.expected_source_code_reference", "msg": "The expected source code reference \"git+https://git.repository@ref\" is not attested", "term": "svn+https://git.repository@sha1:ref"}}) with input.image as expected
+		with input.attestations as [_source_material_attestation("svn+https://git.repository", "ref"), _source_material_attestation("git+https://unexpected.repository", "ref"), _source_material_attestation("git+https://git.repository", "unexpected")]
+}
+
+test_deny_expected_source_code_reference_v10 {
+	# different scm SLSA Provenance v1.0
+	lib.assert_equal_results(deny, {{"code": "slsa_source_correlated.expected_source_code_reference", "msg": "The expected source code reference \"git+https://git.repository@ref\" is not attested", "term": "svn+https://git.repository@sha1:ref"}}) with input.image as expected
+		with input.attestations as [_source_resolvedDependencies_attestation("svn+https://git.repository", "ref")]
+
+	# different repository SLSA Provenance v1.0
+	lib.assert_equal_results(deny, {{"code": "slsa_source_correlated.expected_source_code_reference", "msg": "The expected source code reference \"git+https://git.repository@ref\" is not attested", "term": "git+https://unexpected.repository@sha1:ref"}}) with input.image as expected
+		with input.attestations as [_source_resolvedDependencies_attestation("git+https://unexpected.repository", "ref")]
+
+	# different revision SLSA Provenance v1.0
+	lib.assert_equal_results(deny, {{"code": "slsa_source_correlated.expected_source_code_reference", "msg": "The expected source code reference \"git+https://git.repository@ref\" is not attested", "term": "git+https://git.repository@sha1:unexpected"}}) with input.image as expected
+		with input.attestations as [_source_resolvedDependencies_attestation("git+https://git.repository", "unexpected")]
+
+	# multiple mismatches SLSA Provenance v1.0
+	lib.assert_equal_results(deny, {{"code": "slsa_source_correlated.expected_source_code_reference", "msg": "The expected source code reference \"git+https://git.repository@ref\" is not attested", "term": "git+https://git.repository@sha1:unexpected"}, {"code": "slsa_source_correlated.expected_source_code_reference", "msg": "The expected source code reference \"git+https://git.repository@ref\" is not attested", "term": "git+https://unexpected.repository@sha1:ref"}, {"code": "slsa_source_correlated.expected_source_code_reference", "msg": "The expected source code reference \"git+https://git.repository@ref\" is not attested", "term": "svn+https://git.repository@sha1:ref"}}) with input.image as expected
+		with input.attestations as [_source_resolvedDependencies_attestation("svn+https://git.repository", "ref"), _source_resolvedDependencies_attestation("git+https://unexpected.repository", "ref"), _source_resolvedDependencies_attestation("git+https://git.repository", "unexpected")]
+}
+
+test_slsa_v02_source_references {
+	lib.assert_empty(_source_references)
+	lib.assert_empty(_source_references) with input.attestations as [_material_attestation([])]
+	lib.assert_empty(_source_references) with input.attestations as [_source_material_attestation("https://something:somewhere", "cafe")]
+
+	# no digest
+	lib.assert_empty(_source_references) with input.attestations as [_material_attestation([{"uri": "git+https://git.repository"}])]
+
+	# unsupported digest algorithm
+	lib.assert_empty(_source_references) with input.attestations as [_material_attestation([{"uri": "git+https://git.repository", "digest": {"md2": "unsupported"}}])]
+
+	# no uri
+	lib.assert_empty(_source_references) with input.attestations as [_material_attestation([{"digest": {"sha256": "cafe"}}])]
+	lib.assert_equal({"git+ssh://git.repository@sha1:cafe"}, _source_references) with input.attestations as [_source_material_attestation("git+ssh://git.repository", "cafe")]
+	lib.assert_equal({"git+ssh://git.repository@sha1:cafe", "hg+https://hg.repository@sha1:dada"}, _source_references) with input.attestations as [_source_material_attestation("git+ssh://git.repository", "cafe"), _source_material_attestation("hg+https://hg.repository", "dada")]
+}
+
+test_slsa_v10_source_references {
+	lib.assert_empty(_source_references) with input.attestations as [_resolvedDependencies_attestation([])]
+	lib.assert_empty(_source_references) with input.attestations as [_source_resolvedDependencies_attestation("https://something:somewhere", "cafe")]
+
+	# no digest
+	lib.assert_empty(_source_references) with input.attestations as [_resolvedDependencies_attestation([{"uri": "git+https://git.repository"}])]
+
+	# unsupported digest algorithm
+	lib.assert_empty(_source_references) with input.attestations as [_resolvedDependencies_attestation([{"uri": "git+https://git.repository", "digest": {"md2": "unsupported"}}])]
+
+	# no uri
+	lib.assert_empty(_source_references) with input.attestations as [_resolvedDependencies_attestation([{"digest": {"sha256": "cafe"}}])]
+	lib.assert_equal({"git+ssh://git.repository@sha1:cafe"}, _source_references) with input.attestations as [_source_resolvedDependencies_attestation("git+ssh://git.repository", "cafe")]
+	lib.assert_equal({"git+ssh://git.repository@sha1:cafe", "hg+https://hg.repository@sha1:dada"}, _source_references) with input.attestations as [_source_resolvedDependencies_attestation("git+ssh://git.repository", "cafe"), _source_resolvedDependencies_attestation("hg+https://hg.repository", "dada")]
+}
+
+expected := {"source": {"git": {"url": "https://git.repository", "revision": "ref"}}}
+
+# SLSA Provenance v0.2
+_material_attestation(materials) := {"statement": {"predicate": {
+	"buildType": lib.pipelinerun_att_build_types[0],
+	"materials": materials,
+}}}
+
+# SLSA Provenance v0.2
+_source_material_attestation(uri, sha1) := _material_attestation([{
+	"uri": uri,
+	"digest": {"sha1": sha1},
+}])
+
+# SLSA Provenance v1.0
+_resolvedDependencies_attestation(dependencies) := {"statement": {
+	"predicateType": "https://slsa.dev/provenance/v1",
+	"predicate": {"buildDefinition": {
+		"buildType": "https://tekton.dev/chains/v2/slsa",
+		"externalParameters": {"runSpec": {"pipelineSpec": {}}},
+		"resolvedDependencies": dependencies,
+	}},
+}}
+
+# SLSA Provenance v1.0
+_source_resolvedDependencies_attestation(uri, sha1) := _resolvedDependencies_attestation([{
+	"uri": uri,
+	"digest": {"sha1": sha1},
+	"name": "inputs/result",
+}])


### PR DESCRIPTION
Given the attested source code reference and the source image code reference this check will make sure of their equality.

A warning is issued for source image data not including the source reference.

A failure will be issued if no source reference is present in the materials section or if the materials does not match the expected image source reference for SLSA Provenance v0.2.

Similarly, a failure will be issued if no source reference is present in the resolvedDependencies or if the resolvedDependencies does not match the expected image source reference for SLSA Provenance v1.0.

Ref. https://issues.redhat.com/browse/HACBS-2247