### PR TITLE
Tolerate missing or superfluous `.git` suffix

### DIFF
--- a/policy/release/slsa_source_correlated.rego
+++ b/policy/release/slsa_source_correlated.rego
@@ -99,7 +99,11 @@ deny contains result if {
 	expected_revision := vcs_info.revision
 	expected_sources := {
 		sprintf("%s@sha1:%s", [expected_vcs_uri, expected_revision]),
+		sprintf("%s.git@sha1:%s", [expected_vcs_uri, expected_revision]), # tolerate missing .git suffix
+		sprintf("%s@sha1:%s", [trim_suffix(expected_vcs_uri, ".git"), expected_revision]), # tolerate extra or missing .git suffix
 		sprintf("%s@gitCommit:%s", [expected_vcs_uri, crypto.sha1(sprintf("commit %d%s%s", [count(expected_revision), nul, expected_revision]))]),
+		sprintf("%s.git@gitCommit:%s", [expected_vcs_uri, crypto.sha1(sprintf("commit %d%s%s", [count(expected_revision), nul, expected_revision]))]), # tolerate missing .git suffix
+		sprintf("%s@gitCommit:%s", [trim_suffix(expected_vcs_uri, ".git"), crypto.sha1(sprintf("commit %d%s%s", [count(expected_revision), nul, expected_revision]))]), # tolerate extra or missing .git suffix
 	}
 
 	# TODO: this is rather loose, this checks that the expected source is

--- a/policy/release/slsa_source_correlated_test.rego
+++ b/policy/release/slsa_source_correlated_test.rego
@@ -86,6 +86,70 @@ test_deny_expected_source_code_reference_happy_day {
 			"digest": {"gitCommit": "ec74e6310316babc451947a1a749a233e8da0585"}, # printf 'commit 3\0ref' | sha1sum
 			"name": "inputs/result",
 		}])]
+
+	# missing .git suffix in input.image.source.git.url SLSA Provenance v0.2
+	lib.assert_empty(deny) with input.image as expected
+		with input.attestations as [_source_material_attestation("git+https://git.repository.git", "ref")]
+
+	# missing .git in predicate.materials.uri of SLSA Provenance v0.2
+	lib.assert_empty(deny) with input.image as {"source": {"git": {"url": "https://git.repository.git", "revision": "ref"}}}
+		with input.attestations as [_source_material_attestation("git+https://git.repository", "ref")]
+
+	# extra .git suffix in input.image.source.git.url SLSA Provenance v0.2
+	lib.assert_empty(deny) with input.image as {"source": {"git": {"url": "https://git.repository.git.git", "revision": "ref"}}}
+		with input.attestations as [_source_material_attestation("git+https://git.repository.git", "ref")]
+
+	# extra .git suffix in predicate.materials.uri SLSA Provenance v0.2
+	lib.assert_empty(deny) with input.image as {"source": {"git": {"url": "https://git.repository.git", "revision": "ref"}}}
+		with input.attestations as [_source_material_attestation("git+https://git.repository.git.git", "ref")]
+
+	# missing .git suffix in input.image.source.git.url SLSA Provenance v1.0
+	lib.assert_empty(deny) with input.image as expected
+		with input.attestations as [_source_resolvedDependencies_attestation("git+https://git.repository.git", "ref")]
+
+	# missing .git in predicate.resolvedDependencies.uri of SLSA Provenance v1.0
+	lib.assert_empty(deny) with input.image as {"source": {"git": {"url": "https://git.repository.git", "revision": "ref"}}}
+		with input.attestations as [_source_resolvedDependencies_attestation("git+https://git.repository", "ref")]
+
+	# extra .git suffix in input.image.source.git.url SLSA Provenance v1.0
+	lib.assert_empty(deny) with input.image as {"source": {"git": {"url": "https://git.repository.git.git", "revision": "ref"}}}
+		with input.attestations as [_source_resolvedDependencies_attestation("git+https://git.repository.git", "ref")]
+
+	# extra .git suffix in predicate.resolvedDependencies.uri SLSA Provenance v0.2
+	lib.assert_empty(deny) with input.image as {"source": {"git": {"url": "https://git.repository.git", "revision": "ref"}}}
+		with input.attestations as [_source_resolvedDependencies_attestation("git+https://git.repository.git.git", "ref")]
+
+	# missing .git suffix in input.image.source.git.url SLSA Provenance v1.0, gitCommit support
+	lib.assert_empty(deny) with input.image as expected
+		with input.attestations as [_resolvedDependencies_attestation([{
+			"uri": "git+https://git.repository.git",
+			"digest": {"gitCommit": "ec74e6310316babc451947a1a749a233e8da0585"},
+			"name": "inputs/result",
+		}])]
+
+	# missing .git in predicate.resolvedDependencies.uri of SLSA Provenance v1.0, gitCommit support
+	lib.assert_empty(deny) with input.image as {"source": {"git": {"url": "https://git.repository.git", "revision": "ref"}}}
+		with input.attestations as [_resolvedDependencies_attestation([{
+			"uri": "git+https://git.repository",
+			"digest": {"gitCommit": "ec74e6310316babc451947a1a749a233e8da0585"},
+			"name": "inputs/result",
+		}])]
+
+	# extra .git suffix in input.image.source.git.url SLSA Provenance v1.0, gitCommit support
+	lib.assert_empty(deny) with input.image as {"source": {"git": {"url": "https://git.repository.git.git", "revision": "ref"}}}
+		with input.attestations as [_resolvedDependencies_attestation([{
+			"uri": "git+https://git.repository.git",
+			"digest": {"gitCommit": "ec74e6310316babc451947a1a749a233e8da0585"},
+			"name": "inputs/result",
+		}])]
+
+	# extra .git suffix in predicate.resolvedDependencies.uri SLSA Provenance v0.2, gitCommit support
+	lib.assert_empty(deny) with input.image as {"source": {"git": {"url": "https://git.repository.git", "revision": "ref"}}}
+		with input.attestations as [_resolvedDependencies_attestation([{
+			"uri": "git+https://git.repository.git.git",
+			"digest": {"gitCommit": "ec74e6310316babc451947a1a749a233e8da0585"},
+			"name": "inputs/result",
+		}])]
 }
 
 test_deny_expected_source_code_reference_v02 {


### PR DESCRIPTION
At least in the e2e tests, and recent issue in Chains that was fixed point to issues when the expected source, i.e. the one passed on via ApplicationSnapshot, or the attested source, i.e. one in the materials or resolvedDependencies, do no contain the `.git` suffix or have superfluous `.git` suffix in the repository URL.
This allows for some leniency in the repository URL.