### PR TITLE
Update tasks operations so they support slsav1 attestations.

### DIFF
--- a/policy/release/buildah_build_task.rego
+++ b/policy/release/buildah_build_task.rego
@@ -33,7 +33,8 @@ deny contains result if {
 	buildah_tasks
 	some buildah_task in buildah_tasks
 	not lib.tkn.task_param(buildah_task, "DOCKERFILE")
-	result := lib.result_helper_with_term(rego.metadata.chain(), [buildah_task.name], buildah_task.name)
+	name := lib.tkn.task_name(buildah_task)
+	result := lib.result_helper_with_term(rego.metadata.chain(), [name], name)
 }
 
 # METADATA
@@ -63,9 +64,23 @@ _not_allowed_prefix(search) if {
 }
 
 buildah_tasks contains task if {
-	some att in lib.pipelinerun_attestations
+	some att in _att
 	some task in lib.tkn.tasks(att)
 	"buildah" in lib.tkn.task_names(task)
+}
+
+_att := att if {
+	att := {a |
+		some a in lib.pipelinerun_slsa_provenance_v1
+	}
+	count(att) > 0
+}
+
+_att := att if {
+	att := {a |
+		some a in lib.pipelinerun_attestations
+	}
+	count(att) > 0
 }
 
 dockerfile_params contains param if {

--- a/policy/release/lib/attestations.rego
+++ b/policy/release/lib/attestations.rego
@@ -8,6 +8,11 @@ pipelinerun_att_build_types := [
 	"https://tekton.dev/attestations/chains/pipelinerun@v2",
 ]
 
+slsav1_pipelinerun_att_build_types := [
+	"https://tekton.dev/chains/v2/slsa",
+	"https://tekton.dev/chains/v2/slsa-tekton",
+]
+
 taskrun_att_build_types := [
 	"tekton.dev/v1beta1/TaskRun",
 	# Legacy build type
@@ -35,7 +40,7 @@ pipelinerun_slsa_provenance_v1 := [statement |
 	att := input.attestations[_]
 	statement := _statement(att)
 	statement.predicateType == "https://slsa.dev/provenance/v1"
-	statement.predicate.buildDefinition.buildType == "https://tekton.dev/chains/v2/slsa"
+	statement.predicate.buildDefinition.buildType == slsav1_pipelinerun_att_build_types[_]
 
 	# TODO: Workaround to distinguish between taskrun and pipelinerun attestations
 	spec_keys := object.keys(statement.predicate.buildDefinition.externalParameters.runSpec)


### PR DESCRIPTION
This modifies the task library to handle tasks from the resolvedDepencies list in a slsav1 attestation.

This ONLY updates the task library and the `buildah_task` policy. More policies need to be updated, but I'm breaking them up into separate PRs to reduce the size.

https://issues.redhat.com/browse/HACBS-2246