### PR TITLE
Add Regal linter

### DIFF
--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -1,0 +1,6 @@
+# Configures Regal rules, see https://docs.styra.com/regal/category/rules
+---
+rules:
+  style:
+    todo-comment:
+      level: warning

--- a/Makefile
+++ b/Makefile
@@ -161,8 +161,12 @@ fmt-check: ## Check formatting of Rego files
 	@$(OPA) fmt . --list | xargs -r -n1 echo 'FAIL: Incorrect formatting found in'
 	@$(OPA) fmt . --list --fail >/dev/null 2>&1
 
+.PHONY: lint
+lint: ## Runs Rego linter
+	@go run github.com/styrainc/regal lint . --ignore-files 'antora/docs/policy/**' $(if $(GITHUB_ACTIONS),--format=github)
+
 .PHONY: ci
-ci: quiet-test opa-check conventions-check fmt-check ## Runs all checks and tests
+ci: quiet-test opa-check conventions-check fmt-check lint ## Runs all checks and tests
 
 #--------------------------------------------------------------------
 

--- a/checks/annotations_test.rego
+++ b/checks/annotations_test.rego
@@ -1,5 +1,6 @@
-package checks
+package checks_test
 
+import data.checks
 import data.lib
 
 opa_inspect_valid := {
@@ -10,7 +11,7 @@ opa_inspect_valid := {
 	"annotations": [
 		{
 			"annotations": {
-				"description": "Check if the Tekton Bundle used for the Tasks in the Pipeline definition is pinned to a digest.",
+				"description": "Check if the Tekton Bundle used for the Tasks in the Pipeline definition is...",
 				"scope": "rule",
 				"title": "Task bundle references pinned to digest",
 				"custom": {
@@ -33,9 +34,9 @@ opa_inspect_valid := {
 					"depends_on": ["attestation_type.pipelinerun_attestation_found"],
 					"failure_msg": "Unknown attestation type '%s'",
 					"short_name": "known_attestation_type",
-					"solution": "Make sure the \"_type\" field in the attestation is supported. Supported types are configured in xref:ec-cli:ROOT:configuration.adoc#_data_sources[data sources].",
+					"solution": "Make sure the \"_type\" field in the attestation is supported. Supported types are...",
 				},
-				"description": "A sanity check to confirm the attestation found for the image has a known attestation type.",
+				"description": "A sanity check to confirm the attestation found for the image has a known...",
 				"scope": "rule",
 				"title": "Known attestation type found",
 			},
@@ -67,7 +68,7 @@ opa_inspect_valid := {
 }
 
 test_required_annotations_valid {
-	lib.assert_empty(violation) with input as opa_inspect_valid
+	lib.assert_empty(checks.violation) with input as opa_inspect_valid
 }
 
 opa_inspect_missing_annotations := {
@@ -78,7 +79,7 @@ opa_inspect_missing_annotations := {
 	"annotations": [{
 		"annotations": {
 			"scope": "rule",
-			"description": "Check for the existence of a task bundle. This rule will fail if the task is not called from a bundle.",
+			"description": "Check for the existence of a task bundle. This rule will fail if the task is not called...",
 			"custom": {
 				"flagiure_msg": "Task '%s' does not contain a bundle reference",
 				"short_name": "disallowed_task_reference",
@@ -99,7 +100,7 @@ opa_inspect_missing_dependency := {
 	]},
 	"annotations": [{
 		"annotations": {
-			"description": "Check if the Tekton Bundle used for the Tasks in the Pipeline definition is pinned to a digest.",
+			"description": "Check if the Tekton Bundle used for the Tasks in the Pipeline definition is pinned to...",
 			"scope": "rule",
 			"title": "Task bundle references pinned to digest",
 			"custom": {
@@ -126,9 +127,9 @@ opa_inspect_duplicate := {
 					"collections": ["minimal"],
 					"failure_msg": "Unknown attestation type '%s'",
 					"short_name": "known_attestation_type",
-					"solution": "Make sure the \"_type\" field in the attestation is supported. Supported types are configured in xref:ec-cli:ROOT:configuration.adoc#_data_sources[data sources].",
+					"solution": "Make sure the \"_type\" field in the attestation is supported. Supported types are...",
 				},
-				"description": "A sanity check to confirm the attestation found for the image has a known attestation type.",
+				"description": "A sanity check to confirm the attestation found for the image has a known...",
 				"scope": "rule",
 				"title": "Known attestation type found",
 			},
@@ -144,9 +145,9 @@ opa_inspect_duplicate := {
 					"collections": ["minimal"],
 					"failure_msg": "Unknown attestation type '%s'",
 					"short_name": "known_attestation_type",
-					"solution": "Make sure the \"_type\" field in the attestation is supported. Supported types are configured in xref:ec-cli:ROOT:configuration.adoc#_data_sources[data sources].",
+					"solution": "Make sure the \"_type\" field in the attestation is supported. Supported types are...",
 				},
-				"description": "A sanity check to confirm the attestation found for the image has a known attestation type.",
+				"description": "A sanity check to confirm the attestation found for the image has a known...",
 				"scope": "rule",
 				"title": "Known attestation type found",
 			},
@@ -160,13 +161,21 @@ opa_inspect_duplicate := {
 }
 
 test_required_annotations_invalid {
-	lib.assert_equal({"ERROR: Missing annotation(s) custom.failure_msg, title at policy/release/attestation_task_bundle.rego:13"}, violation) with input as opa_inspect_missing_annotations
+	err = "ERROR: Missing annotation(s) custom.failure_msg, title at policy/release/attestation_task_bundle.rego:13"
+	lib.assert_equal({err}, checks.violation) with input as opa_inspect_missing_annotations
 }
 
 test_missing_dependency_invalid {
-	lib.assert_equal({"ERROR: Missing dependency rule \"data.policy.release.attestation_type.known_attestation_type\" at policy/release/attestation_task_bundle.rego:71"}, violation) with input as opa_inspect_missing_dependency
+	# regal ignore:line-length
+	err = `ERROR: Missing dependency rule "data.policy.release.attestation_type.known_attestation_type" at policy/release/attestation_task_bundle.rego:71`
+	lib.assert_equal({err}, checks.violation) with input as opa_inspect_missing_dependency
 }
 
 test_duplicate_rules {
-	lib.assert_equal({"ERROR: Found non-unique code \"data.policy.release.attestation_type.known_attestation_type\" at policy/release/attestation_type.rego:30", "ERROR: Found non-unique code \"data.policy.release.attestation_type.known_attestation_type\" at policy/release/attestation_type.rego:50"}, violation) with input as opa_inspect_duplicate
+	# regal ignore:line-length
+	err1 = `ERROR: Found non-unique code "data.policy.release.attestation_type.known_attestation_type" at policy/release/attestation_type.rego:30`
+
+	# regal ignore:line-length
+	err2 = `ERROR: Found non-unique code "data.policy.release.attestation_type.known_attestation_type" at policy/release/attestation_type.rego:50`
+	lib.assert_equal({err1, err2}, checks.violation) with input as opa_inspect_duplicate
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/open-policy-agent/conftest v0.45.0
 	github.com/open-policy-agent/opa v0.56.0
+	github.com/styrainc/regal v0.8.0
 	github.com/tektoncd/cli v0.32.0
 )
 
@@ -30,6 +31,7 @@ require (
 	contrib.go.opencensus.io/exporter/ocagent v0.7.1-0.20200907061046-05415f1de66d // indirect
 	contrib.go.opencensus.io/exporter/prometheus v0.4.0 // indirect
 	cuelang.org/go v0.6.0 // indirect
+	dario.cat/mergo v1.0.0 // indirect
 	filippo.io/edwards25519 v1.0.0 // indirect
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect
 	github.com/AlecAivazis/survey/v2 v2.3.7 // indirect
@@ -164,14 +166,14 @@ require (
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
-	github.com/golang/glog v1.1.0 // indirect
+	github.com/golang/glog v1.1.1 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/cel-go v0.17.1 // indirect
 	github.com/google/certificate-transparency-go v1.1.6 // indirect
-	github.com/google/flatbuffers v22.9.29+incompatible // indirect
+	github.com/google/flatbuffers v23.5.26+incompatible // indirect
 	github.com/google/gnostic v0.6.9 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/go-containerregistry v0.16.1 // indirect
@@ -190,6 +192,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.12.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
+	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/grafeas/grafeas v0.2.2 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
@@ -238,7 +241,7 @@ require (
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.17 // indirect
+	github.com/mattn/go-isatty v0.0.18 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
@@ -275,7 +278,7 @@ require (
 	github.com/prometheus/procfs v0.10.1 // indirect
 	github.com/prometheus/statsd_exporter v0.21.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
-	github.com/rivo/uniseg v0.4.2 // indirect
+	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sassoftware/relic v7.2.1+incompatible // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -640,6 +640,8 @@ contrib.go.opencensus.io/exporter/stackdriver v0.13.14/go.mod h1:5pSSGY0Bhuk7waT
 contrib.go.opencensus.io/integrations/ocsql v0.1.7/go.mod h1:8DsSdjz3F+APR+0z0WkU1aRorQCFfRxvqjUUPMbF3fE=
 cuelang.org/go v0.6.0 h1:dJhgKCog+FEZt7OwAYV1R+o/RZPmE8aqFoptmxSWyr8=
 cuelang.org/go v0.6.0/go.mod h1:9CxOX8aawrr3BgSdqPj7V0RYoXo7XIb+yDFC6uESrOQ=
+dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
+dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 filippo.io/edwards25519 v1.0.0 h1:0wAIcmJUqRdI8IJ/3eGi5/HwXZWPujYXXlkrQogz0Ek=
 filippo.io/edwards25519 v1.0.0/go.mod h1:N1IkdkCkiLB6tki+MYJoSx2JTY9NUlxZE7eHn5EwJns=
@@ -1562,8 +1564,9 @@ github.com/golang-sql/sqlexp v0.1.0/go.mod h1:J4ad9Vo8ZCWQ2GMrC4UCQy1JpCbwU9m3EO
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
-github.com/golang/glog v1.1.0 h1:/d3pCKDPWNnvIWe0vVUpNP32qc8U3PDVxySP/y360qE=
 github.com/golang/glog v1.1.0/go.mod h1:pfYeQZ3JWZoXTV5sFc986z3HTpwQs9At6P4ImfuP3NQ=
+github.com/golang/glog v1.1.1 h1:jxpi2eWoU84wbX9iIEyAeeoac3FLuifZpY9tcNUD9kw=
+github.com/golang/glog v1.1.1/go.mod h1:zR+okUeTbrL6EL3xHUDxZuEtGv04p5shwip1+mL/rLQ=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -1616,8 +1619,8 @@ github.com/google/certificate-transparency-go v1.1.6 h1:SW5K3sr7ptST/pIvNkSVWMiJ
 github.com/google/certificate-transparency-go v1.1.6/go.mod h1:0OJjOsOk+wj6aYQgP7FU0ioQ0AJUmnWPFMqTjQeazPQ=
 github.com/google/flatbuffers v1.12.1/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/flatbuffers v2.0.8+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
-github.com/google/flatbuffers v22.9.29+incompatible h1:3UBb679lq3V/O9rgzoJmnkP1jJzmC9OdFzITUBkLU/A=
-github.com/google/flatbuffers v22.9.29+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
+github.com/google/flatbuffers v23.5.26+incompatible h1:M9dgRyhJemaM4Sw8+66GHBu8ioaQmyPLg1b8VwK5WJg=
+github.com/google/flatbuffers v23.5.26+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/gnostic v0.5.7-v3refs/go.mod h1:73MKFl6jIHelAJNaBGFzt3SPtZULs9dYrGFt8OiIsHQ=
 github.com/google/gnostic v0.6.9 h1:ZK/5VhkoX835RikCHpSUJV9a+S3e1zLh59YnyWeBW+0=
 github.com/google/gnostic v0.6.9/go.mod h1:Nm8234We1lq6iB9OmlgNv3nH91XLLVZHCDayfA3xq+E=
@@ -1756,6 +1759,8 @@ github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gosuri/uitable v0.0.4 h1:IG2xLKRvErL3uhY6e1BylFzG+aJiwQviDDTfOKeKTpY=
+github.com/gosuri/uitable v0.0.4/go.mod h1:tKR86bXuXPZazfOTG1FIzvjIdXzd0mo4Vtn16vt0PJo=
 github.com/grafana/regexp v0.0.0-20220304095617-2e8d9baf4ac2/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
 github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
 github.com/grafeas/grafeas v0.2.2 h1:dhn3M/RkBVrEP+gCowny1qoG1Opfa09SwPL1BGT6k0U=
@@ -2100,8 +2105,9 @@ github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOA
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
-github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-isatty v0.0.18 h1:DOKFKCQ7FNG2L1rbrmstDN4QVRdS89Nkh85u68Uwp98=
+github.com/mattn/go-isatty v0.0.18/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
@@ -2422,8 +2428,9 @@ github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5X
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
-github.com/rivo/uniseg v0.4.2 h1:YwD0ulJSJytLpiaWua0sBDusfsCZohxjxzVTYjwxfV8=
 github.com/rivo/uniseg v0.4.2/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
+github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -2589,6 +2596,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/styrainc/regal v0.8.0 h1:KDXjbfTc51Hj4RjbeFVm4SurkQiU3i/0qyoBycp+M0g=
+github.com/styrainc/regal v0.8.0/go.mod h1:xBl9WkG6a7vvBVIobsKw0hiYV9aifc5x+CIzFCK7vZs=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8=

--- a/hack/simplecov.rego
+++ b/hack/simplecov.rego
@@ -1,16 +1,17 @@
 # Copied from https://github.com/open-policy-agent/contrib/tree/main/simplecov/simplecov.rego
 package simplecov
 
-import future.keywords
+import future.keywords.if
+import future.keywords.in
 
 from_opa := {"coverage": coverage}
 
-coverage[file] = obj if {
+coverage[file] := obj if {
 	some file, report in input.files
 	obj := {"lines": lines(report)}
 }
 
-covered_map(report) = cm if {
+covered_map(report) := cm if {
 	covered := object.get(report, "covered", [])
 	cm := {line: 1 |
 		some item in covered
@@ -18,7 +19,7 @@ covered_map(report) = cm if {
 	}
 }
 
-not_covered_map(report) = ncm if {
+not_covered_map(report) := ncm if {
 	not_covered := object.get(report, "not_covered", [])
 	ncm := {line: 0 |
 		some item in not_covered
@@ -26,7 +27,7 @@ not_covered_map(report) = ncm if {
 	}
 }
 
-lines(report) = lines if {
+lines(report) := lines if {
 	cm := covered_map(report)
 	ncm := not_covered_map(report)
 	keys := sort([line | some line, _ in object.union(cm, ncm)])
@@ -38,15 +39,15 @@ lines(report) = lines if {
 	]
 }
 
-to_value(cm, _, line) = 1 if {
+to_value(cm, _, line) := 1 if {
 	cm[line]
 }
 
-to_value(_, ncm, line) = 0 if {
+to_value(_, ncm, line) := 0 if {
 	ncm[line]
 }
 
-to_value(cm, ncm, line) = null if {
+to_value(cm, ncm, line) := null if {
 	not cm[line]
 	not ncm[line]
 }

--- a/policy/build_task/labels_test.rego
+++ b/policy/build_task/labels_test.rego
@@ -1,20 +1,22 @@
-package policy.build_task.labels
+package policy.build_task.labels_test
 
 import data.lib
+import data.policy.build_task.labels
 
 test_build_label_found {
-	lib.assert_empty(deny) with input as {"metadata": {"labels": {"build.appstudio.redhat.com/build_type": "docker"}}}
+	# regal ignore:line-length
+	lib.assert_empty(labels.deny) with input as {"metadata": {"labels": {"build.appstudio.redhat.com/build_type": "docker"}}}
 }
 
 test_build_label_not_found {
-	lib.assert_equal_results(deny, {{
+	lib.assert_equal_results(labels.deny, {{
 		"code": "labels.build_type_label_set",
 		"msg": "The required build label 'build.appstudio.redhat.com/build_type' is missing",
 	}}) with input as {"metadata": {"labels": {"bad": "docker"}}}
 }
 
 test_no_labels {
-	lib.assert_equal_results(deny, {{
+	lib.assert_equal_results(labels.deny, {{
 		"code": "labels.build_task_has_label",
 		"msg": "The task definition does not include any labels",
 	}}) with input as {"metadata": {"name": "no_labels"}}

--- a/policy/lib/array_helpers.rego
+++ b/policy/lib/array_helpers.rego
@@ -8,7 +8,7 @@ _max_int := 9223372036854775807
 # native comparison in Rego if both left and right are of the same type, or by
 # comparing their numerical values if they're not. Undefined values are always
 # less or equal to any other value.
-le(left, right) = is_le {
+le(left, right) := is_le {
 	type_name(left) == type_name(right)
 	is_le := left <= right
 } else = is_le {
@@ -18,7 +18,7 @@ le(left, right) = is_le {
 # Calculates the rank of an object by given key within an array ary. That is,
 # returns number of elements `o` of ary that have `o[key]` less than `obj[key]`
 # for a given object `obj`.
-rank(obj, key, ary) = count(less_or_eq) {
+rank(obj, key, ary) := count(less_or_eq) {
 	less_or_eq := [o |
 		some o in ary
 		left := object.get(o, key, _max_int)
@@ -30,7 +30,7 @@ rank(obj, key, ary) = count(less_or_eq) {
 # Sorts elements of the array of objects by the the specified key in ascending
 # order. Performs a # N x (N-1) search of an element of `ary` that has the rank
 # corresponding to the indexing variable 1..N.
-sort_by(key, ary) = [sorted |
+sort_by(key, ary) := [sorted |
 	some i in numbers.range(1, count(ary))
 
 	ranked := [o |
@@ -40,5 +40,5 @@ sort_by(key, ary) = [sorted |
 	]
 
 	count(ranked) > 0 # skip gaps in ranking that happen when two or more objects have the same rank
-	sorted := ranked[_] # flatten any objects with the same rank
+	some sorted in ranked # flatten any objects with the same rank
 ]

--- a/policy/lib/array_helpers_test.rego
+++ b/policy/lib/array_helpers_test.rego
@@ -1,43 +1,56 @@
-package lib.arrays
+package lib.arrays_test
 
 import data.lib
+import data.lib.arrays
 
 ary := [{"x": 1, "z": "X"}, {"x": 2}, {"x": 6, "y": "B"}, {"x": 1, "z": "X"}, {"x": -1}]
 
 test_rank {
-	lib.assert_equal(4, rank({"x": 4, "y": "A"}, "x", ary))
-	lib.assert_equal(1, rank({"x": -1}, "x", ary))
-	lib.assert_equal(0, rank({"x": -2}, "x", ary))
-	lib.assert_equal(5, rank({"x": 7}, "x", ary))
-	lib.assert_equal(count(ary), rank({}, "x", ary))
-	lib.assert_equal(count(ary), rank({}, "w", ary))
+	lib.assert_equal(4, arrays.rank({"x": 4, "y": "A"}, "x", ary))
+	lib.assert_equal(1, arrays.rank({"x": -1}, "x", ary))
+	lib.assert_equal(0, arrays.rank({"x": -2}, "x", ary))
+	lib.assert_equal(5, arrays.rank({"x": 7}, "x", ary))
+	lib.assert_equal(count(ary), arrays.rank({}, "x", ary))
+	lib.assert_equal(count(ary), arrays.rank({}, "w", ary))
 }
 
 test_sort_by {
-	lib.assert_equal([{"x": -1}, {"x": 1, "z": "X"}, {"x": 1, "z": "X"}, {"x": 2}, {"x": 6, "y": "B"}], sort_by("x", ary))
-	lib.assert_equal([{"x": 6, "y": "B"}, {"x": 1, "z": "X"}, {"x": 2}, {"x": 1, "z": "X"}, {"x": -1}], sort_by("y", ary))
+	lib.assert_equal(
+		[
+			{"x": -1},
+			{"x": 1, "z": "X"}, {"x": 1, "z": "X"}, {"x": 2}, {"x": 6, "y": "B"},
+		],
+		arrays.sort_by("x", ary),
+	)
+	lib.assert_equal(
+		[
+			{"x": 6, "y": "B"},
+			{"x": 1, "z": "X"}, {"x": 2}, {"x": 1, "z": "X"}, {"x": -1},
+		],
+		arrays.sort_by("y", ary),
+	)
 }
 
 test_sort_by_mixed_types {
-	lib.assert_equal([{"x": 0}, {"x": "1"}, {"x": 2.0}], sort_by("x", [{"x": "1"}, {"x": 0}, {"x": 2.0}]))
+	lib.assert_equal([{"x": 0}, {"x": "1"}, {"x": 2.0}], arrays.sort_by("x", [{"x": "1"}, {"x": 0}, {"x": 2.0}]))
 }
 
 test_le {
-	le(0, 0)
-	le("A", "A")
-	le(1, "1")
-	le("2", 2)
-	le(3.0, 3.0)
-	le("4.0", 4.0)
-	le(5.0, "5.0")
+	arrays.le(0, 0)
+	arrays.le("A", "A")
+	arrays.le(1, "1")
+	arrays.le("2", 2)
+	arrays.le(3.0, 3.0)
+	arrays.le("4.0", 4.0)
+	arrays.le(5.0, "5.0")
 
-	le(0, 1)
-	le("A", "B")
-	le("0", 1)
-	le(0, "1")
+	arrays.le(0, 1)
+	arrays.le("A", "B")
+	arrays.le("0", 1)
+	arrays.le(0, "1")
 
-	not le(1, 0)
-	not le("B", "A")
-	not le(1, "0")
-	not le("1", 0)
+	not arrays.le(1, 0)
+	not arrays.le("B", "A")
+	not arrays.le(1, "0")
+	not arrays.le("1", 0)
 }

--- a/policy/lib/assertions.rego
+++ b/policy/lib/assertions.rego
@@ -44,16 +44,26 @@ _assert_not_empty_fails(value) {
 }
 
 _assert_output_two_values(assert_type, left_value, right_value) {
-	debug_output := sprintf("Assert %s failure:\n  Left value:  %s\n  Right value: %s", [assert_type, left_value, right_value])
+	debug_output := sprintf("Assert %s failure:\n  Left value:  %s\n  Right value: %s", [
+		assert_type,
+		left_value, right_value,
+	])
 
 	# Use trace to show debug output in query explanations and print for stdout
+	# regal ignore:print-or-trace-call
 	trace(debug_output)
+
+	# regal ignore:print-or-trace-call
 	print(debug_output)
 }
 
 _assert_output_one_value(assert_type, value) {
 	debug_output := sprintf("Assert %s failure:\n  Value: %s", [assert_type, value])
+
+	# regal ignore:print-or-trace-call
 	trace(debug_output)
+
+	# regal ignore:print-or-trace-call
 	print(debug_output)
 }
 

--- a/policy/lib/assertions_test.rego
+++ b/policy/lib/assertions_test.rego
@@ -1,97 +1,99 @@
-package lib
+package lib_test
+
+import data.lib
 
 test_assert_equal {
-	assert_equal("a", "a")
-	assert_equal({"a": 10}, {"a": 10})
-	assert_equal(["a"], ["a"])
-	assert_equal({"a"}, {"a"})
-	not assert_equal("a", "b")
-	not assert_equal({"a": 10}, {"a", 11})
-	not assert_equal(["a"], ["b"])
-	not assert_equal({"a"}, {"b"})
+	lib.assert_equal("a", "a")
+	lib.assert_equal({"a": 10}, {"a": 10})
+	lib.assert_equal(["a"], ["a"])
+	lib.assert_equal({"a"}, {"a"})
+	not lib.assert_equal("a", "b")
+	not lib.assert_equal({"a": 10}, {"a", 11})
+	not lib.assert_equal(["a"], ["b"])
+	not lib.assert_equal({"a"}, {"b"})
 }
 
 test_assert_not_equal {
-	assert_not_equal("a", "b")
-	assert_not_equal({"a": 10}, {"a", 11})
-	assert_not_equal(["a"], ["b"])
-	assert_not_equal({"a"}, {"b"})
-	not assert_not_equal("a", "a")
-	not assert_not_equal({"a": 10}, {"a": 10})
-	not assert_not_equal(["a"], ["a"])
-	not assert_not_equal({"a"}, {"a"})
+	lib.assert_not_equal("a", "b")
+	lib.assert_not_equal({"a": 10}, {"a", 11})
+	lib.assert_not_equal(["a"], ["b"])
+	lib.assert_not_equal({"a"}, {"b"})
+	not lib.assert_not_equal("a", "a")
+	not lib.assert_not_equal({"a": 10}, {"a": 10})
+	not lib.assert_not_equal(["a"], ["a"])
+	not lib.assert_not_equal({"a"}, {"a"})
 }
 
 test_assert_empty {
-	assert_empty([])
-	assert_empty({})
-	assert_empty(set())
-	not assert_empty(["a"])
-	not assert_empty({"a"})
-	not assert_empty({"a": "b"})
+	lib.assert_empty([])
+	lib.assert_empty({})
+	lib.assert_empty(set())
+	not lib.assert_empty(["a"])
+	not lib.assert_empty({"a"})
+	not lib.assert_empty({"a": "b"})
 }
 
 test_assert_not_empty {
-	assert_not_empty(["a"])
-	assert_not_empty({"a"})
-	assert_not_empty({"a": "b"})
-	not assert_not_empty([])
-	not assert_not_empty({})
-	not assert_not_empty(set())
+	lib.assert_not_empty(["a"])
+	lib.assert_not_empty({"a"})
+	lib.assert_not_empty({"a": "b"})
+	not lib.assert_not_empty([])
+	not lib.assert_not_empty({})
+	not lib.assert_not_empty(set())
 }
 
 test_assert_equal_results {
 	# Empty results
-	assert_equal_results(set(), set())
-	assert_equal_results({{}}, {{}})
+	lib.assert_equal_results(set(), set())
+	lib.assert_equal_results({{}}, {{}})
 
 	# collections attribute is ignored
-	assert_equal_results({{"collections": ["a", "b"]}}, {{}})
-	assert_equal_results({{}}, {{"collections": ["a", "b"]}})
-	assert_equal_results({{"collections": ["a", "b"]}}, {{"collections": ["c", "d"]}})
-	assert_equal_results(
+	lib.assert_equal_results({{"collections": ["a", "b"]}}, {{}})
+	lib.assert_equal_results({{}}, {{"collections": ["a", "b"]}})
+	lib.assert_equal_results({{"collections": ["a", "b"]}}, {{"collections": ["c", "d"]}})
+	lib.assert_equal_results(
 		{{"spam": "maps", "collections": ["a", "b"]}},
 		{{"spam": "maps", "collections": ["c", "d"]}},
 	)
 
 	# effective_on attribute is ignored
-	assert_equal_results({{"effective_on": "2022-01-01T00:00:00Z"}}, {{}})
-	assert_equal_results({{}}, {{"effective_on": "2022-01-01T00:00:00Z"}})
-	assert_equal_results(
+	lib.assert_equal_results({{"effective_on": "2022-01-01T00:00:00Z"}}, {{}})
+	lib.assert_equal_results({{}}, {{"effective_on": "2022-01-01T00:00:00Z"}})
+	lib.assert_equal_results(
 		{{"effective_on": "2022-01-01T00:00:00Z"}},
 		{{"effective_on": "1970-01-01T00:00:00Z"}},
 	)
-	assert_equal_results(
+	lib.assert_equal_results(
 		{{"spam": "maps", "effective_on": "2022-01-01T00:00:00Z"}},
 		{{"spam": "maps", "effective_on": "1970-01-01T00:00:00Z"}},
 	)
 
 	# both collections and effective_on attributes are ignored
-	assert_equal_results(
+	lib.assert_equal_results(
 		{{"spam": "maps", "collections": ["a", "b"], "effective_on": "2022-01-01T00:00:00Z"}},
 		{{"spam": "maps", "collections": ["c", "d"], "effective_on": "1970-01-01T00:00:00Z"}},
 	)
 
 	# any other attribute is not ignored
-	not assert_equal_results(
+	not lib.assert_equal_results(
 		{{"spam": "maps", "collections": ["a", "b"], "effective_on": "2022-01-01T00:00:00Z"}},
 		{{"collections": ["c", "d"], "effective_on": "1970-01-01T00:00:00Z"}},
 	)
 
 	# missing attributes in one result is not ignored
-	not assert_equal_results(
+	not lib.assert_equal_results(
 		{{"spam": "SPAM", "collections": ["a", "b"], "effective_on": "2022-01-01T00:00:00Z"}},
 		{{"collections": ["c", "d"], "effective_on": "1970-01-01T00:00:00Z"}},
 	)
-	not assert_equal_results(
+	not lib.assert_equal_results(
 		{{"collections": ["c", "d"], "effective_on": "1970-01-01T00:00:00Z"}},
 		{{"spam": "SPAM", "collections": ["a", "b"], "effective_on": "2022-01-01T00:00:00Z"}},
 	)
 
 	# fallback for unexpected types
-	assert_equal_results({"spam", "maps"}, {"spam", "maps"})
-	not assert_equal_results({"spam", "maps"}, "spam")
-	not assert_equal_results(
+	lib.assert_equal_results({"spam", "maps"}, {"spam", "maps"})
+	not lib.assert_equal_results({"spam", "maps"}, "spam")
+	not lib.assert_equal_results(
 		# These are "objects" instead of the expected "set of objects"
 		{"spam": "maps", "collections": ["a", "b"], "effective_on": "2022-01-01T00:00:00Z"},
 		{"spam": "maps", "collections": ["c", "d"], "effective_on": "1970-01-01T00:00:00Z"},

--- a/policy/lib/bundles_test.rego
+++ b/policy/lib/bundles_test.rego
@@ -1,6 +1,9 @@
-package lib.bundles
+package lib.bundles_test
+
+import future.keywords.in
 
 import data.lib
+import data.lib.bundles
 
 # used as reference bundle data in tests
 bundle_data := {"registry.img/acceptable": [{
@@ -18,8 +21,8 @@ test_disallowed_task_reference {
 		{"name": "my-task-2", "ref": {}},
 	]
 
-	expected := {task | task := tasks[_]}
-	lib.assert_equal(disallowed_task_reference(tasks), expected)
+	expected := {task | some task in tasks}
+	lib.assert_equal(bundles.disallowed_task_reference(tasks), expected)
 }
 
 test_empty_task_bundle_reference {
@@ -28,8 +31,8 @@ test_empty_task_bundle_reference {
 		{"name": "my-task-2", "ref": {"bundle": ""}},
 	]
 
-	expected := {task | task := tasks[_]}
-	lib.assert_equal(empty_task_bundle_reference(tasks), expected)
+	expected := {task | some task in tasks}
+	lib.assert_equal(bundles.empty_task_bundle_reference(tasks), expected)
 }
 
 test_unpinned_task_bundle {
@@ -44,8 +47,8 @@ test_unpinned_task_bundle {
 		},
 	]
 
-	expected := {task | task := tasks[_]}
-	lib.assert_equal(unpinned_task_bundle(tasks), expected)
+	expected := {task | some task in tasks}
+	lib.assert_equal(bundles.unpinned_task_bundle(tasks), expected)
 }
 
 # All good when the most recent bundle is used.
@@ -55,11 +58,11 @@ test_acceptable_bundle {
 		{"name": "my-task-2", "ref": {"bundle": "reg.com/repo@sha256:abc"}},
 	]
 
-	lib.assert_empty(disallowed_task_reference(tasks)) with data["task-bundles"] as task_bundles
-	lib.assert_empty(empty_task_bundle_reference(tasks)) with data["task-bundles"] as task_bundles
-	lib.assert_empty(unpinned_task_bundle(tasks)) with data["task-bundles"] as task_bundles
-	lib.assert_empty(out_of_date_task_bundle(tasks)) with data["task-bundles"] as task_bundles
-	lib.assert_empty(unacceptable_task_bundle(tasks)) with data["task-bundles"] as task_bundles
+	lib.assert_empty(bundles.disallowed_task_reference(tasks)) with data["task-bundles"] as task_bundles
+	lib.assert_empty(bundles.empty_task_bundle_reference(tasks)) with data["task-bundles"] as task_bundles
+	lib.assert_empty(bundles.unpinned_task_bundle(tasks)) with data["task-bundles"] as task_bundles
+	lib.assert_empty(bundles.out_of_date_task_bundle(tasks)) with data["task-bundles"] as task_bundles
+	lib.assert_empty(bundles.unacceptable_task_bundle(tasks)) with data["task-bundles"] as task_bundles
 }
 
 test_out_of_date_task_bundle {
@@ -70,8 +73,8 @@ test_out_of_date_task_bundle {
 		{"name": "my-task-4", "ref": {"bundle": "reg.com/repo@sha256:cde"}},
 	]
 
-	expected := {task | task := tasks[_]}
-	lib.assert_equal(out_of_date_task_bundle(tasks), expected) with data["task-bundles"] as task_bundles
+	expected := {task | some task in tasks}
+	lib.assert_equal(bundles.out_of_date_task_bundle(tasks), expected) with data["task-bundles"] as task_bundles
 }
 
 test_unacceptable_task_bundles {
@@ -80,33 +83,33 @@ test_unacceptable_task_bundles {
 		{"name": "my-task-2", "ref": {"bundle": "reg.com/repo@sha256:def"}},
 	]
 
-	expected := {task | task := tasks[_]}
-	lib.assert_equal(unacceptable_task_bundle(tasks), expected) with data["task-bundles"] as task_bundles
+	expected := {task | some task in tasks}
+	lib.assert_equal(bundles.unacceptable_task_bundle(tasks), expected) with data["task-bundles"] as task_bundles
 }
 
 test_is_equal {
 	record := {"digest": "sha256:abc", "tag": "spam"}
 
 	# Exact match
-	lib.assert_equal(is_equal(record, {"digest": "sha256:abc", "tag": "spam"}), true)
+	lib.assert_equal(bundles.is_equal(record, {"digest": "sha256:abc", "tag": "spam"}), true)
 
 	# Tag is ignored if digest matches
-	lib.assert_equal(is_equal(record, {"digest": "sha256:abc", "tag": "not-spam"}), true)
+	lib.assert_equal(bundles.is_equal(record, {"digest": "sha256:abc", "tag": "not-spam"}), true)
 
 	# Tag is not required
-	lib.assert_equal(is_equal(record, {"digest": "sha256:abc", "tag": ""}), true)
+	lib.assert_equal(bundles.is_equal(record, {"digest": "sha256:abc", "tag": ""}), true)
 
 	# When digest is missing on ref, compare tag
-	lib.assert_equal(is_equal(record, {"digest": "", "tag": "spam"}), true)
+	lib.assert_equal(bundles.is_equal(record, {"digest": "", "tag": "spam"}), true)
 
 	# If digest does not match, tag is still ignored
-	lib.assert_equal(is_equal(record, {"digest": "sha256:bcd", "tag": "spam"}), false)
+	lib.assert_equal(bundles.is_equal(record, {"digest": "sha256:bcd", "tag": "spam"}), false)
 
 	# No match is honored when digest is missing
-	lib.assert_equal(is_equal(record, {"digest": "", "tag": "not-spam"}), false)
+	lib.assert_equal(bundles.is_equal(record, {"digest": "", "tag": "not-spam"}), false)
 }
 
-task_bundles = {"reg.com/repo": [
+task_bundles := {"reg.com/repo": [
 	{
 		"digest": "sha256:abc", # Allow
 		"tag": "903d49a833d22f359bce3d67b15b006e1197bae5",
@@ -130,14 +133,14 @@ task_bundles = {"reg.com/repo": [
 ]}
 
 test_acceptable_bundle_is_acceptable {
-	is_acceptable(acceptable_bundle_ref) with data["task-bundles"] as bundle_data
+	bundles.is_acceptable(acceptable_bundle_ref) with data["task-bundles"] as bundle_data
 }
 
 test_unacceptable_bundle_is_unacceptable {
-	not is_acceptable("registry.img/unacceptable@sha256:digest") with data["task-bundles"] as bundle_data
+	not bundles.is_acceptable("registry.img/unacceptable@sha256:digest") with data["task-bundles"] as bundle_data
 }
 
 test_missing_required_data {
-	lib.assert_equal(missing_task_bundles_data, false) with data["task-bundles"] as task_bundles
-	lib.assert_equal(missing_task_bundles_data, true) with data["task-bundles"] as []
+	lib.assert_equal(bundles.missing_task_bundles_data, false) with data["task-bundles"] as task_bundles
+	lib.assert_equal(bundles.missing_task_bundles_data, true) with data["task-bundles"] as []
 }

--- a/policy/lib/image.rego
+++ b/policy/lib/image.rego
@@ -2,7 +2,7 @@ package lib.image
 
 # parse returns a data structure representing the different portions
 # of the OCI image reference.
-parse(ref) = d {
+parse(ref) := d {
 	digest_parts := split(ref, "@")
 	digest := _get(digest_parts, 1, "")
 
@@ -29,7 +29,7 @@ parse(ref) = d {
 }
 
 # Formats the parsed reference as string
-str(d) = s1 {
+str(d) := s1 {
 	d.repo != ""
 	d.digest != ""
 	d.tag != ""
@@ -69,6 +69,6 @@ equal_ref(ref1, ref2) {
 	object.remove(img1, ["tag"]) == object.remove(img2, ["tag"])
 }
 
-_get(array, index, default_value) = value {
+_get(array, index, default_value) := value {
 	value := array[index]
 } else = default_value

--- a/policy/lib/image_test.rego
+++ b/policy/lib/image_test.rego
@@ -1,6 +1,7 @@
-package lib.image
+package lib.image_test
 
 import data.lib
+import data.lib.image
 
 test_parse {
 	repository := "registry.com/re/po"
@@ -9,58 +10,61 @@ test_parse {
 	digest := "sha256:01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"
 
 	lib.assert_equal(
-		parse(concat("", [repository, ":", tag, "@", digest])),
+		image.parse(concat("", [repository, ":", tag, "@", digest])),
 		{"repo": repository, "tag": tag, "digest": digest},
 	)
 
 	lib.assert_equal(
-		parse(concat("", [repository, "@", digest])),
+		image.parse(concat("", [repository, "@", digest])),
 		{"repo": repository, "tag": "", "digest": digest},
 	)
 
 	lib.assert_equal(
-		parse(concat("", [repository, ":", tag])),
+		image.parse(concat("", [repository, ":", tag])),
 		{"repo": repository, "tag": tag, "digest": ""},
 	)
 
 	lib.assert_equal(
-		parse(concat("", [repository_with_port, ":", tag, "@", digest])),
+		image.parse(concat("", [repository_with_port, ":", tag, "@", digest])),
 		{"repo": repository_with_port, "tag": tag, "digest": digest},
 	)
 
 	lib.assert_equal(
-		parse(concat("", [repository_with_port, "@", digest])),
+		image.parse(concat("", [repository_with_port, "@", digest])),
 		{"repo": repository_with_port, "tag": "", "digest": digest},
 	)
 
 	lib.assert_equal(
-		parse(concat("", [repository_with_port, ":", tag])),
+		image.parse(concat("", [repository_with_port, ":", tag])),
 		{"repo": repository_with_port, "tag": tag, "digest": ""},
 	)
 }
 
 test_equal {
-	equal_ref("registry.com/re/po", "registry.com/re/po")
-	equal_ref("registry.com/re/po:tag", "registry.com/re/po:tag")
-	equal_ref("registry.com/re/po:tag@digest", "registry.com/re/po:tag@digest")
-	equal_ref("registry.com/re/po:different@digest", "registry.com/re/po:tag@digest")
-	equal_ref("registry.com/re/po@digest", "registry.com/re/po:tag@digest")
-	equal_ref("registry.com/re/po:tag@digest", "registry.com/re/po@digest")
-	not equal_ref("registry.com/re/po", "different.com/re/po")
-	not equal_ref("registry.com/different/po", "registry.com/re/po")
-	not equal_ref("registry.com/re/different", "registry.com/re/po")
-	not equal_ref("registry.com/re/po:different", "registry.com/re/po:tag")
-	not equal_ref("registry.com/re/po:tag@different", "registry.com/re/po:tag@digest")
-	not equal_ref("registry.com/re/po@different", "registry.com/re/po:tag@digest")
-	not equal_ref("registry.com/re/po:tag@different", "registry.com/re/po@digest")
-	not equal_ref("registry.com/re/po@different", "registry.com/re/po@digest")
-	not equal_ref("registry.com/re/po@digest", "different.com/re/po@digest")
-	not equal_ref("registry.com/re/po@digest", "registry.com/different/po@digest")
-	not equal_ref("registry.com/re/po@digest", "registry.com/re/different@digest")
+	image.equal_ref("registry.com/re/po", "registry.com/re/po")
+	image.equal_ref("registry.com/re/po:tag", "registry.com/re/po:tag")
+	image.equal_ref("registry.com/re/po:tag@digest", "registry.com/re/po:tag@digest")
+	image.equal_ref("registry.com/re/po:different@digest", "registry.com/re/po:tag@digest")
+	image.equal_ref("registry.com/re/po@digest", "registry.com/re/po:tag@digest")
+	image.equal_ref("registry.com/re/po:tag@digest", "registry.com/re/po@digest")
+	not image.equal_ref("registry.com/re/po", "different.com/re/po")
+	not image.equal_ref("registry.com/different/po", "registry.com/re/po")
+	not image.equal_ref("registry.com/re/different", "registry.com/re/po")
+	not image.equal_ref("registry.com/re/po:different", "registry.com/re/po:tag")
+	not image.equal_ref("registry.com/re/po:tag@different", "registry.com/re/po:tag@digest")
+	not image.equal_ref("registry.com/re/po@different", "registry.com/re/po:tag@digest")
+	not image.equal_ref("registry.com/re/po:tag@different", "registry.com/re/po@digest")
+	not image.equal_ref("registry.com/re/po@different", "registry.com/re/po@digest")
+	not image.equal_ref("registry.com/re/po@digest", "different.com/re/po@digest")
+	not image.equal_ref("registry.com/re/po@digest", "registry.com/different/po@digest")
+	not image.equal_ref("registry.com/re/po@digest", "registry.com/re/different@digest")
 }
 
 test_str {
-	lib.assert_equal("registry.io/repository:tag@digest", str({"repo": "registry.io/repository", "tag": "tag", "digest": "digest"}))
-	lib.assert_equal("registry.io/repository:tag", str({"repo": "registry.io/repository", "tag": "tag"}))
-	lib.assert_equal("registry.io/repository@digest", str({"repo": "registry.io/repository", "digest": "digest"}))
+	lib.assert_equal(
+		"registry.io/repository:tag@digest",
+		image.str({"repo": "registry.io/repository", "tag": "tag", "digest": "digest"}),
+	)
+	lib.assert_equal("registry.io/repository:tag", image.str({"repo": "registry.io/repository", "tag": "tag"}))
+	lib.assert_equal("registry.io/repository@digest", image.str({"repo": "registry.io/repository", "digest": "digest"}))
 }

--- a/policy/lib/refs.rego
+++ b/policy/lib/refs.rego
@@ -12,7 +12,7 @@ import future.keywords.in
 # gives precedence to the old-style. Further, Tekton falls back to the local resolver if
 # a bundle is not used in neither format. The "else" usage in this function ensures the
 # same precendence order is honored.
-task_ref(task) = i {
+task_ref(task) := i {
 	# Handle old-style bundle reference
 	r := _ref(task)
 	i := {
@@ -46,13 +46,13 @@ task_ref(task) = i {
 	}
 }
 
-_param(taskRef, name, fallback) = value {
+_param(taskRef, name, fallback) := value {
 	some param in taskRef.params
 	param.name == name
 	value := param.value
 } else = fallback
 
-_ref(task) = r {
+_ref(task) := r {
 	# Reference from within a PipelineRun attestation
 	r := task.ref
 } else = r {

--- a/policy/lib/refs_test.rego
+++ b/policy/lib/refs_test.rego
@@ -1,12 +1,13 @@
-package lib.refs
+package lib.refs_test
 
 import data.lib
+import data.lib.refs
 
 test_bundle_in_pipelinerun {
 	image := "registry.img/test@sha256:digest"
 	ref := {"ref": {"bundle": image, "kind": "Task", "name": "test"}}
 	info := {"bundle": image, "kind": "task", "name": "test"}
-	lib.assert_equal(task_ref(ref), info)
+	lib.assert_equal(refs.task_ref(ref), info)
 }
 
 test_bundle_resolver_in_pipelinerun {
@@ -21,14 +22,14 @@ test_bundle_resolver_in_pipelinerun {
 	}}
 
 	info := {"bundle": image, "kind": "task", "name": "test"}
-	lib.assert_equal(task_ref(ref), info)
+	lib.assert_equal(refs.task_ref(ref), info)
 }
 
 test_bundle_in_pipeline {
 	image := "registry.img/test@sha256:digest"
 	ref := {"taskRef": {"bundle": image, "name": "test", "kind": "Task"}}
 	info := {"bundle": image, "kind": "task", "name": "test"}
-	lib.assert_equal(task_ref(ref), info)
+	lib.assert_equal(refs.task_ref(ref), info)
 }
 
 test_bundle_resolver_in_pipeline {
@@ -43,14 +44,14 @@ test_bundle_resolver_in_pipeline {
 	}}
 
 	info := {"bundle": image, "kind": "task", "name": "test"}
-	lib.assert_equal(task_ref(ref), info)
+	lib.assert_equal(refs.task_ref(ref), info)
 }
 
 test_bundle_in_pipelinerun_with_defaults {
 	image := "registry.img/test@sha256:digest"
 	ref := {"ref": {"bundle": image}}
 	info := {"bundle": image, "kind": "task", "name": ""}
-	lib.assert_equal(task_ref(ref), info)
+	lib.assert_equal(refs.task_ref(ref), info)
 }
 
 test_bundle_resolver_in_pipelinerun_with_defaults {
@@ -61,13 +62,13 @@ test_bundle_resolver_in_pipelinerun_with_defaults {
 	}}
 
 	info := {"bundle": image, "kind": "task", "name": ""}
-	lib.assert_equal(task_ref(ref), info)
+	lib.assert_equal(refs.task_ref(ref), info)
 }
 
 test_slsav1_local_ref {
 	ref := {"spec": {"taskRef": {"name": "task-name", "kind": "Task"}}}
 	info := {"kind": "task", "name": "task-name"}
-	lib.assert_equal(task_ref(ref), info)
+	lib.assert_equal(refs.task_ref(ref), info)
 }
 
 test_git_resolver_in_slsav1_pipelinerun {
@@ -89,6 +90,9 @@ test_git_resolver_in_slsav1_pipelinerun {
 			},
 		],
 	}}}
-	info := {"url": "https://github.com/enterprise-contract/hacbs-docker-build.git", "revision": "main", "pathInRepo": "pipelines/git-clone.yaml"}
-	lib.assert_equal(task_ref(ref), info)
+	info := {
+		"url": "https://github.com/enterprise-contract/hacbs-docker-build.git",
+		"revision": "main", "pathInRepo": "pipelines/git-clone.yaml",
+	}
+	lib.assert_equal(refs.task_ref(ref), info)
 }

--- a/policy/lib/result_helper.rego
+++ b/policy/lib/result_helper.rego
@@ -9,16 +9,15 @@ result_helper(chain, failure_sprintf_params) := result {
 	result := _basic_result(chain, failure_sprintf_params)
 }
 
-result_helper_with_term(chain, failure_sprintf_params, term) := result {
-	result := object.union(result_helper(chain, failure_sprintf_params), {"term": term})
-}
+result_helper_with_term(chain, failure_sprintf_params, term) := object.union(
+	result_helper(chain, failure_sprintf_params),
+	{"term": term},
+)
 
-_basic_result(chain, failure_sprintf_params) := result {
-	result := {
-		"code": _code(chain),
-		"msg": sprintf(_rule_annotations(chain).custom.failure_msg, failure_sprintf_params),
-		"effective_on": time_lib.when(chain),
-	}
+_basic_result(chain, failure_sprintf_params) := {
+	"code": _code(chain),
+	"msg": sprintf(_rule_annotations(chain).custom.failure_msg, failure_sprintf_params),
+	"effective_on": time_lib.when(chain),
 }
 
 _code(chain) := code {
@@ -28,9 +27,7 @@ _code(chain) := code {
 	code := sprintf("%s.%s", [pkg_name, rule_name])
 }
 
-_rule_annotations(chain) := annotations {
-	# The first entry in the chain always points to the active rule, even if it has
-	# no declared annotations (in which case the annotations member is not present).
-	# Thus, result_helper assumes every rule defines annotations.
-	annotations := chain[0].annotations
-}
+# The first entry in the chain always points to the active rule, even if it has
+# no declared annotations (in which case the annotations member is not present).
+# Thus, result_helper assumes every rule defines annotations.
+_rule_annotations(chain) := chain[0].annotations

--- a/policy/lib/result_helper_test.rego
+++ b/policy/lib/result_helper_test.rego
@@ -1,4 +1,4 @@
-package lib
+package lib_test
 
 import data.lib
 
@@ -19,7 +19,7 @@ test_result_helper {
 		{"annotations": {}, "path": ["ignored", "oh"]},
 	]
 
-	lib.assert_equal(expected_result, result_helper(chain, ["foo"]))
+	lib.assert_equal(expected_result, lib.result_helper(chain, ["foo"]))
 }
 
 test_result_helper_with_collections {
@@ -41,7 +41,7 @@ test_result_helper_with_collections {
 		{"annotations": {}, "path": ["ignored", "oh"]},
 	]
 
-	lib.assert_equal(expected, result_helper(chain, ["foo"]))
+	lib.assert_equal(expected, lib.result_helper(chain, ["foo"]))
 }
 
 test_result_helper_with_term {
@@ -62,5 +62,5 @@ test_result_helper_with_term {
 		{"annotations": {}, "path": ["ignored", "oh"]},
 	]
 
-	lib.assert_equal(expected, result_helper_with_term(chain, ["foo"], "ola"))
+	lib.assert_equal(expected, lib.result_helper_with_term(chain, ["foo"], "ola"))
 }

--- a/policy/lib/rule_data.rego
+++ b/policy/lib/rule_data.rego
@@ -40,7 +40,31 @@ rule_data_defaults := {
 	# Used in policy/release/slsa_source_correlated.rego
 	# Supported digests in DigestSet of SLSA Provenance v1.0
 	# See https://github.com/in-toto/attestation/blob/main/spec/v1/digest_set.md
-	"supported_digests": ["sha256", "sha224", "sha384", "sha512", "sha512_224", "sha512_256", "sha3_224", "sha3_256", "sha3_384", "sha3_512", "shake128", "shake256", "blake2b", "blake2s", "ripemd160", "sm3", "gost", "sha1", "md5", "gitCommit", "gitTree", "gitBlob", "gitTag"],
+	"supported_digests": [
+		"sha256",
+		"sha224",
+		"sha384",
+		"sha512",
+		"sha512_224",
+		"sha512_256",
+		"sha3_224",
+		"sha3_256",
+		"sha3_384",
+		"sha3_512",
+		"shake128",
+		"shake256",
+		"blake2b",
+		"blake2s",
+		"ripemd160",
+		"sm3",
+		"gost",
+		"sha1",
+		"md5",
+		"gitCommit",
+		"gitTree",
+		"gitBlob",
+		"gitTag",
+	],
 }
 
 # Returns the "first found" of the following:

--- a/policy/lib/rule_data_test.rego
+++ b/policy/lib/rule_data_test.rego
@@ -1,4 +1,4 @@
-package lib
+package lib_test
 
 import data.lib
 

--- a/policy/lib/set_helpers.rego
+++ b/policy/lib/set_helpers.rego
@@ -5,7 +5,7 @@ import future.keywords.in
 # It's fairly idiomatic rego to just write this inline but still
 # I think this makes things a little more readable
 #
-to_set(arr) := {member | member := arr[_]}
+to_set(arr) := {member | some member in arr}
 
 # Without the in keyword it could be done like this:
 #  needle == haystack[_]

--- a/policy/lib/set_helpers_test.rego
+++ b/policy/lib/set_helpers_test.rego
@@ -1,4 +1,4 @@
-package lib
+package lib_test
 
 import data.lib
 
@@ -7,37 +7,37 @@ my_list := ["a", "b", "c"]
 my_set := {"a", "b", "c"}
 
 test_to_set {
-	lib.assert_equal(my_set, to_set(my_list))
-	lib.assert_equal(my_set, to_set(my_set))
+	lib.assert_equal(my_set, lib.to_set(my_list))
+	lib.assert_equal(my_set, lib.to_set(my_set))
 }
 
 test_included_in {
-	included_in("a", my_list)
-	included_in("a", my_set)
-	not included_in("z", my_list)
-	not included_in("z", my_set)
+	lib.included_in("a", my_list)
+	lib.included_in("a", my_set)
+	not lib.included_in("z", my_list)
+	not lib.included_in("z", my_set)
 }
 
 test_any_included_in {
-	any_included_in(["a", "z"], my_list)
-	any_included_in(["a", "z"], my_set)
-	any_included_in({"a", "z"}, my_list)
-	any_included_in({"a", "z"}, my_set)
+	lib.any_included_in(["a", "z"], my_list)
+	lib.any_included_in(["a", "z"], my_set)
+	lib.any_included_in({"a", "z"}, my_list)
+	lib.any_included_in({"a", "z"}, my_set)
 
-	not any_included_in({"x", "z"}, my_set)
+	not lib.any_included_in({"x", "z"}, my_set)
 }
 
 test_all_included_in {
-	all_included_in({"a", "b"}, my_set)
-	not all_included_in({"a", "z"}, my_set)
+	lib.all_included_in({"a", "b"}, my_set)
+	not lib.all_included_in({"a", "z"}, my_set)
 }
 
 test_none_included_in {
-	none_included_in({"x", "z"}, my_set)
-	not none_included_in({"a", "z"}, my_set)
+	lib.none_included_in({"x", "z"}, my_set)
+	not lib.none_included_in({"a", "z"}, my_set)
 }
 
 test_any_not_included_in {
-	any_not_included_in({"a", "z"}, my_set)
-	not any_not_included_in({"a", "b"}, my_set)
+	lib.any_not_included_in({"a", "z"}, my_set)
+	not lib.any_not_included_in({"a", "b"}, my_set)
 }

--- a/policy/lib/string_utils.rego
+++ b/policy/lib/string_utils.rego
@@ -1,8 +1,10 @@
 package lib
 
-quoted_values_string(value_list) = result {
+import future.keywords.in
+
+quoted_values_string(value_list) := result {
 	quoted_list := [quoted_item |
-		item := value_list[_]
+		some item in value_list
 		quoted_item := sprintf("'%s'", [item])
 	]
 

--- a/policy/lib/string_utils_test.rego
+++ b/policy/lib/string_utils_test.rego
@@ -1,8 +1,8 @@
-package lib
+package lib_test
 
 import data.lib
 
 test_quoted_values_string {
-	lib.assert_equal("'a', 'b', 'c'", quoted_values_string(["a", "b", "c"]))
-	lib.assert_equal("'a', 'b', 'c'", quoted_values_string({"a", "b", "c"}))
+	lib.assert_equal("'a', 'b', 'c'", lib.quoted_values_string(["a", "b", "c"]))
+	lib.assert_equal("'a', 'b', 'c'", lib.quoted_values_string({"a", "b", "c"}))
 }

--- a/policy/lib/tekton/pipeline.rego
+++ b/policy/lib/tekton/pipeline.rego
@@ -35,6 +35,4 @@ pipeline_label_selector(pipeline, selector) := value if {
 	label == selector
 }
 
-pipeline_name := name if {
-	name := input.metadata.name
-}
+pipeline_name := input.metadata.name

--- a/policy/lib/tekton/task.rego
+++ b/policy/lib/tekton/task.rego
@@ -23,11 +23,9 @@ current_required_default_tasks contains task if {
 }
 
 # tasks returns the set of tasks found in the object.
-tasks(obj) := _tasks if {
-	_tasks := {task |
-		some task in _maybe_tasks(obj)
-		_slsa_task(task)
-	}
+tasks(obj) := {task |
+	some task in _maybe_tasks(obj)
+	_slsa_task(task)
 }
 
 # task from a slsav0.1 or slsav0.2 attestation
@@ -77,11 +75,9 @@ _slsav1_tekton(dep) if {
 # tasks_names returns the set of task names extracted from the
 # given object. It expands names to include the parameterized
 # form, see task_names.
-tasks_names(obj) := names if {
-	names := {name |
-		some task in tasks(obj)
-		some name in task_names(task)
-	}
+tasks_names(obj) := {name |
+	some task in tasks(obj)
+	some name in task_names(task)
 }
 
 # task_names returns the different names of the task. Additional
@@ -100,16 +96,12 @@ task_names(task) := names if {
 }
 
 # task name from a v0.1 and v0.2 attestation
-task_name(task) := name if {
-	name := refs.task_ref(task).name
-}
+task_name(task) := refs.task_ref(task).name
 
 # _task_params returns an object where keys are parameter names
 # and values are parameter values.
 # Handle parameters of a task from a PipelineRun attestation.
-_task_params(task) := params if {
-	params := task.invocation.parameters
-}
+_task_params(task) := task.invocation.parameters
 
 # Handle parameters of a task in a Pipeline definition.
 _task_params(task) := params if {
@@ -132,8 +124,10 @@ _task_params(task) := params if {
 }
 
 # task_param returns the value of the given parameter in the task.
-task_param(task, name) := value if {
-	value := _task_params(task)[name]
+task_param(task, name) := params if {
+	# without this we end up with https://docs.styra.com/regal/rules/bugs/top-level-iteration
+	# regal ignore:unconditional-assignment
+	params := _task_params(task)[name]
 }
 
 # task_result returns the value of the given result in the task.
@@ -167,7 +161,7 @@ git_clone_task(attestation) := task if {
 
 # task_data returns the data relating to the task. If the task is
 # referenced from a bundle, the "bundle" attribute is included.
-task_data(task) = info if {
+task_data(task) := info if {
 	r := refs.task_ref(task)
 	info := {"name": r.name, "bundle": r.bundle}
 } else := info if {
@@ -180,6 +174,4 @@ _key_value(obj, name) := value if {
 }
 
 # task_labels returns the key/value pair of task labels
-task_labels := labels if {
-	labels := input.metadata.labels
-}
+task_labels := input.metadata.labels

--- a/policy/lib/tekton/task_test.rego
+++ b/policy/lib/tekton/task_test.rego
@@ -1,18 +1,25 @@
-package lib.tkn
+package lib.tkn_test
 
 import future.keywords.if
 import future.keywords.in
 
 import data.lib
+import data.lib.tkn
 
 test_latest_required_tasks if {
 	expected := {t | some t in _expected_latest.tasks}
-	lib.assert_equal(expected, latest_required_default_tasks) with data["required-tasks"] as _time_based_required_tasks
+	lib.assert_equal(
+		expected,
+		tkn.latest_required_default_tasks,
+	) with data["required-tasks"] as _time_based_required_tasks
 }
 
 test_current_required_tasks if {
 	expected := {t | some t in _expected_current.tasks}
-	lib.assert_equal(expected, current_required_default_tasks) with data["required-tasks"] as _time_based_required_tasks
+	lib.assert_equal(
+		expected,
+		tkn.current_required_default_tasks,
+	) with data["required-tasks"] as _time_based_required_tasks
 }
 
 test_tasks_from_attestation if {
@@ -21,7 +28,7 @@ test_tasks_from_attestation if {
 
 	attestation := {"predicate": {"buildConfig": {"tasks": [git_clone, buildah]}}}
 	expected := {git_clone, buildah}
-	lib.assert_equal(expected, tasks(attestation))
+	lib.assert_equal(expected, tkn.tasks(attestation))
 }
 
 test_tasks_from_slsav1_tekton_attestation if {
@@ -41,8 +48,37 @@ test_tasks_from_slsav1_tekton_attestation if {
 			"resolvedDependencies": [task],
 		}},
 	}
-	expected := {{"params": [{"name": "IMAGE", "value": "quay.io/jstuart/hacbs-docker-build"}, {"name": "DOCKERFILE", "value": "./image_with_labels/Dockerfile"}], "podTemplate": {"imagePullSecrets": [{"name": "docker-chains"}], "securityContext": {"fsGroup": 65532}}, "serviceAccountName": "default", "taskRef": {"kind": "Task", "name": "buildah"}, "timeout": "1h0m0s", "workspaces": [{"name": "source", "persistentVolumeClaim": {"claimName": "pvc-bf2ed289ae"}}, {"name": "dockerconfig", "secret": {"secretName": "docker-credentials"}}]}}
-	lib.assert_equal(expected, tasks(attestation))
+	expected := {{
+		"params": [
+			{
+				"name": "IMAGE",
+				"value": "quay.io/jstuart/hacbs-docker-build",
+			},
+			{
+				"name": "DOCKERFILE",
+				"value": "./image_with_labels/Dockerfile",
+			},
+		],
+		"podTemplate": {
+			"imagePullSecrets": [{"name": "docker-chains"}],
+			"securityContext": {"fsGroup": 65532},
+		},
+		"serviceAccountName": "default", "taskRef": {
+			"kind": "Task",
+			"name": "buildah",
+		},
+		"timeout": "1h0m0s", "workspaces": [
+			{
+				"name": "source",
+				"persistentVolumeClaim": {"claimName": "pvc-bf2ed289ae"},
+			},
+			{
+				"name": "dockerconfig",
+				"secret": {"secretName": "docker-credentials"},
+			},
+		],
+	}}
+	lib.assert_equal(expected, tkn.tasks(attestation))
 }
 
 test_tasks_from_slsav1_tekton_mixture_attestation if {
@@ -89,8 +125,51 @@ test_tasks_from_slsav1_tekton_mixture_attestation if {
 			git_init_bad,
 		],
 	}}}
-	expected := {{"params": [{"name": "IMAGE", "value": "quay.io/jstuart/hacbs-docker-build"}, {"name": "DOCKERFILE", "value": "./image_with_labels/Dockerfile"}], "podTemplate": {"imagePullSecrets": [{"name": "docker-chains"}], "securityContext": {"fsGroup": 65532}}, "serviceAccountName": "default", "taskRef": {"kind": "Task", "name": "task1"}, "timeout": "1h0m0s", "workspaces": [{"name": "source", "persistentVolumeClaim": {"claimName": "pvc-bf2ed289ae"}}, {"name": "dockerconfig", "secret": {"secretName": "docker-credentials"}}]}, {"params": [{"name": "IMAGE", "value": "quay.io/jstuart/hacbs-docker-build"}, {"name": "DOCKERFILE", "value": "./image_with_labels/Dockerfile"}], "podTemplate": {"imagePullSecrets": [{"name": "docker-chains"}], "securityContext": {"fsGroup": 65532}}, "serviceAccountName": "default", "taskRef": {"kind": "Task", "name": "task2"}, "timeout": "1h0m0s", "workspaces": [{"name": "source", "persistentVolumeClaim": {"claimName": "pvc-bf2ed289ae"}}, {"name": "dockerconfig", "secret": {"secretName": "docker-credentials"}}]}}
-	lib.assert_equal(expected, tasks(attestation))
+	expected := {
+		{
+			"params": [
+				{
+					"name": "IMAGE",
+					"value": "quay.io/jstuart/hacbs-docker-build",
+				},
+				{
+					"name": "DOCKERFILE",
+					"value": "./image_with_labels/Dockerfile",
+				},
+			],
+			"podTemplate": {
+				"imagePullSecrets": [{"name": "docker-chains"}],
+				"securityContext": {"fsGroup": 65532},
+			},
+			"serviceAccountName": "default", "taskRef": {
+				"kind": "Task",
+				"name": "task1",
+			},
+			"timeout": "1h0m0s", "workspaces": [
+				{"name": "source", "persistentVolumeClaim": {"claimName": "pvc-bf2ed289ae"}},
+				{"name": "dockerconfig", "secret": {"secretName": "docker-credentials"}},
+			],
+		},
+		{
+			"params": [
+				{
+					"name": "IMAGE",
+					"value": "quay.io/jstuart/hacbs-docker-build",
+				},
+				{"name": "DOCKERFILE", "value": "./image_with_labels/Dockerfile"},
+			],
+			"podTemplate": {
+				"imagePullSecrets": [{"name": "docker-chains"}],
+				"securityContext": {"fsGroup": 65532},
+			},
+			"serviceAccountName": "default",
+			"taskRef": {"kind": "Task", "name": "task2"}, "timeout": "1h0m0s", "workspaces": [
+				{"name": "source", "persistentVolumeClaim": {"claimName": "pvc-bf2ed289ae"}},
+				{"name": "dockerconfig", "secret": {"secretName": "docker-credentials"}},
+			],
+		},
+	}
+	lib.assert_equal(expected, tkn.tasks(attestation))
 }
 
 test_tasks_from_slsav1_attestation if {
@@ -103,7 +182,7 @@ test_tasks_from_slsav1_attestation if {
 		"buildType": "https://tekton.dev/chains/v2/slsa-tekton",
 		"resolvedDependencies": [git_init],
 	}}}
-	lib.assert_equal(set(), tasks(attestation))
+	lib.assert_equal(set(), tkn.tasks(attestation))
 }
 
 test_tasks_from_pipeline if {
@@ -118,41 +197,45 @@ test_tasks_from_pipeline if {
 		},
 	}
 	expected := {git_clone, buildah, summary}
-	lib.assert_equal(expected, tasks(pipeline))
+	lib.assert_equal(expected, tkn.tasks(pipeline))
 }
 
 test_tasks_from_partial_pipeline if {
-	lib.assert_empty(tasks({"kind": "Pipeline"}))
-	lib.assert_empty(tasks({"kind": "Pipeline", "spec": {}}))
+	lib.assert_empty(tkn.tasks({"kind": "Pipeline"}))
+	lib.assert_empty(tkn.tasks({"kind": "Pipeline", "spec": {}}))
 
 	git_clone := {"taskRef": {"name": "git-clone"}}
-	lib.assert_equal({git_clone}, tasks({"kind": "Pipeline", "spec": {"tasks": [git_clone]}}))
-	lib.assert_equal({git_clone}, tasks({"kind": "Pipeline", "spec": {"finally": [git_clone]}}))
+	lib.assert_equal({git_clone}, tkn.tasks({"kind": "Pipeline", "spec": {"tasks": [git_clone]}}))
+	lib.assert_equal({git_clone}, tkn.tasks({"kind": "Pipeline", "spec": {"finally": [git_clone]}}))
 }
 
 test_tasks_not_found if {
-	lib.assert_empty(tasks({}))
+	lib.assert_empty(tkn.tasks({}))
 }
 
 test_task_param if {
 	task := {"params": [{"name": "NETWORK", "value": "none"}]}
-	lib.assert_equal("none", task_param(task, "NETWORK"))
-	not task_param(task, "missing")
+	lib.assert_equal("none", tkn.task_param(task, "NETWORK"))
+	not tkn.task_param(task, "missing")
 }
 
 test_task_slsav1_param if {
-	task := {"kind": "TaskRun", "metadata": {"name": "buildah"}, "spec": {"params": [{"name": "NETWORK", "value": "none"}]}}
-	lib.assert_equal("none", task_param(task, "NETWORK"))
-	not task_param(task, "missing")
+	task := {
+		"kind": "TaskRun",
+		"metadata": {"name": "buildah"},
+		"spec": {"params": [{"name": "NETWORK", "value": "none"}]},
+	}
+	lib.assert_equal("none", tkn.task_param(task, "NETWORK"))
+	not tkn.task_param(task, "missing")
 }
 
 test_task_result if {
 	task := {"results": [{"name": "SPAM", "value": "maps"}]}
-	lib.assert_equal("maps", task_result(task, "SPAM"))
-	not task_result(task, "missing")
+	lib.assert_equal("maps", tkn.task_result(task, "SPAM"))
+	not tkn.task_result(task, "missing")
 }
 
-test_tasks_from_attestation if {
+test_tasks_from_attestation_with_spam if {
 	expected_tasks := {
 		{"ref": {"name": "git-clone", "kind": "Task", "bundle": _bundle}},
 		_good_build_task,
@@ -165,13 +248,13 @@ test_tasks_from_attestation if {
 
 	attestation := {"predicate": {"buildConfig": {"tasks": expected_tasks}}}
 
-	lib.assert_equal(expected_tasks, tasks(attestation))
+	lib.assert_equal(expected_tasks, tkn.tasks(attestation))
 
 	expected_names := {"git-clone", "buildah", "buildah[HERMETIC=true]", "weird", "weird[SPAM=MAPS]", "summary"}
-	lib.assert_equal(expected_names, tasks_names(attestation))
+	lib.assert_equal(expected_names, tkn.tasks_names(attestation))
 }
 
-test_tasks_from_pipeline if {
+test_tasks_from_pipeline_with_spam if {
 	pipeline := {
 		"kind": "Pipeline",
 		"spec": {
@@ -204,15 +287,15 @@ test_tasks_from_pipeline if {
 		},
 		{"taskRef": {"name": "summary", "kind": "Task", "bundle": _bundle}},
 	}
-	lib.assert_equal(expected_tasks, tasks(pipeline))
+	lib.assert_equal(expected_tasks, tkn.tasks(pipeline))
 
 	expected_names := {"git-clone", "buildah", "buildah[NETWORK=none]", "weird", "weird[SPAM=MAPS]", "summary"}
-	lib.assert_equal(expected_names, tasks_names(pipeline))
+	lib.assert_equal(expected_names, tkn.tasks_names(pipeline))
 }
 
 test_build_task if {
 	expected := _good_build_task
-	lib.assert_equal(expected, build_task(_good_attestation))
+	lib.assert_equal(expected, tkn.build_task(_good_attestation))
 }
 
 test_build_task_not_found if {
@@ -221,22 +304,22 @@ test_build_task_not_found if {
 		"path": "/predicate/buildConfig/tasks/0/results/0/name",
 		"value": "IMAGE_URL_SKIP",
 	}])
-	not build_task(missing_image_url)
+	not tkn.build_task(missing_image_url)
 
 	missing_image_digest := json.patch(_good_attestation, [{
 		"op": "add",
 		"path": "/predicate/buildConfig/tasks/0/results/1/name",
 		"value": "IMAGE_DIGEST_SKIP",
 	}])
-	not build_task(missing_image_digest)
+	not tkn.build_task(missing_image_digest)
 
 	missing_results := json.remove(_good_attestation, ["/predicate/buildConfig/tasks/0/results"])
-	not build_task(missing_results)
+	not tkn.build_task(missing_results)
 }
 
 test_git_clone_task if {
 	expected := _good_git_clone_task
-	lib.assert_equal(expected, git_clone_task(_good_attestation))
+	lib.assert_equal(expected, tkn.git_clone_task(_good_attestation))
 }
 
 test_git_clone_task_not_found if {
@@ -245,17 +328,17 @@ test_git_clone_task_not_found if {
 		"path": "/predicate/buildConfig/tasks/1/results/0/name",
 		"value": "you-argh-el",
 	}])
-	not git_clone_task(missing_url)
+	not tkn.git_clone_task(missing_url)
 
 	missing_commit := json.patch(_good_attestation, [{
 		"op": "add",
 		"path": "/predicate/buildConfig/tasks/1/results/1/name",
 		"value": "bachelor",
 	}])
-	not git_clone_task(missing_commit)
+	not tkn.git_clone_task(missing_commit)
 
 	missing_results := json.remove(_good_attestation, ["/predicate/buildConfig/tasks/1/results"])
-	not git_clone_task(missing_results)
+	not tkn.git_clone_task(missing_results)
 }
 
 test_task_data_bundle_ref if {
@@ -264,7 +347,7 @@ test_task_data_bundle_ref if {
 			"bundle": "bundle",
 			"name": "ref-name",
 		},
-		task_data({
+		tkn.task_data({
 			"name": "name",
 			"ref": {
 				"name": "ref-name",
@@ -277,18 +360,22 @@ test_task_data_bundle_ref if {
 
 test_task_names_local if {
 	lib.assert_equal(
-		{"buildah", "buildah[DOCKERFILE=./image_with_labels/Dockerfile]", "buildah[IMAGE=quay.io/jstuart/hacbs-docker-build]"},
-		task_names(slsav1_attestation_local_spec),
+		{
+			"buildah",
+			"buildah[DOCKERFILE=./image_with_labels/Dockerfile]",
+			"buildah[IMAGE=quay.io/jstuart/hacbs-docker-build]",
+		},
+		tkn.task_names(slsav1_attestation_local_spec),
 	)
 }
 
-test_task_data_no_bundle_Ref if {
-	lib.assert_equal({"name": "name"}, task_data({"name": "name"}))
+test_task_data_no_bundle_ref if {
+	lib.assert_equal({"name": "name"}, tkn.task_data({"name": "name"}))
 }
 
 test_missing_required_tasks_data if {
-	lib.assert_equal(missing_required_tasks_data, true) with data["required-tasks"] as []
-	lib.assert_equal(missing_required_tasks_data, false) with data["required-tasks"] as _time_based_required_tasks
+	lib.assert_equal(tkn.missing_required_tasks_data, true) with data["required-tasks"] as []
+	lib.assert_equal(tkn.missing_required_tasks_data, false) with data["required-tasks"] as _time_based_required_tasks
 }
 
 _expected_latest := {
@@ -344,7 +431,7 @@ _good_git_clone_task := {
 }
 
 _good_attestation := {"predicate": {
-	"buildType": lib.pipelinerun_att_build_types[0],
+	"buildType": lib.tekton_pipeline_run,
 	"buildConfig": {"tasks": [_good_build_task, _good_git_clone_task]},
 }}
 

--- a/policy/lib/time.rego
+++ b/policy/lib/time.rego
@@ -13,12 +13,12 @@ default_effective_on := "2022-01-01T00:00:00Z"
 # precedence to the narrowest scope. Let's keep it that way even though
 # currently we're not using any scopes except for the rule scope.
 #
-when(metadata_chain) = effective_on {
+when(metadata_chain) := effective_on {
 	scope_precedence := ["rule", "document", "package"]
 	all_effective_on := [e |
-		annotations := metadata_chain[_].annotations
-		e := annotations.custom.effective_on
-		annotations.scope in scope_precedence
+		some metadata in metadata_chain
+		e := metadata.annotations.custom.effective_on
+		metadata.annotations.scope in scope_precedence
 	]
 
 	# Use the first one found in scope_precedence or fall back to the default
@@ -28,14 +28,14 @@ when(metadata_chain) = effective_on {
 
 # Use the nanosecond epoch defined in the policy config if it is
 # present, otherwise use the real current time
-effective_current_time_ns = now_ns {
+effective_current_time_ns := now_ns {
 	data.config
 	now_ns := object.get(data.config, ["policy", "when_ns"], time.now_ns())
 }
 
 # Handle edge case where data.config is not present
 # (We can't do `object.get(data, ...)` for some reason)
-effective_current_time_ns = now_ns {
+effective_current_time_ns := now_ns {
 	not data.config
 	now_ns := time.now_ns()
 }
@@ -45,9 +45,9 @@ effective_current_time_ns = now_ns {
 # not define the effective_on attribute are ignored. If the given list of
 # items is empty, or no items are current, most_current does not produce a
 # value.
-most_current(items) = item {
+most_current(items) := item {
 	current := [i |
-		i := items[_]
+		some i in items
 		i.effective_on
 		not time.parse_rfc3339_ns(i.effective_on) > effective_current_time_ns
 	]
@@ -58,24 +58,22 @@ most_current(items) = item {
 # future_items returns a filtered list of the given items where each item has
 # an effective_on value in the future (greater than now). Items that do not
 # define the effective_on attribute are ignored.
-future_items(items) = some_items {
-	some_items := [i |
-		i := items[_]
-		i.effective_on
-		time.parse_rfc3339_ns(i.effective_on) > effective_current_time_ns
-	]
-}
+future_items(items) := [i |
+	some i in items
+	i.effective_on
+	time.parse_rfc3339_ns(i.effective_on) > effective_current_time_ns
+]
 
 # acceptable_items return a filtered list of the given items by only including
 # the future_items and the most_current item. If a most_current item is not
 # available, this function behaves just like future_items.
-acceptable_items(items) = some_items {
+acceptable_items(items) := some_items {
 	some_items := array.concat(future_items(items), [most_current(items)])
 } else = future_items(items)
 
 # newest returns the newest item by `effective_on`. Assumes same date format and
 # time-zone for `effective_on` field.
-newest(items) = item {
+newest(items) := item {
 	ordered := arrays.sort_by("effective_on", items)
 
 	item := ordered[count(ordered) - 1]

--- a/policy/lib/time_test.rego
+++ b/policy/lib/time_test.rego
@@ -2,9 +2,10 @@
 # custom:
 #   effective_on: 2001-02-03T00:00:00Z
 #   scope: package
-package lib.time
+package lib.time_test
 
 import data.lib
+import data.lib.time as lib_time
 
 future_timestamp := time.add_date(time.now_ns(), 0, 0, 1)
 
@@ -12,24 +13,32 @@ future_timestamp := time.add_date(time.now_ns(), 0, 0, 1)
 # custom:
 #   effective_on: 2004-05-06T00:00:00Z
 test_when_rule_precedence {
-	when(rego.metadata.chain()) == "2004-05-06T00:00:00Z"
+	lib_time.when(rego.metadata.chain()) == "2004-05-06T00:00:00Z"
 }
 
 test_when_package_precedence {
-	when(rego.metadata.chain()) == "2001-02-03T00:00:00Z"
+	lib_time.when(rego.metadata.chain()) == "2001-02-03T00:00:00Z"
 }
 
 test_effective_current_time_ns {
-	lib.assert_equal(effective_current_time_ns, time.now_ns()) # with no config at all
-	lib.assert_equal(effective_current_time_ns, time.now_ns()) with data.config as {} # no config.policy
-	lib.assert_equal(effective_current_time_ns, time.now_ns()) with data.config.policy as {} # no config.policy.when_ns
-	lib.assert_equal(effective_current_time_ns, lib.time.future_timestamp) with data.config.policy.when_ns as lib.time.future_timestamp
+	# with no config at all
+	lib.assert_equal(lib_time.effective_current_time_ns, time.now_ns())
+
+	# no config.policy
+	lib.assert_equal(lib_time.effective_current_time_ns, time.now_ns()) with data.config as {}
+
+	# no config.policy.when_ns
+	lib.assert_equal(lib_time.effective_current_time_ns, time.now_ns()) with data.config.policy as {}
+	lib.assert_equal(
+		lib_time.effective_current_time_ns,
+		future_timestamp,
+	) with data.config.policy.when_ns as future_timestamp
 }
 
 test_most_current {
 	# Ignore future item
 	lib.assert_equal(
-		most_current([
+		lib_time.most_current([
 			{"name": "future", "effective_on": "2099-01-01T00:00:00Z"},
 			{"name": "past", "effective_on": "2022-01-01T00:00:00Z"},
 			{"name": "ancient", "effective_on": "1985-01-01T00:00:00Z"},
@@ -38,10 +47,10 @@ test_most_current {
 	)
 
 	# Produce no value when input is an empty list
-	not most_current([])
+	not lib_time.most_current([])
 
 	# Produce no value if there are no current items
-	not most_current([
+	not lib_time.most_current([
 		{"name": "supernova", "effective_on": "2262-04-11T00:00:00Z"},
 		{"name": "visionary", "effective_on": "2199-01-01T00:00:00Z"},
 		{"name": "future", "effective_on": "2099-01-01T00:00:00Z"},
@@ -49,7 +58,7 @@ test_most_current {
 
 	# Ignore items without effective_on
 	lib.assert_equal(
-		most_current([
+		lib_time.most_current([
 			{"name": "incomplete"},
 			{"name": "past", "effective_on": "2022-01-01T00:00:00Z"},
 			{"name": "lacking"},
@@ -61,7 +70,7 @@ test_most_current {
 test_future_items {
 	# Ignore items in the past
 	lib.assert_equal(
-		future_items([
+		lib_time.future_items([
 			{"name": "supernova", "effective_on": "2262-04-11T00:00:00Z"},
 			{"name": "visionary", "effective_on": "2199-01-01T00:00:00Z"},
 			{"name": "future", "effective_on": "2099-01-01T00:00:00Z"},
@@ -76,11 +85,11 @@ test_future_items {
 	)
 
 	# Return empty list when input is an empty list
-	lib.assert_equal(future_items([]), [])
+	lib.assert_equal(lib_time.future_items([]), [])
 
 	# Return empty list when all items are in the past
 	lib.assert_equal(
-		future_items([
+		lib_time.future_items([
 			{"name": "past", "effective_on": "2022-01-01T00:00:00Z"},
 			{"name": "ancient", "effective_on": "1985-01-01T00:00:00Z"},
 			{"name": "dino", "effective_on": "1965-01-01T00:00:00Z"},
@@ -90,7 +99,7 @@ test_future_items {
 
 	# Ignore items without effective_on
 	lib.assert_equal(
-		future_items([
+		lib_time.future_items([
 			{"name": "incomplete"},
 			{"name": "future", "effective_on": "2099-01-01T00:00:00Z"},
 			{"name": "lacking"},
@@ -102,7 +111,7 @@ test_future_items {
 test_acceptable_items {
 	# Include future items and most current
 	lib.assert_equal(
-		acceptable_items([
+		lib_time.acceptable_items([
 			{"name": "supernova", "effective_on": "2262-04-11T00:00:00Z"},
 			{"name": "visionary", "effective_on": "2199-01-01T00:00:00Z"},
 			{"name": "future", "effective_on": "2099-01-01T00:00:00Z"},
@@ -119,7 +128,7 @@ test_acceptable_items {
 
 	# Most current item is optional
 	lib.assert_equal(
-		acceptable_items([
+		lib_time.acceptable_items([
 			{"name": "supernova", "effective_on": "2262-04-11T00:00:00Z"},
 			{"name": "visionary", "effective_on": "2199-01-01T00:00:00Z"},
 			{"name": "future", "effective_on": "2099-01-01T00:00:00Z"},
@@ -132,11 +141,11 @@ test_acceptable_items {
 	)
 
 	# Return empty list when input is an empty list
-	lib.assert_equal(future_items([]), [])
+	lib.assert_equal(lib_time.future_items([]), [])
 }
 
 test_newest {
-	lib.assert_equal({"effective_on": "2262-04-11T00:00:00Z"}, newest([
+	lib.assert_equal({"effective_on": "2262-04-11T00:00:00Z"}, lib_time.newest([
 		{"effective_on": "2199-01-01T00:00:00Z"},
 		{"effective_on": "2262-04-11T00:00:00Z"},
 		{"effective_on": "2099-01-01T00:00:00Z"},

--- a/policy/pipeline/basic_test.rego
+++ b/policy/pipeline/basic_test.rego
@@ -1,9 +1,10 @@
-package policy.pipeline.basic
+package policy.pipeline.basic_test
 
 import data.lib
+import data.policy.pipeline.basic
 
 test_unexpected_kind {
-	lib.assert_equal_results(deny, {{
+	lib.assert_equal_results(basic.deny, {{
 		"code": "basic.expected_kind",
 		"msg": "Unexpected kind 'Foo' for pipeline definition",
 	}}) with input.kind as "Foo"

--- a/policy/pipeline/required_tasks.rego
+++ b/policy/pipeline/required_tasks.rego
@@ -102,11 +102,9 @@ deny contains result if {
 
 # _missing_tasks returns a set of task names that are in the given
 # required_tasks, but not in the pipeline definition.
-_missing_tasks(required_tasks) := tasks if {
-	tasks := {task |
-		some task in required_tasks
-		not task in tkn.tasks_names(input)
-	}
+_missing_tasks(required_tasks) := {task |
+	some task in required_tasks
+	not task in tkn.tasks_names(input)
 }
 
 # get the future tasks that are pipeline specific. If none exists

--- a/policy/pipeline/required_tasks_test.rego
+++ b/policy/pipeline/required_tasks_test.rego
@@ -1,18 +1,19 @@
-package policy.pipeline.required_tasks
+package policy.pipeline.required_tasks_test
 
 import future.keywords.contains
 import future.keywords.if
 import future.keywords.in
 
 import data.lib
+import data.policy.pipeline.required_tasks
 
 test_required_tasks_met if {
 	pipeline := _pipeline_with_tasks_and_label(_expected_required_tasks, [], [])
-	lib.assert_empty(deny) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
+	lib.assert_empty(required_tasks.deny) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
 		with input as pipeline
 
 	pipeline_finally := _pipeline_with_tasks_and_label([], _expected_required_tasks, [])
-	lib.assert_empty(deny) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
+	lib.assert_empty(required_tasks.deny) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
 		with input as pipeline_finally
 }
 
@@ -21,27 +22,31 @@ test_required_tasks_not_met if {
 	pipeline := _pipeline_with_tasks_and_label(_expected_required_tasks - missing_tasks, [], [])
 
 	expected := _missing_tasks_violation(missing_tasks)
-	lib.assert_equal_results(expected, deny) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
+	lib.assert_equal_results(
+		expected,
+		required_tasks.deny,
+	) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
 		with input as pipeline
 }
 
 test_future_required_tasks_met if {
 	pipeline := _pipeline_with_tasks_and_label(_expected_future_required_tasks, [], [])
-	lib.assert_empty(warn) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
+	lib.assert_empty(required_tasks.warn) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
 		with input as pipeline
 
 	pipeline_finally := _pipeline_with_tasks_and_label([], _expected_future_required_tasks, [])
-	lib.assert_empty(warn) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
+	lib.assert_empty(required_tasks.warn) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
 		with input as pipeline_finally
 }
 
 test_not_warn_if_only_future_required_tasks if {
+	tasks := _time_based_pipeline_required_tasks_future_only
 	pipeline := _pipeline_with_tasks_and_label(_expected_future_required_tasks, [], [])
-	lib.assert_empty(warn) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks_future_only
+	lib.assert_empty(required_tasks.warn) with data["pipeline-required-tasks"] as tasks
 		with input as pipeline
 
 	pipeline_finally := _pipeline_with_tasks_and_label([], _expected_future_required_tasks, [])
-	lib.assert_empty(warn) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks_future_only
+	lib.assert_empty(required_tasks.warn) with data["pipeline-required-tasks"] as tasks
 		with input as pipeline_finally
 }
 
@@ -50,13 +55,17 @@ test_future_required_tasks_not_met if {
 	pipeline := _pipeline_with_tasks_and_label(_expected_future_required_tasks - missing_tasks, [], [])
 
 	expected := _missing_tasks_warning(missing_tasks)
-	lib.assert_equal_results(expected, warn) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
+	lib.assert_equal_results(
+		expected,
+		required_tasks.warn,
+	) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
 		with input as pipeline
 }
 
 test_extra_tasks_ignored if {
 	pipeline := _pipeline_with_tasks_and_label(_expected_future_required_tasks | {"spam"}, [], [])
-	lib.assert_empty(deny | warn) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
+	all := required_tasks.deny | required_tasks.warn
+	lib.assert_empty(all) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
 		with input as pipeline
 }
 
@@ -66,21 +75,24 @@ test_missing_pipeline_label if {
 		"msg": "Required tasks do not exist for pipeline \"fbc\"",
 	}}
 	pipeline := _pipeline_with_tasks(_expected_required_tasks, [], [])
-	lib.assert_equal_results(expected, warn) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
+	lib.assert_equal_results(
+		expected,
+		required_tasks.warn,
+	) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
 		with input as pipeline
 }
 
 test_default_required_task_met if {
 	pipeline := _pipeline_with_tasks(_expected_required_tasks, [], [])
-	lib.assert_empty(deny) with data["required-tasks"] as _time_based_required_tasks
+	lib.assert_empty(required_tasks.deny) with data["required-tasks"] as _time_based_required_tasks
 		with input as pipeline
 
 	pipeline_finally := _pipeline_with_tasks([], _expected_required_tasks, [])
-	lib.assert_empty(deny) with data["required-tasks"] as _time_based_required_tasks
+	lib.assert_empty(required_tasks.deny) with data["required-tasks"] as _time_based_required_tasks
 		with input as pipeline_finally
 
 	expected_warn := _missing_pipeline_tasks_warning("fbc")
-	lib.assert_equal_results(expected_warn, warn) with data["required-tasks"] as _expected_required_tasks
+	lib.assert_equal_results(expected_warn, required_tasks.warn) with data["required-tasks"] as _expected_required_tasks
 		with input as pipeline
 }
 
@@ -89,22 +101,28 @@ test_default_required_tasks_not_met if {
 	pipeline := _pipeline_with_tasks(_expected_required_tasks - missing_tasks, [], [])
 
 	expected := _missing_default_tasks_violation(missing_tasks)
-	lib.assert_equal_results(expected, deny) with data["required-tasks"] as _time_based_required_tasks
+	lib.assert_equal_results(expected, required_tasks.deny) with data["required-tasks"] as _time_based_required_tasks
 		with input as pipeline
 
 	expected_warn := _missing_pipeline_tasks_warning("fbc")
-	lib.assert_equal_results(expected_warn, warn) with data["required-tasks"] as _expected_required_tasks
+	lib.assert_equal_results(expected_warn, required_tasks.warn) with data["required-tasks"] as _expected_required_tasks
 		with input as pipeline
 }
 
 test_default_future_required_tasks_met if {
 	expected_warn := _missing_pipeline_tasks_warning("fbc")
 	pipeline := _pipeline_with_tasks(_expected_future_required_tasks, [], [])
-	lib.assert_equal_results(expected_warn, warn) with data["required-tasks"] as _time_based_required_tasks
+	lib.assert_equal_results(
+		expected_warn,
+		required_tasks.warn,
+	) with data["required-tasks"] as _time_based_required_tasks
 		with input as pipeline
 
 	pipeline_finally := _pipeline_with_tasks([], _expected_future_required_tasks, [])
-	lib.assert_equal_results(expected_warn, warn) with data["required-tasks"] as _time_based_required_tasks
+	lib.assert_equal_results(
+		expected_warn,
+		required_tasks.warn,
+	) with data["required-tasks"] as _time_based_required_tasks
 		with input as pipeline_finally
 }
 
@@ -112,29 +130,40 @@ test_default_future_required_tasks_not_met if {
 	missing_tasks := {"conftest-clair"}
 	pipeline := _pipeline_with_tasks(_expected_required_tasks - missing_tasks, [], [])
 
-	expected := _missing_pipeline_tasks_warning("fbc") | {{"code": "required_tasks.missing_future_required_task", "effective_on": "2022-01-01T00:00:00Z", "msg": "Task \"conftest-clair\" is missing and will be required in the future", "term": "conftest-clair"}}
-	lib.assert_equal_results(expected, warn) with data["required-tasks"] as _time_based_required_tasks
+	expected := _missing_pipeline_tasks_warning("fbc") | {{
+		"code": "required_tasks.missing_future_required_task",
+		"effective_on": "2022-01-01T00:00:00Z",
+		"msg": "Task \"conftest-clair\" is missing and will be required in the future",
+		"term": "conftest-clair",
+	}}
+	lib.assert_equal_results(expected, required_tasks.warn) with data["required-tasks"] as _time_based_required_tasks
 		with input as pipeline
 }
 
 test_current_equal_latest if {
-	required_tasks := {"fbc": [{"effective_on": "2021-01-01T00:00:00Z", "tasks": _time_based_required_tasks[0].tasks}]}
+	req_tasks := {"fbc": [{"effective_on": "2021-01-01T00:00:00Z", "tasks": _time_based_required_tasks[0].tasks}]}
 	pipeline := _pipeline_with_tasks_and_label(_expected_future_required_tasks, [], [])
 
-	lib.assert_empty(deny | warn) with data["pipeline-required-tasks"] as required_tasks
+	lib.assert_empty(required_tasks.deny | required_tasks.warn) with data["pipeline-required-tasks"] as req_tasks
 		with input as pipeline
 }
 
 test_current_equal_latest_also if {
-	required_tasks := {"fbc": [{"effective_on": "2021-01-01T00:00:00Z", "tasks": _expected_required_tasks}]}
+	req_tasks := {"fbc": [{"effective_on": "2021-01-01T00:00:00Z", "tasks": _expected_required_tasks}]}
 	pipeline := _pipeline_with_tasks_and_label(_expected_required_tasks, [], [])
 
-	lib.assert_empty(warn) with data["pipeline-required-tasks"] as required_tasks
+	lib.assert_empty(required_tasks.warn) with data["pipeline-required-tasks"] as req_tasks
 		with input as pipeline
 
-	required_tasks_denies := {"fbc": [{"effective_on": "2021-01-01T00:00:00Z", "tasks": _expected_future_required_tasks}]}
+	required_tasks_denies := {"fbc": [{
+		"effective_on": "2021-01-01T00:00:00Z",
+		"tasks": _expected_future_required_tasks,
+	}]}
 	expected_denies := _missing_tasks_violation(_expected_future_required_tasks - _expected_required_tasks)
-	lib.assert_equal_results(expected_denies, deny) with data["pipeline-required-tasks"] as required_tasks_denies
+	lib.assert_equal_results(
+		expected_denies,
+		required_tasks.deny,
+	) with data["pipeline-required-tasks"] as required_tasks_denies
 		with input as pipeline
 }
 
@@ -144,13 +173,22 @@ test_no_tasks_present if {
 		"msg": "No tasks found in pipeline",
 	}}
 
-	lib.assert_equal_results(expected, deny) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
+	lib.assert_equal_results(
+		expected,
+		required_tasks.deny,
+	) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
 		with input as {"kind": "Pipeline"}
 
-	lib.assert_equal_results(expected, deny) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
+	lib.assert_equal_results(
+		expected,
+		required_tasks.deny,
+	) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
 		with input as {"kind": "Pipeline", "spec": {}}
 
-	lib.assert_equal_results(expected, deny) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
+	lib.assert_equal_results(
+		expected,
+		required_tasks.deny,
+	) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
 		with input as {"kind": "Pipeline", "spec": {"tasks": [], "finally": []}}
 }
 
@@ -176,7 +214,7 @@ test_parameterized if {
 	pipeline := _pipeline_with_tasks_and_label({"git-clone", "buildah"}, [], with_wrong_parameter)
 
 	expected := _missing_default_tasks_violation({"label-check[POLICY_NAMESPACE=required_checks]"})
-	lib.assert_equal_results(expected, deny) with data["required-tasks"] as _time_based_required_tasks
+	lib.assert_equal_results(expected, required_tasks.deny) with data["required-tasks"] as _time_based_required_tasks
 		with input as pipeline
 }
 
@@ -186,14 +224,14 @@ test_missing_required_tasks_data if {
 		"code": "required_tasks.required_tasks_list_present",
 		"msg": "The required tasks list is missing from the rule data",
 	}}
-	lib.assert_equal_results(expected, deny) with data["required-tasks"] as []
+	lib.assert_equal_results(expected, required_tasks.deny) with data["required-tasks"] as []
 		with data["pipeline-required-tasks"] as {}
 		with input as pipeline
 }
 
-_pipeline_with_tasks_and_label(names, finally_names, add_tasks) = pipeline if {
-	tasks := array.concat([t | t := _task(names[_])], add_tasks)
-	finally_tasks := [t | t := _task(finally_names[_])]
+_pipeline_with_tasks_and_label(names, finally_names, add_tasks) := pipeline if {
+	tasks := array.concat([t | some name in names; t := _task(name)], add_tasks)
+	finally_tasks := [t | some name in finally_names; t := _task(name)]
 
 	pipeline := {
 		"kind": "Pipeline",
@@ -205,9 +243,9 @@ _pipeline_with_tasks_and_label(names, finally_names, add_tasks) = pipeline if {
 	}
 }
 
-_pipeline_with_tasks(names, finally_names, add_tasks) = pipeline if {
-	tasks := array.concat([t | t := _task(names[_])], add_tasks)
-	finally_tasks := [t | t := _task(finally_names[_])]
+_pipeline_with_tasks(names, finally_names, add_tasks) := pipeline if {
+	tasks := array.concat([t | some name in names; t := _task(name)], add_tasks)
+	finally_tasks := [t | some name in finally_names; t := _task(name)]
 
 	pipeline := {
 		"kind": "Pipeline",
@@ -216,8 +254,8 @@ _pipeline_with_tasks(names, finally_names, add_tasks) = pipeline if {
 	}
 }
 
-_task(name) = task if {
-	parts := regex.split("[\\[\\]=]", name)
+_task(name) := task if {
+	parts := regex.split(`[\[\]=]`, name)
 	parts[1]
 	task_name := parts[0]
 
@@ -227,51 +265,43 @@ _task(name) = task if {
 	}
 }
 
-_task(name) = task if {
-	parts := regex.split("[\\[\\]=]", name)
+_task(name) := task if {
+	parts := regex.split(`[\[\]=]`, name)
 	not parts[1]
 	task := {"taskRef": {"name": name, "kind": "Task", "bundle": _bundle}}
 }
 
-_missing_tasks_violation(tasks) = errors if {
-	errors := {error |
-		some task in tasks
-		error := {
-			"code": "required_tasks.missing_required_task",
-			"msg": sprintf("Required task %q is missing", [task]),
-			"term": task,
-		}
+_missing_tasks_violation(tasks) := {error |
+	some task in tasks
+	error := {
+		"code": "required_tasks.missing_required_task",
+		"msg": sprintf("Required task %q is missing", [task]),
+		"term": task,
 	}
 }
 
-_missing_default_tasks_violation(tasks) = errors if {
-	errors := {error |
-		some task in tasks
-		error := {
-			"code": "required_tasks.missing_required_task",
-			"msg": sprintf("Required task %q is missing", [task]),
-			"term": task,
-		}
+_missing_default_tasks_violation(tasks) := {error |
+	some task in tasks
+	error := {
+		"code": "required_tasks.missing_required_task",
+		"msg": sprintf("Required task %q is missing", [task]),
+		"term": task,
 	}
 }
 
-_missing_tasks_warning(tasks) = warnings if {
-	warnings := {warning |
-		some task in tasks
-		warning := {
-			"code": "required_tasks.missing_future_required_task",
-			"msg": sprintf("Task %q is missing and will be required in the future", [task]),
-			"term": task,
-		}
+_missing_tasks_warning(tasks) := {warning |
+	some task in tasks
+	warning := {
+		"code": "required_tasks.missing_future_required_task",
+		"msg": sprintf("Task %q is missing and will be required in the future", [task]),
+		"term": task,
 	}
 }
 
-_missing_pipeline_tasks_warning(name) = warnings if {
-	warnings := {warning |
-		warning := {
-			"code": "required_tasks.required_tasks_found",
-			"msg": sprintf("Required tasks do not exist for pipeline %q", [name]),
-		}
+_missing_pipeline_tasks_warning(name) := {warning |
+	warning := {
+		"code": "required_tasks.required_tasks_found",
+		"msg": sprintf("Required tasks do not exist for pipeline %q", [name]),
 	}
 }
 
@@ -280,7 +310,10 @@ _time_based_pipeline_required_tasks := {"fbc": [
 	{"tasks": _expected_future_required_tasks, "effective_on": "2099-01-02T00:00:00Z"},
 ]}
 
-_time_based_pipeline_required_tasks_future_only := {"fbc": [{"tasks": _expected_future_required_tasks, "effective_on": "2099-01-02T00:00:00Z"}]}
+_time_based_pipeline_required_tasks_future_only := {"fbc": [{
+	"tasks": _expected_future_required_tasks,
+	"effective_on": "2099-01-02T00:00:00Z",
+}]}
 
 _expected_required_tasks := {
 	"git-clone",

--- a/policy/pipeline/task_bundle_test.rego
+++ b/policy/pipeline/task_bundle_test.rego
@@ -1,29 +1,30 @@
-package policy.pipeline.task_bundle
+package policy.pipeline.task_bundle_test
 
 import data.lib
+import data.policy.pipeline.task_bundle
 
 test_bundle_not_exists {
 	tasks := [{"name": "my-task", "taskRef": {}}]
 
 	expected_msg := "Pipeline task 'my-task' does not contain a bundle reference"
-	lib.assert_equal_results(deny, {{
+	lib.assert_equal_results(task_bundle.deny, {{
 		"code": "task_bundle.disallowed_task_reference",
 		"msg": expected_msg,
 	}}) with input.spec.tasks as tasks with data["task-bundles"] as task_bundles
 
-	lib.assert_empty(warn) with input.spec.tasks as tasks
+	lib.assert_empty(task_bundle.warn) with input.spec.tasks as tasks
 }
 
 test_bundle_not_exists_empty_string {
 	tasks := [{"name": "my-task", "taskRef": {"bundle": ""}}]
 
 	expected_msg := "Pipeline task 'my-task' uses an empty bundle image reference"
-	lib.assert_equal_results(deny, {{
+	lib.assert_equal_results(task_bundle.deny, {{
 		"code": "task_bundle.empty_task_bundle_reference",
 		"msg": expected_msg,
 	}}) with input.spec.tasks as tasks with data["task-bundles"] as task_bundles
 
-	lib.assert_empty(warn) with input.spec.tasks as tasks
+	lib.assert_empty(task_bundle.warn) with input.spec.tasks as tasks
 }
 
 test_bundle_unpinned {
@@ -32,7 +33,7 @@ test_bundle_unpinned {
 		"taskRef": {"bundle": "reg.com/repo:latest"},
 	}]
 
-	lib.assert_equal_results(warn, {{
+	lib.assert_equal_results(task_bundle.warn, {{
 		"code": "task_bundle.unpinned_task_bundle",
 		"msg": "Pipeline task 'my-task' uses an unpinned task bundle reference 'reg.com/repo:latest'",
 	}}) with input.spec.tasks as tasks
@@ -44,18 +45,18 @@ test_bundle_reference_valid {
 		"taskRef": {"bundle": "quay.io/redhat-appstudio/hacbs-templates-bundle:latest@sha256:abc"},
 	}]
 
-	lib.assert_empty(deny) with input.spec.tasks as tasks with data["task-bundles"] as task_bundles
-	lib.assert_empty(warn) with input.spec.tasks as tasks with data["task-bundles"] as task_bundles
+	lib.assert_empty(task_bundle.deny) with input.spec.tasks as tasks with data["task-bundles"] as task_bundles
+	lib.assert_empty(task_bundle.warn) with input.spec.tasks as tasks with data["task-bundles"] as task_bundles
 }
 
 # All good when the most recent bundle is used.
 test_acceptable_bundle_up_to_date {
 	tasks := [{"name": "my-task", "taskRef": {"bundle": "reg.com/repo@sha256:abc"}}]
 
-	lib.assert_empty(warn) with input.spec.tasks as tasks
+	lib.assert_empty(task_bundle.warn) with input.spec.tasks as tasks
 		with data["task-bundles"] as task_bundles
 
-	lib.assert_empty(deny) with input.spec.tasks as tasks
+	lib.assert_empty(task_bundle.deny) with input.spec.tasks as tasks
 		with data["task-bundles"] as task_bundles
 }
 
@@ -66,7 +67,7 @@ test_acceptable_bundle_out_of_date_past {
 		{"name": "my-task-2", "taskRef": {"bundle": "reg.com/repo@sha256:cde"}},
 	]
 
-	lib.assert_equal_results(warn, {
+	lib.assert_equal_results(task_bundle.warn, {
 		{
 			"code": "task_bundle.out_of_date_task_bundle",
 			"msg": "Pipeline task 'my-task-1' uses an out of date task bundle 'reg.com/repo@sha256:bcd'",
@@ -78,7 +79,7 @@ test_acceptable_bundle_out_of_date_past {
 	}) with input.spec.tasks as tasks
 		with data["task-bundles"] as task_bundles
 
-	lib.assert_empty(deny) with input.spec.tasks as tasks
+	lib.assert_empty(task_bundle.deny) with input.spec.tasks as tasks
 		with data["task-bundles"] as task_bundles
 }
 
@@ -86,10 +87,10 @@ test_acceptable_bundle_out_of_date_past {
 test_acceptable_bundle_expired {
 	tasks := [{"name": "my-task", "taskRef": {"bundle": "reg.com/repo@sha256:def"}}]
 
-	lib.assert_empty(warn) with input.spec.tasks as tasks
+	lib.assert_empty(task_bundle.warn) with input.spec.tasks as tasks
 		with data["task-bundles"] as task_bundles
 
-	lib.assert_equal_results(deny, {{
+	lib.assert_equal_results(task_bundle.deny, {{
 		"code": "task_bundle.unacceptable_task_bundle",
 		"msg": "Pipeline task 'my-task' uses an unacceptable task bundle 'reg.com/repo@sha256:def'",
 	}}) with input.spec.tasks as tasks
@@ -101,10 +102,10 @@ test_missing_required_data {
 		"code": "task_bundle.missing_required_data",
 		"msg": "Missing required task-bundles data",
 	}}
-	lib.assert_equal_results(expected, deny) with data["task-bundles"] as []
+	lib.assert_equal_results(expected, task_bundle.deny) with data["task-bundles"] as []
 }
 
-task_bundles = {"reg.com/repo": [
+task_bundles := {"reg.com/repo": [
 	{
 		# Latest bundle, allowed
 		"digest": "sha256:abc",

--- a/policy/release/attestation_task_bundle.rego
+++ b/policy/release/attestation_task_bundle.rego
@@ -14,6 +14,7 @@ package policy.release.attestation_task_bundle
 
 import future.keywords.contains
 import future.keywords.if
+import future.keywords.in
 
 import data.lib
 import data.lib.bundles
@@ -33,8 +34,8 @@ import data.lib.bundles
 #   - attestation_type.known_attestation_type
 #
 deny contains result if {
-	name := bundles.disallowed_task_reference(lib.tasks_from_pipelinerun)[_].name
-	result := lib.result_helper(rego.metadata.chain(), [name])
+	some bundle in bundles.disallowed_task_reference(lib.tasks_from_pipelinerun)
+	result := lib.result_helper(rego.metadata.chain(), [bundle.name])
 }
 
 # METADATA
@@ -53,7 +54,8 @@ deny contains result if {
 #   - attestation_type.known_attestation_type
 #
 deny contains result if {
-	name := bundles.empty_task_bundle_reference(lib.tasks_from_pipelinerun)[_].name
+	some task in bundles.empty_task_bundle_reference(lib.tasks_from_pipelinerun)
+	name := task.name
 	result := lib.result_helper(rego.metadata.chain(), [name])
 }
 
@@ -73,7 +75,7 @@ deny contains result if {
 #   - attestation_type.known_attestation_type
 #
 warn contains result if {
-	task := bundles.unpinned_task_bundle(lib.tasks_from_pipelinerun)[_]
+	some task in bundles.unpinned_task_bundle(lib.tasks_from_pipelinerun)
 	result := lib.result_helper(rego.metadata.chain(), [task.name, bundles.bundle(task)])
 }
 
@@ -94,7 +96,7 @@ warn contains result if {
 #   - attestation_type.known_attestation_type
 #
 warn contains result if {
-	task := bundles.out_of_date_task_bundle(lib.tasks_from_pipelinerun)[_]
+	some task in bundles.out_of_date_task_bundle(lib.tasks_from_pipelinerun)
 	result := lib.result_helper(rego.metadata.chain(), [task.name, bundles.bundle(task)])
 }
 
@@ -116,7 +118,7 @@ warn contains result if {
 #   - attestation_type.known_attestation_type
 #
 deny contains result if {
-	task := bundles.unacceptable_task_bundle(lib.tasks_from_pipelinerun)[_]
+	some task in bundles.unacceptable_task_bundle(lib.tasks_from_pipelinerun)
 	result := lib.result_helper(rego.metadata.chain(), [task.name, bundles.bundle(task)])
 }
 

--- a/policy/release/attestation_type_test.rego
+++ b/policy/release/attestation_type_test.rego
@@ -1,25 +1,24 @@
-package policy.release.attestation_type
+package policy.release.attestation_type_test
 
 import data.lib
+import data.policy.release.attestation_type
 
 good_type := "https://in-toto.io/Statement/v0.1"
 
 bad_type := "https://in-toto.io/Statement/v0.0.9999999"
 
-mock_data(att_type) = d {
-	d := [{"statement": {
-		"_type": att_type,
-		"predicate": {"buildType": lib.pipelinerun_att_build_types[0]},
-	}}]
-}
+mock_data(att_type) := [{"statement": {
+	"_type": att_type,
+	"predicate": {"buildType": lib.tekton_pipeline_run},
+}}]
 
 test_allow_when_permitted {
-	lib.assert_empty(deny) with input.attestations as mock_data(good_type)
+	lib.assert_empty(attestation_type.deny) with input.attestations as mock_data(good_type)
 }
 
 test_deny_when_not_permitted {
 	expected_msg := sprintf("Unknown attestation type '%s'", [bad_type])
-	lib.assert_equal_results(deny, {{
+	lib.assert_equal_results(attestation_type.deny, {{
 		"code": "attestation_type.known_attestation_type",
 		"msg": expected_msg,
 	}}) with input.attestations as mock_data(bad_type)
@@ -40,7 +39,7 @@ test_deny_when_pipelinerun_attestation_founds {
 			"predicate": {"buildType": "spam/spam/eggs/spam"},
 		}},
 	]
-	lib.assert_equal_results(deny, expected) with input.attestations as attestations
+	lib.assert_equal_results(attestation_type.deny, expected) with input.attestations as attestations
 }
 
 test_deny_deprecated_policy_attestation_format {
@@ -50,7 +49,7 @@ test_deny_deprecated_policy_attestation_format {
 	}}
 	attestations := [{
 		"_type": good_type,
-		"predicate": {"buildType": lib.pipelinerun_att_build_types[0]},
+		"predicate": {"buildType": lib.tekton_pipeline_run},
 	}]
-	lib.assert_equal_results(deny, expected) with input.attestations as attestations
+	lib.assert_equal_results(attestation_type.deny, expected) with input.attestations as attestations
 }

--- a/policy/release/base_image_registries.rego
+++ b/policy/release/base_image_registries.rego
@@ -88,11 +88,13 @@ deny contains result if {
 }
 
 _image_ref_permitted(image_ref, allowed_prefixes) if {
-	startswith(image_ref, allowed_prefixes[_])
+	some allowed_prefix in allowed_prefixes
+	startswith(image_ref, allowed_prefix)
 }
 
 _base_images contains name if {
-	some name in split(_base_images_results[_].value, "\n")
+	some _, image in _base_images_results
+	some name in split(image.value, "\n")
 	count(name) > 0
 }
 

--- a/policy/release/base_image_registries_test.rego
+++ b/policy/release/base_image_registries_test.rego
@@ -1,11 +1,13 @@
-package policy.release.base_image_registries
+package policy.release.base_image_registries_test
 
 import data.lib
+import data.lib_test
+import data.policy.release.base_image_registries
 
 mock_bundle := "registry.img/spam@sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb"
 
 test_acceptable_base_images {
-	attestations := [lib.att_mock_helper_ref_plain_result(
+	attestations := [lib_test.att_mock_helper_ref_plain_result(
 		lib.build_base_images_digests_result_name,
 		concat("\n", [
 			"registry.redhat.io/ubi7:latest@sha256:abc",
@@ -15,21 +17,21 @@ test_acceptable_base_images {
 		"buildah-task-1",
 		mock_bundle,
 	)]
-	lib.assert_empty(deny) with input.attestations as attestations
+	lib.assert_empty(base_image_registries.deny) with input.attestations as attestations
 }
 
 test_empty_base_images {
-	attestations := [lib.att_mock_helper_ref_plain_result(
+	attestations := [lib_test.att_mock_helper_ref_plain_result(
 		lib.build_base_images_digests_result_name,
 		"",
 		"buildah-task-1",
 		mock_bundle,
 	)]
-	lib.assert_empty(deny) with input.attestations as attestations
+	lib.assert_empty(base_image_registries.deny) with input.attestations as attestations
 }
 
 test_unacceptable_base_images {
-	attestations := [lib.att_mock_helper_ref_plain_result(
+	attestations := [lib_test.att_mock_helper_ref_plain_result(
 		lib.build_base_images_digests_result_name,
 		concat("\n", [
 			"registry.redhat.io/ubi7:latest@sha256:abc",
@@ -50,11 +52,11 @@ test_unacceptable_base_images {
 			"msg": "Base image \"registry.redhat.ioo/spam:latest@sha256:def\" is from a disallowed registry",
 		},
 	}
-	lib.assert_equal_results(deny, expected) with input.attestations as attestations
+	lib.assert_equal_results(base_image_registries.deny, expected) with input.attestations as attestations
 }
 
 test_missing_result {
-	attestations := [lib.att_mock_helper_ref_plain_result(
+	attestations := [lib_test.att_mock_helper_ref_plain_result(
 		"SPAM_SPAM_SPAM",
 		"registry.redhat.io/ubi7:latest@sha256:abc",
 		"buildah-task-1",
@@ -64,7 +66,7 @@ test_missing_result {
 		"code": "base_image_registries.base_image_info_found",
 		"msg": "Base images result is missing",
 	}}
-	lib.assert_equal_results(deny, expected) with input.attestations as attestations
+	lib.assert_equal_results(base_image_registries.deny, expected) with input.attestations as attestations
 }
 
 test_allowed_registries_provided {
@@ -72,5 +74,5 @@ test_allowed_registries_provided {
 		"code": "base_image_registries.allowed_registries_provided",
 		"msg": "Missing required allowed_registry_prefixes rule data",
 	}}
-	lib.assert_equal_results(expected, deny) with data.rule_data as {}
+	lib.assert_equal_results(expected, base_image_registries.deny) with data.rule_data as {}
 }

--- a/policy/release/buildah_build_task.rego
+++ b/policy/release/buildah_build_task.rego
@@ -59,8 +59,9 @@ deny contains result if {
 }
 
 _not_allowed_prefix(search) if {
-	not_allowed := ["http://", "https://"]
-	startswith(search, not_allowed[_])
+	not_allowed_prefixes := ["http://", "https://"]
+	some not_allowed_prefix in not_allowed_prefixes
+	startswith(search, not_allowed_prefix)
 }
 
 buildah_tasks contains task if {

--- a/policy/release/cve.rego
+++ b/policy/release/cve.rego
@@ -95,10 +95,8 @@ _vulnerabilities := vulnerabilities if {
 
 _result_name := "CLAIR_SCAN_RESULT"
 
-_non_zero_levels(key) := d if {
-	d := {level: amount |
-		some level in {a | some a in lib.rule_data(key)}
-		amount := _vulnerabilities[level]
-		amount > 0
-	}
+_non_zero_levels(key) := {level: amount |
+	some level in {a | some a in lib.rule_data(key)}
+	amount := _vulnerabilities[level]
+	amount > 0
 }

--- a/policy/release/cve_test.rego
+++ b/policy/release/cve_test.rego
@@ -1,35 +1,37 @@
-package policy.release.cve
+package policy.release.cve_test
 
 import future.keywords.contains
 import future.keywords.if
 import future.keywords.in
 
 import data.lib
+import data.lib_test
+import data.policy.release.cve
 
 test_success if {
-	attestations := [lib.att_mock_helper_ref(
-		_result_name,
+	attestations := [lib_test.att_mock_helper_ref(
+		cve._result_name,
 		{"vulnerabilities": {"critical": 0, "high": 0, "medium": 20, "low": 300}},
 		"clair-scan",
 		_bundle,
 	)]
-	lib.assert_empty(deny) with input.attestations as attestations
+	lib.assert_empty(cve.deny) with input.attestations as attestations
 }
 
 test_success_with_rule_data if {
-	attestations := [lib.att_mock_helper_ref(
-		_result_name,
+	attestations := [lib_test.att_mock_helper_ref(
+		cve._result_name,
 		{"vulnerabilities": {"critical": 1, "high": 1, "medium": 20, "low": 300}},
 		"clair-scan",
 		_bundle,
 	)]
-	lib.assert_empty(deny) with input.attestations as attestations
+	lib.assert_empty(cve.deny) with input.attestations as attestations
 		with data.rule_data.restrict_cve_security_levels as ["spam"]
 }
 
 test_failure if {
-	attestations := [lib.att_mock_helper_ref(
-		_result_name,
+	attestations := [lib_test.att_mock_helper_ref(
+		cve._result_name,
 		{"vulnerabilities": {"critical": 1, "high": 10, "medium": 20, "low": 300}},
 		"clair-scan",
 		_bundle,
@@ -46,12 +48,12 @@ test_failure if {
 			"msg": "Found 10 CVE vulnerabilities of high security level",
 		},
 	}
-	lib.assert_equal_results(deny, expected) with input.attestations as attestations
+	lib.assert_equal_results(cve.deny, expected) with input.attestations as attestations
 }
 
 test_failure_with_rule_data if {
-	attestations := [lib.att_mock_helper_ref(
-		_result_name,
+	attestations := [lib_test.att_mock_helper_ref(
+		cve._result_name,
 		{"vulnerabilities": {"spam": 1, "bacon": 2, "eggs": 3}},
 		"clair-scan",
 		_bundle,
@@ -68,23 +70,23 @@ test_failure_with_rule_data if {
 			"msg": "Found 2 CVE vulnerabilities of bacon security level",
 		},
 	}
-	lib.assert_equal_results(deny, expected) with input.attestations as attestations
+	lib.assert_equal_results(cve.deny, expected) with input.attestations as attestations
 		with data.rule_data.restrict_cve_security_levels as ["spam", "bacon"]
 }
 
 test_warn if {
-	attestations := [lib.att_mock_helper_ref(
-		_result_name,
+	attestations := [lib_test.att_mock_helper_ref(
+		cve._result_name,
 		{"vulnerabilities": {"critical": 1, "high": 10, "medium": 20, "low": 300}},
 		"clair-scan",
 		_bundle,
 	)]
-	lib.assert_empty(warn) with input.attestations as attestations
+	lib.assert_empty(cve.warn) with input.attestations as attestations
 }
 
 test_warn_with_rule_data if {
-	attestations := [lib.att_mock_helper_ref(
-		_result_name,
+	attestations := [lib_test.att_mock_helper_ref(
+		cve._result_name,
 		{"vulnerabilities": {"critical": 1, "high": 10, "medium": 20, "low": 300}},
 		"clair-scan",
 		_bundle,
@@ -101,12 +103,12 @@ test_warn_with_rule_data if {
 			"msg": "Found 300 non-blocking CVE vulnerabilities of low security level",
 		},
 	}
-	lib.assert_equal_results(warn, expected) with input.attestations as attestations
+	lib.assert_equal_results(cve.warn, expected) with input.attestations as attestations
 		with data.rule_data.warn_cve_security_levels as ["medium", "low"]
 }
 
 test_missing_cve_scan_result if {
-	attestations := [lib.att_mock_helper_ref(
+	attestations := [lib_test.att_mock_helper_ref(
 		"WRONG_RESULT_NAME",
 		{"vulnerabilities": {"critical": 1, "high": 1, "medium": 20, "low": 300}},
 		"clair-scan",
@@ -116,12 +118,12 @@ test_missing_cve_scan_result if {
 		"code": "cve.cve_results_found",
 		"msg": "Clair CVE scan results were not found",
 	}}
-	lib.assert_equal_results(deny, expected) with input.attestations as attestations
+	lib.assert_equal_results(cve.deny, expected) with input.attestations as attestations
 }
 
 test_missing_cve_scan_vulnerabilities if {
-	attestations := [lib.att_mock_helper_ref(
-		_result_name,
+	attestations := [lib_test.att_mock_helper_ref(
+		cve._result_name,
 		{"seitilibarenluv": {"critical": 1, "high": 1, "medium": 20, "low": 300}},
 		"clair-scan",
 		_bundle,
@@ -130,7 +132,7 @@ test_missing_cve_scan_vulnerabilities if {
 		"code": "cve.cve_results_found",
 		"msg": "Clair CVE scan results were not found",
 	}}
-	lib.assert_equal_results(deny, expected) with input.attestations as attestations
+	lib.assert_equal_results(cve.deny, expected) with input.attestations as attestations
 }
 
 _bundle := "registry.img/spam@sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb"

--- a/policy/release/external_parameters_test.rego
+++ b/policy/release/external_parameters_test.rego
@@ -1,22 +1,25 @@
-package policy.release.external_parameters
+package policy.release.external_parameters_test
 
 import future.keywords.contains
 import future.keywords.if
 import future.keywords.in
 
 import data.lib
+import data.policy.release.external_parameters
 
 test_success if {
-	lib.assert_empty(deny) with input.attestations as [good_provenance]
+	lib.assert_empty(external_parameters.deny) with input.attestations as [good_provenance]
 }
 
 test_pipeline_run_params_missing_params if {
+	# regal ignore:line-length
 	provenance := json.remove(good_provenance, ["/statement/predicate/buildDefinition/externalParameters/runSpec/params/0"])
 	expected := {{
 		"code": "external_parameters.pipeline_run_params",
-		"msg": "PipelineRun params, {\"git-revision\", \"output-image\"}, do not match expectation, {\"git-repo\", \"git-revision\", \"output-image\"}.",
+		# regal ignore:line-length
+		"msg": `PipelineRun params, {"git-revision", "output-image"}, do not match expectation, {"git-repo", "git-revision", "output-image"}.`,
 	}}
-	lib.assert_equal_results(deny, expected) with input.attestations as [provenance]
+	lib.assert_equal_results(external_parameters.deny, expected) with input.attestations as [provenance]
 }
 
 test_pipeline_run_params_empty_values if {
@@ -27,9 +30,10 @@ test_pipeline_run_params_empty_values if {
 	}])
 	expected := {{
 		"code": "external_parameters.pipeline_run_params",
-		"msg": "PipelineRun params, {\"git-revision\", \"output-image\"}, do not match expectation, {\"git-repo\", \"git-revision\", \"output-image\"}.",
+		# regal ignore:line-length
+		"msg": `PipelineRun params, {"git-revision", "output-image"}, do not match expectation, {"git-repo", "git-revision", "output-image"}.`,
 	}}
-	lib.assert_equal_results(deny, expected) with input.attestations as [provenance]
+	lib.assert_equal_results(external_parameters.deny, expected) with input.attestations as [provenance]
 }
 
 test_restrict_shared_volumes_existing_pvc if {
@@ -42,7 +46,7 @@ test_restrict_shared_volumes_existing_pvc if {
 		"code": "external_parameters.restrict_shared_volumes",
 		"msg": "PipelineRun uses shared volumes, {{\"persistentVolumeClaim\": {\"claimName\": \"my-pvc\"}}}.",
 	}}
-	lib.assert_equal_results(deny, expected) with input.attestations as [provenance]
+	lib.assert_equal_results(external_parameters.deny, expected) with input.attestations as [provenance]
 }
 
 good_provenance := {"statement": {

--- a/policy/release/github_certificate.rego
+++ b/policy/release/github_certificate.rego
@@ -122,12 +122,17 @@ _fulcio_extension_value(ext) := value if {
 	value := base64.decode(extension.Value)
 }
 
+# regal ignore:prefer-snake-case
 _TRIGGER := {"id": 2, "name": "GitHub Workflow Trigger"}
 
+# regal ignore:prefer-snake-case
 _SHA := {"id": 3, "name": "GitHub Workflow SHA"}
 
+# regal ignore:prefer-snake-case
 _NAME := {"id": 4, "name": "GitHub Workflow Name"}
 
+# regal ignore:prefer-snake-case
 _REPOSITORY := {"id": 5, "name": "GitHub Workflow Repository"}
 
+# regal ignore:prefer-snake-case
 _REF := {"id": 6, "name": "GitHub Workflow Ref"}

--- a/policy/release/github_certificate_test.rego
+++ b/policy/release/github_certificate_test.rego
@@ -1,26 +1,27 @@
-package policy.release.github_certificate
+package policy.release.github_certificate_test
 
 import future.keywords.contains
 import future.keywords.if
 import future.keywords.in
 
 import data.lib
+import data.policy.release.github_certificate
 
 test_all_good if {
 	signatures := [{"certificate": good_cert}]
-	lib.assert_empty(deny) with input.image.signatures as signatures
-	lib.assert_empty(warn) with input.image.signatures as signatures
+	lib.assert_empty(github_certificate.deny) with input.image.signatures as signatures
+	lib.assert_empty(github_certificate.warn) with input.image.signatures as signatures
 }
 
 test_at_least_one_good if {
 	signatures := [{"certificate": good_cert}, {"certificate": bad_cert}]
-	lib.assert_empty(deny) with input.image.signatures as signatures
-	lib.assert_empty(warn) with input.image.signatures as signatures
+	lib.assert_empty(github_certificate.deny) with input.image.signatures as signatures
+	lib.assert_empty(github_certificate.warn) with input.image.signatures as signatures
 }
 
 test_gh_workflow_repository_match if {
 	signatures := [{"certificate": good_cert}]
-	lib.assert_empty(deny) with input.image.signatures as signatures
+	lib.assert_empty(github_certificate.deny) with input.image.signatures as signatures
 		with data.rule_data.allowed_gh_workflow_repos as ["spam", "lcarva/festoji", "eggs"]
 }
 
@@ -30,13 +31,13 @@ test_gh_workflow_repository_mismatch if {
 		"code": "github_certificate.gh_workflow_repository",
 		"msg": "Repository \"lcarva/festoji\" not in allowed list: [\"ec-cli\", \"ec-policies\"]",
 	}}
-	lib.assert_equal_results(deny, expected) with input.image.signatures as signatures
+	lib.assert_equal_results(github_certificate.deny, expected) with input.image.signatures as signatures
 		with data.rule_data.allowed_gh_workflow_repos as ["ec-cli", "ec-policies"]
 }
 
 test_gh_workflow_ref_match if {
 	signatures := [{"certificate": good_cert}]
-	lib.assert_empty(deny) with input.image.signatures as signatures
+	lib.assert_empty(github_certificate.deny) with input.image.signatures as signatures
 		with data.rule_data.allowed_gh_workflow_refs as ["refs/heads/master", "refs/heads/main"]
 }
 
@@ -46,13 +47,13 @@ test_gh_workflow_ref_mismatch if {
 		"code": "github_certificate.gh_workflow_ref",
 		"msg": "Ref \"refs/heads/master\" not in allowed list: [\"refs/heads/prod\"]",
 	}}
-	lib.assert_equal_results(deny, expected) with input.image.signatures as signatures
+	lib.assert_equal_results(github_certificate.deny, expected) with input.image.signatures as signatures
 		with data.rule_data.allowed_gh_workflow_refs as ["refs/heads/prod"]
 }
 
 test_gh_workflow_name_match if {
 	signatures := [{"certificate": good_cert}]
-	lib.assert_empty(deny) with input.image.signatures as signatures
+	lib.assert_empty(github_certificate.deny) with input.image.signatures as signatures
 		with data.rule_data.allowed_gh_workflow_names as ["Package"]
 }
 
@@ -62,13 +63,13 @@ test_gh_workflow_name_mismatch if {
 		"code": "github_certificate.gh_workflow_name",
 		"msg": "Name \"Package\" not in allowed list: [\"hackery\"]",
 	}}
-	lib.assert_equal_results(deny, expected) with input.image.signatures as signatures
+	lib.assert_equal_results(github_certificate.deny, expected) with input.image.signatures as signatures
 		with data.rule_data.allowed_gh_workflow_names as ["hackery"]
 }
 
 test_gh_workflow_trigger_match if {
 	signatures := [{"certificate": good_cert}]
-	lib.assert_empty(deny) with input.image.signatures as signatures
+	lib.assert_empty(github_certificate.deny) with input.image.signatures as signatures
 		with data.rule_data.allowed_gh_workflow_triggers as ["push"]
 }
 
@@ -78,7 +79,7 @@ test_gh_workflow_trigger_mismatch if {
 		"code": "github_certificate.gh_workflow_trigger",
 		"msg": "Trigger \"push\" not in allowed list: [\"build\"]",
 	}}
-	lib.assert_equal_results(deny, expected) with input.image.signatures as signatures
+	lib.assert_equal_results(github_certificate.deny, expected) with input.image.signatures as signatures
 		with data.rule_data.allowed_gh_workflow_triggers as ["build"]
 }
 
@@ -105,13 +106,13 @@ test_missing_extensions if {
 			"msg": "Missing extension \"GitHub Workflow Trigger\"",
 		},
 	}
-	lib.assert_equal_results(warn, expected)
-	lib.assert_equal_results(warn, expected) with input as {}
-	lib.assert_equal_results(warn, expected) with input.image as {}
-	lib.assert_equal_results(warn, expected) with input.image.signatures as []
-	lib.assert_equal_results(warn, expected) with input.image.signatures as [{}]
-	lib.assert_equal_results(warn, expected) with input.image.signatures as [{"certificate": ""}]
-	lib.assert_equal_results(warn, expected) with input.image.signatures as [{"certificate": bad_cert}]
+	lib.assert_equal_results(github_certificate.warn, expected)
+	lib.assert_equal_results(github_certificate.warn, expected) with input as {}
+	lib.assert_equal_results(github_certificate.warn, expected) with input.image as {}
+	lib.assert_equal_results(github_certificate.warn, expected) with input.image.signatures as []
+	lib.assert_equal_results(github_certificate.warn, expected) with input.image.signatures as [{}]
+	lib.assert_equal_results(github_certificate.warn, expected) with input.image.signatures as [{"certificate": ""}]
+	lib.assert_equal_results(github_certificate.warn, expected) with input.image.signatures as [{"certificate": bad_cert}]
 }
 
 # This is a certificate used when signing an image on GitHub. It

--- a/policy/release/hermetic_build_task_test.rego
+++ b/policy/release/hermetic_build_task_test.rego
@@ -1,11 +1,12 @@
-package policy.release.hermetic_build_task
+package policy.release.hermetic_build_task_test
 
 import future.keywords.if
 
 import data.lib
+import data.policy.release.hermetic_build_task
 
 test_hermetic_build if {
-	lib.assert_empty(deny) with input.attestations as [_good_attestation]
+	lib.assert_empty(hermetic_build_task.deny) with input.attestations as [_good_attestation]
 }
 
 test_not_hermetic_build if {
@@ -19,14 +20,15 @@ test_not_hermetic_build if {
 		"path": "/statement/predicate/buildConfig/tasks/0/invocation/parameters/HERMETIC",
 		"value": "false",
 	}])
-	lib.assert_equal_results(expected, deny) with input.attestations as [hermetic_not_true]
+	lib.assert_equal_results(expected, hermetic_build_task.deny) with input.attestations as [hermetic_not_true]
 
+	# regal ignore:line-length
 	hermetic_missing := json.remove(_good_attestation, ["/statement/predicate/buildConfig/tasks/0/invocation/parameters/HERMETIC"])
-	lib.assert_equal_results(expected, deny) with input.attestations as [hermetic_missing]
+	lib.assert_equal_results(expected, hermetic_build_task.deny) with input.attestations as [hermetic_missing]
 }
 
 _good_attestation := {"statement": {"predicate": {
-	"buildType": lib.pipelinerun_att_build_types[0],
+	"buildType": lib.tekton_pipeline_run,
 	"buildConfig": {"tasks": [{
 		"results": [
 			{"name": "IMAGE_URL", "value": "registry/repo"},

--- a/policy/release/java_test.rego
+++ b/policy/release/java_test.rego
@@ -1,19 +1,21 @@
-package policy.release.java
+package policy.release.java_test
 
 import data.lib
+import data.lib_test
+import data.policy.release.java
 
 test_all_good {
-	attestations := [lib.att_mock_helper_ref(
+	attestations := [lib_test.att_mock_helper_ref(
 		lib.java_sbom_component_count_result_name,
 		{"redhat": 12, "rebuilt": 42},
 		"java-task-1",
 		_bundle,
 	)]
-	lib.assert_empty(deny) with input.attestations as attestations
+	lib.assert_empty(java.deny) with input.attestations as attestations
 }
 
 test_has_foreign {
-	attestations := [lib.att_mock_helper_ref(
+	attestations := [lib_test.att_mock_helper_ref(
 		lib.java_sbom_component_count_result_name,
 		{"redhat": 12, "rebuilt": 42, "central": 1},
 		"java-task-1",
@@ -23,7 +25,7 @@ test_has_foreign {
 		"code": "java.no_foreign_dependencies",
 		"msg": "Found Java dependencies from 'central', expecting to find only from 'rebuilt,redhat'",
 	}}
-	lib.assert_equal_results(deny, expected) with input.attestations as attestations
+	lib.assert_equal_results(java.deny, expected) with input.attestations as attestations
 }
 
 test_trusted_dependency_source_list_provided {
@@ -31,7 +33,7 @@ test_trusted_dependency_source_list_provided {
 		"code": "java.trusted_dependencies_source_list_provided",
 		"msg": "Missing required allowed_java_component_sources rule data",
 	}}
-	lib.assert_equal_results(expected, deny) with data.rule_data as {}
+	lib.assert_equal_results(expected, java.deny) with data.rule_data as {}
 }
 
 _bundle := "registry.img/spam@sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb"

--- a/policy/release/labels.rego
+++ b/policy/release/labels.rego
@@ -128,13 +128,11 @@ parent_labels contains label if {
 	label := {"name": name, "value": value}
 }
 
-_value(labels, name) := value if {
-	value := [v |
-		some label in labels
-		label.name == name
-		v := label.value
-	][0]
-}
+_value(labels, name) := [v |
+	some label in labels
+	label.name == name
+	v := label.value
+][0]
 
 required_labels := lib.rule_data("required_labels") if {
 	not is_fbc

--- a/policy/release/labels_test.rego
+++ b/policy/release/labels_test.rego
@@ -1,12 +1,13 @@
-package policy.release.labels
+package policy.release.labels_test
 
 import future.keywords.if
 
 import data.lib
+import data.policy.release.labels
 
 test_all_good if {
-	lib.assert_empty(deny | warn) with input.image as _image with data.rule_data as _rule_data
-	lib.assert_empty(deny | warn) with input.image as _fbc_image with data.rule_data as _rule_data
+	lib.assert_empty(labels.deny | labels.warn) with input.image as _image with data.rule_data as _rule_data
+	lib.assert_empty(labels.deny | labels.warn) with input.image as _fbc_image with data.rule_data as _rule_data
 }
 
 test_deprecated_image_labels if {
@@ -16,7 +17,7 @@ test_deprecated_image_labels if {
 		"term": "oldie",
 	}}
 
-	lib.assert_equal_results(deny, expected) with input.image as json.patch(_image, [{
+	lib.assert_equal_results(labels.deny, expected) with input.image as json.patch(_image, [{
 		"op": "add",
 		"path": "/config/Labels/oldie",
 		"value": "sudo rm -rf /",
@@ -31,7 +32,7 @@ test_required_image_labels if {
 		"term": "name",
 	}}
 
-	lib.assert_equal_results(deny, expected) with input.image as json.remove(_image, ["/config/Labels/name"])
+	lib.assert_equal_results(labels.deny, expected) with input.image as json.remove(_image, ["/config/Labels/name"])
 		with data.rule_data as _rule_data
 }
 
@@ -42,7 +43,10 @@ test_fbc_required_image_labels if {
 		"term": "fbc.name",
 	}}
 
-	lib.assert_equal_results(deny, expected) with input.image as json.remove(_fbc_image, ["/config/Labels/fbc.name"])
+	lib.assert_equal_results(
+		labels.deny,
+		expected,
+	) with input.image as json.remove(_fbc_image, ["/config/Labels/fbc.name"])
 		with data.rule_data as _rule_data
 }
 
@@ -53,7 +57,7 @@ test_optional_image_labels if {
 		"term": "summary",
 	}}
 
-	lib.assert_equal_results(warn, expected) with input.image as json.remove(_image, ["/config/Labels/summary"])
+	lib.assert_equal_results(labels.warn, expected) with input.image as json.remove(_image, ["/config/Labels/summary"])
 		with data.rule_data as _rule_data
 }
 
@@ -64,7 +68,10 @@ test_fbc_optional_image_labels if {
 		"term": "fbc.summary",
 	}}
 
-	lib.assert_equal_results(warn, expected) with input.image as json.remove(_fbc_image, ["/config/Labels/fbc.summary"])
+	lib.assert_equal_results(
+		labels.warn,
+		expected,
+	) with input.image as json.remove(_fbc_image, ["/config/Labels/fbc.summary"])
 		with data.rule_data as _rule_data
 }
 
@@ -79,16 +86,16 @@ test_disallowed_inherited_image_labels if {
 		{"op": "add", "path": "/config/Labels/unique", "value": "spam"},
 		{"op": "add", "path": "/parent/config/Labels/unique", "value": "spam"},
 	])
-	lib.assert_equal_results(deny, expected) with input.image as image with data.rule_data as _rule_data
+	lib.assert_equal_results(labels.deny, expected) with input.image as image with data.rule_data as _rule_data
 
 	# A missing label on either image does not trigger a violation.
-	lib.assert_empty(deny) with input.image as json.patch(_image, [{
+	lib.assert_empty(labels.deny) with input.image as json.patch(_image, [{
 		"op": "add",
 		"path": "/parent/config/Labels/unique",
 		"value": "spam",
 	}])
 		with data.rule_data as _rule_data
-	lib.assert_empty(deny) with input.image as json.patch(_image, [{
+	lib.assert_empty(labels.deny) with input.image as json.patch(_image, [{
 		"op": "add",
 		"path": "/config/Labels/unique",
 		"value": "spam",
@@ -107,16 +114,16 @@ test_fbc_disallowed_inherited_image_labels if {
 		{"op": "add", "path": "/config/Labels/fbc.unique", "value": "spam"},
 		{"op": "add", "path": "/parent/config/Labels/fbc.unique", "value": "spam"},
 	])
-	lib.assert_equal_results(deny, expected) with input.image as image with data.rule_data as _rule_data
+	lib.assert_equal_results(labels.deny, expected) with input.image as image with data.rule_data as _rule_data
 
 	# A missing label on either image does not trigger a violation.
-	lib.assert_empty(deny) with input.image as json.patch(_fbc_image, [{
+	lib.assert_empty(labels.deny) with input.image as json.patch(_fbc_image, [{
 		"op": "add",
 		"path": "/parent/config/Labels/fbc.unique",
 		"value": "spam",
 	}])
 		with data.rule_data as _rule_data
-	lib.assert_empty(deny) with input.image as json.patch(_fbc_image, [{
+	lib.assert_empty(labels.deny) with input.image as json.patch(_fbc_image, [{
 		"op": "add",
 		"path": "/config/Labels/fbc.unique",
 		"value": "spam",

--- a/policy/release/olm_test.rego
+++ b/policy/release/olm_test.rego
@@ -1,16 +1,17 @@
-package policy.release.olm
+package policy.release.olm_test
 
 import future.keywords.if
 
 import data.lib
+import data.policy.release.olm
 
 pinned := "registry.io/repository/image@sha256:cafe"
 
 pinned2 := "registry.io/repository/image2@sha256:cafe"
 
-pinned_ref = {"digest": "sha256:cafe", "repo": "registry.io/repository/image", "tag": ""}
+pinned_ref := {"digest": "sha256:cafe", "repo": "registry.io/repository/image", "tag": ""}
 
-pinned_ref2 = {"digest": "sha256:cafe", "repo": "registry.io/repository/image2", "tag": ""}
+pinned_ref2 := {"digest": "sha256:cafe", "repo": "registry.io/repository/image2", "tag": ""}
 
 manifest := {
 	"apiVersion": "operators.coreos.com/v1alpha1",
@@ -55,23 +56,38 @@ test_all_image_ref if {
 			{"path": "annotations[\"enclosurePicture\"]", "ref": pinned_ref2},
 			{"path": "annotations[\"docket\"]", "ref": pinned_ref},
 			{"path": "annotations[\"docket\"]", "ref": pinned_ref2},
-			{"path": "spec.install.spec.deployments[0 (\"unnamed\")].spec.template.spec.containers[0 (\"c1\")].image", "ref": pinned_ref},
-			{"path": "spec.install.spec.deployments[0 (\"unnamed\")].spec.template.spec.initContainers[0 (\"i1\")].image", "ref": pinned_ref},
-			{"path": "spec.install.spec.deployments[0 (\"unnamed\")].spec.template.spec.containers[0 (\"c1\")].env[\"RELATED_IMAGE_C1\"]", "ref": pinned_ref},
-			{"path": "spec.install.spec.deployments[0 (\"unnamed\")].spec.template.spec.initContainers[0 (\"i1\")].env[\"RELATED_IMAGE_E1\"]", "ref": pinned_ref},
+			{
+				"path": `spec.install.spec.deployments[0 ("unnamed")].spec.template.spec.containers[0 ("c1")].image`,
+				"ref": pinned_ref,
+			},
+			{
+				# regal ignore:line-length
+				"path": `spec.install.spec.deployments[0 ("unnamed")].spec.template.spec.initContainers[0 ("i1")].image`,
+				"ref": pinned_ref,
+			},
+			{
+				# regal ignore:line-length
+				"path": `spec.install.spec.deployments[0 ("unnamed")].spec.template.spec.containers[0 ("c1")].env["RELATED_IMAGE_C1"]`,
+				"ref": pinned_ref,
+			},
+			{
+				# regal ignore:line-length
+				"path": `spec.install.spec.deployments[0 ("unnamed")].spec.template.spec.initContainers[0 ("i1")].env["RELATED_IMAGE_E1"]`,
+				"ref": pinned_ref,
+			},
 		],
-		all_image_ref(manifest),
+		olm.all_image_ref(manifest),
 	)
 }
 
 test_all_good if {
-	lib.assert_empty(deny) with input.image.files as {"manifests/csv.yaml": manifest}
-		with input.image.config.Labels as {olm_manifestv1: "manifests/"}
+	lib.assert_empty(olm.deny) with input.image.files as {"manifests/csv.yaml": manifest}
+		with input.image.config.Labels as {olm.olm_manifestv1: "manifests/"}
 }
 
 test_all_good_custom_dir if {
-	lib.assert_empty(deny) with input.image.files as {"other/csv.yaml": manifest}
-		with input.image.config.Labels as {olm_manifestv1: "other/"}
+	lib.assert_empty(olm.deny) with input.image.files as {"other/csv.yaml": manifest}
+		with input.image.config.Labels as {olm.olm_manifestv1: "other/"}
 }
 
 test_related_img_unpinned if {
@@ -83,10 +99,11 @@ test_related_img_unpinned if {
 
 	expected = {{
 		"code": "olm.unpinned_references",
+		# regal ignore:line-length
 		"msg": `The "registry.io/repository:tag" image reference is not pinned at spec.install.spec.deployments[0 ("unnamed")].spec.template.spec.containers[0 ("c1")].env["RELATED_IMAGE_C1"].`,
 		"term": "registry.io/repository:tag",
 	}}
 
-	lib.assert_equal_results(deny, expected) with input.image.files as {"manifests/csv.yaml": unpinned_manifest}
-		with input.image.config.Labels as {olm_manifestv1: "manifests/"}
+	lib.assert_equal_results(olm.deny, expected) with input.image.files as {"manifests/csv.yaml": unpinned_manifest}
+		with input.image.config.Labels as {olm.olm_manifestv1: "manifests/"}
 }

--- a/policy/release/provenance_materials.rego
+++ b/policy/release/provenance_materials.rego
@@ -70,9 +70,7 @@ deny contains result if {
 	result := lib.result_helper(rego.metadata.chain(), [url, commit])
 }
 
-_normalize_git_url(url) := normalized if {
-	normalized := _suffix_git_url(_prefix_git_url(url))
-}
+_normalize_git_url(url) := _suffix_git_url(_prefix_git_url(url))
 
 _prefix_git_url(url) := normalized if {
 	prefix := "git+"

--- a/policy/release/redhat_manifests_test.rego
+++ b/policy/release/redhat_manifests_test.rego
@@ -1,34 +1,38 @@
-package policy.release.redhat_manifests
+package policy.release.redhat_manifests_test
 
 import future.keywords.contains
 import future.keywords.if
 import future.keywords.in
 
 import data.lib
+import data.policy.release.redhat_manifests
 
 test_success if {
-	lib.assert_empty(deny) with input.image.files as {_sbom_purl_path: {}, _sbom_cyclonedx_path: {}}
+	lib.assert_empty(redhat_manifests.deny) with input.image.files as {
+		redhat_manifests._sbom_purl_path: {},
+		redhat_manifests._sbom_cyclonedx_path: {},
+	}
 }
 
 test_missing_manifests if {
 	cyclonedx_violation := {
 		"code": "redhat_manifests.redhat_manifests_missing",
-		"msg": sprintf("Missing Red Hat manifest \"%s\"", [_sbom_cyclonedx_path]),
-		"term": _sbom_cyclonedx_path,
+		"msg": sprintf("Missing Red Hat manifest \"%s\"", [redhat_manifests._sbom_cyclonedx_path]),
+		"term": redhat_manifests._sbom_cyclonedx_path,
 	}
 	purl_violation := {
 		"code": "redhat_manifests.redhat_manifests_missing",
-		"msg": sprintf("Missing Red Hat manifest \"%s\"", [_sbom_purl_path]),
-		"term": _sbom_purl_path,
+		"msg": sprintf("Missing Red Hat manifest \"%s\"", [redhat_manifests._sbom_purl_path]),
+		"term": redhat_manifests._sbom_purl_path,
 	}
 
-	lib.assert_equal_results({cyclonedx_violation, purl_violation}, deny) with input.image as {}
-	lib.assert_equal_results({purl_violation}, deny) with input.image.files as {
-		_sbom_cyclonedx_path: {},
+	lib.assert_equal_results({cyclonedx_violation, purl_violation}, redhat_manifests.deny) with input.image as {}
+	lib.assert_equal_results({purl_violation}, redhat_manifests.deny) with input.image.files as {
+		redhat_manifests._sbom_cyclonedx_path: {},
 		"something/else": {},
 	}
-	lib.assert_equal_results({cyclonedx_violation}, deny) with input.image.files as {
-		_sbom_purl_path: {},
+	lib.assert_equal_results({cyclonedx_violation}, redhat_manifests.deny) with input.image.files as {
+		redhat_manifests._sbom_purl_path: {},
 		"something/else": {},
 	}
 }

--- a/policy/release/sbom_spdx_test.rego
+++ b/policy/release/sbom_spdx_test.rego
@@ -78,7 +78,7 @@ test_missing_packages if {
 		with input.image.ref as "registry.local/spam@sha256:123"
 }
 
-test_missing_packages if {
+test_missing_files if {
 	expected := {{"code": "sbom_spdx.contains_files", "msg": "The list of files is empty"}}
 	att := json.patch(_sbom_attestation, [{
 		"op": "add",

--- a/policy/release/schedule_test.rego
+++ b/policy/release/schedule_test.rego
@@ -1,45 +1,46 @@
-package policy.release.schedule
+package policy.release.schedule_test
 
 import data.lib
+import data.policy.release.schedule
 
 test_no_restriction_by_default {
-	lib.assert_empty(deny)
+	lib.assert_empty(schedule.deny)
 }
 
 test_weekday_restriction {
 	disallowed := ["friday", "saturday", "sunday"]
 
-	lib.assert_empty(deny) with data.rule_data.disallowed_weekdays as disallowed
+	lib.assert_empty(schedule.deny) with data.rule_data.disallowed_weekdays as disallowed
 		with data.config.policy.when_ns as monday
 
-	lib.assert_empty(deny) with data.rule_data.disallowed_weekdays as disallowed
+	lib.assert_empty(schedule.deny) with data.rule_data.disallowed_weekdays as disallowed
 		with data.config.policy.when_ns as tuesday
 
-	lib.assert_empty(deny) with data.rule_data.disallowed_weekdays as disallowed
+	lib.assert_empty(schedule.deny) with data.rule_data.disallowed_weekdays as disallowed
 		with data.config.policy.when_ns as wednesday
 
-	lib.assert_empty(deny) with data.rule_data.disallowed_weekdays as disallowed
+	lib.assert_empty(schedule.deny) with data.rule_data.disallowed_weekdays as disallowed
 		with data.config.policy.when_ns as thursday
 
 	friday_violation := {{
 		"code": "schedule.weekday_restriction",
 		"msg": "friday is a disallowed weekday: friday, saturday, sunday",
 	}}
-	lib.assert_equal_results(deny, friday_violation) with data.rule_data.disallowed_weekdays as disallowed
+	lib.assert_equal_results(schedule.deny, friday_violation) with data.rule_data.disallowed_weekdays as disallowed
 		with data.config.policy.when_ns as friday
 
 	saturday_violation := {{
 		"code": "schedule.weekday_restriction",
 		"msg": "saturday is a disallowed weekday: friday, saturday, sunday",
 	}}
-	lib.assert_equal_results(deny, saturday_violation) with data.rule_data.disallowed_weekdays as disallowed
+	lib.assert_equal_results(schedule.deny, saturday_violation) with data.rule_data.disallowed_weekdays as disallowed
 		with data.config.policy.when_ns as saturday
 
 	sunday_violation := {{
 		"code": "schedule.weekday_restriction",
 		"msg": "sunday is a disallowed weekday: friday, saturday, sunday",
 	}}
-	lib.assert_equal_results(deny, sunday_violation) with data.rule_data.disallowed_weekdays as disallowed
+	lib.assert_equal_results(schedule.deny, sunday_violation) with data.rule_data.disallowed_weekdays as disallowed
 		with data.config.policy.when_ns as sunday
 }
 
@@ -49,14 +50,14 @@ test_weekday_restriction_case_insensitive {
 		"msg": "friday is a disallowed weekday: friday",
 	}}
 
-	lib.assert_equal_results(deny, violation) with data.rule_data.disallowed_weekdays as ["FRIDAY"]
+	lib.assert_equal_results(schedule.deny, violation) with data.rule_data.disallowed_weekdays as ["FRIDAY"]
 		with data.config.policy.when_ns as friday
-	lib.assert_empty(deny) with data.rule_data.disallowed_weekdays as ["FRIDAY"]
+	lib.assert_empty(schedule.deny) with data.rule_data.disallowed_weekdays as ["FRIDAY"]
 		with data.config.policy.when_ns as monday
 
-	lib.assert_equal_results(deny, violation) with data.rule_data.disallowed_weekdays as ["friday"]
+	lib.assert_equal_results(schedule.deny, violation) with data.rule_data.disallowed_weekdays as ["friday"]
 		with data.config.policy.when_ns as friday
-	lib.assert_empty(deny) with data.rule_data.disallowed_weekdays as ["friday"]
+	lib.assert_empty(schedule.deny) with data.rule_data.disallowed_weekdays as ["friday"]
 		with data.config.policy.when_ns as monday
 }
 
@@ -65,16 +66,16 @@ test_date_restriction {
 		"code": "schedule.date_restriction",
 		"msg": "2023-01-01 is a disallowed date: 2023-01-01",
 	}}
-	lib.assert_equal_results(deny, violation) with data.rule_data.disallowed_dates as ["2023-01-01"]
+	lib.assert_equal_results(schedule.deny, violation) with data.rule_data.disallowed_dates as ["2023-01-01"]
 		with data.config.policy.when_ns as time.parse_rfc3339_ns("2023-01-01T00:00:00Z")
 
-	lib.assert_empty(deny) with data.rule_data.disallowed_dates as ["2023-01-01"]
+	lib.assert_empty(schedule.deny) with data.rule_data.disallowed_dates as ["2023-01-01"]
 		with data.config.policy.when_ns as time.parse_rfc3339_ns("2023-01-02T00:00:00Z")
-	lib.assert_empty(deny) with data.rule_data.disallowed_dates as ["2023-01-01"]
+	lib.assert_empty(schedule.deny) with data.rule_data.disallowed_dates as ["2023-01-01"]
 		with data.config.policy.when_ns as time.parse_rfc3339_ns("2023-02-01T00:00:00Z")
-	lib.assert_empty(deny) with data.rule_data.disallowed_dates as ["2023-01-01"]
+	lib.assert_empty(schedule.deny) with data.rule_data.disallowed_dates as ["2023-01-01"]
 		with data.config.policy.when_ns as time.parse_rfc3339_ns("2024-01-01T00:00:00Z")
-	lib.assert_empty(deny) with data.rule_data.disallowed_dates as ["2023-01-01"]
+	lib.assert_empty(schedule.deny) with data.rule_data.disallowed_dates as ["2023-01-01"]
 		with data.config.policy.when_ns as time.parse_rfc3339_ns("2024-02-03T00:00:00Z")
 }
 

--- a/policy/release/slsa_build_build_service_test.rego
+++ b/policy/release/slsa_build_build_service_test.rego
@@ -1,12 +1,13 @@
-package policy.release.slsa_build_build_service
+package policy.release.slsa_build_build_service_test
 
 import future.keywords.if
 
 import data.lib
+import data.policy.release.slsa_build_build_service
 
 test_all_good if {
 	builder_id := lib.rule_data("allowed_builder_ids")[0]
-	lib.assert_empty(deny) with input.attestations as [_mock_attestation(builder_id)]
+	lib.assert_empty(slsa_build_build_service.deny) with input.attestations as [_mock_attestation(builder_id)]
 }
 
 test_slsa_builder_id_found if {
@@ -14,10 +15,10 @@ test_slsa_builder_id_found if {
 		# Missing predicate.builder.id
 		{"statement": {"predicate": {
 			"builder": {},
-			"buildType": lib.pipelinerun_att_build_types[0],
+			"buildType": lib.tekton_pipeline_run,
 		}}},
 		# Missing predicate.builder
-		{"statement": {"predicate": {"buildType": lib.pipelinerun_att_build_types[0]}}},
+		{"statement": {"predicate": {"buildType": lib.tekton_pipeline_run}}},
 	]
 
 	expected := {{
@@ -25,7 +26,7 @@ test_slsa_builder_id_found if {
 		"msg": "Builder ID not set in attestation",
 	}}
 
-	lib.assert_equal_results(expected, deny) with input.attestations as attestations
+	lib.assert_equal_results(expected, slsa_build_build_service.deny) with input.attestations as attestations
 }
 
 test_accepted_slsa_builder_id if {
@@ -34,12 +35,13 @@ test_accepted_slsa_builder_id if {
 		"code": "slsa_build_build_service.slsa_builder_id_accepted",
 		"msg": "Builder ID \"https://notket.ved/sniahc/2v\" is unexpected",
 	}}
-	lib.assert_equal_results(expected, deny) with input.attestations as [_mock_attestation(builder_id)]
+	lib.assert_equal_results(
+		expected,
+		slsa_build_build_service.deny,
+	) with input.attestations as [_mock_attestation(builder_id)]
 }
 
-_mock_attestation(builder_id) = d if {
-	d := {"statement": {"predicate": {
-		"builder": {"id": builder_id},
-		"buildType": lib.pipelinerun_att_build_types[0],
-	}}}
-}
+_mock_attestation(builder_id) := {"statement": {"predicate": {
+	"builder": {"id": builder_id},
+	"buildType": lib.tekton_pipeline_run,
+}}}

--- a/policy/release/slsa_build_scripted_build_test.rego
+++ b/policy/release/slsa_build_scripted_build_test.rego
@@ -1,10 +1,11 @@
-package policy.release.slsa_build_scripted_build
+package policy.release.slsa_build_scripted_build_test
 
 import future.keywords.contains
 import future.keywords.if
 import future.keywords.in
 
 import data.lib
+import data.policy.release.slsa_build_scripted_build
 
 mock_bundle := "registry.img/spam@sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb"
 
@@ -18,7 +19,7 @@ test_all_good if {
 		"steps": [{"entrypoint": "/bin/bash"}],
 	}]
 
-	lib.assert_empty(deny) with input.attestations as [_mock_attestation(tasks)]
+	lib.assert_empty(slsa_build_scripted_build.deny) with input.attestations as [_mock_attestation(tasks)]
 }
 
 # It's unclear if this should be allowed or not. This unit test exists to
@@ -42,7 +43,10 @@ test_scattered_results if {
 		"msg": "Build task not found",
 	}}
 
-	lib.assert_equal_results(expected, deny) with input.attestations as [_mock_attestation(tasks)]
+	lib.assert_equal_results(
+		expected,
+		slsa_build_scripted_build.deny,
+	) with input.attestations as [_mock_attestation(tasks)]
 }
 
 test_missing_task_steps if {
@@ -60,7 +64,10 @@ test_missing_task_steps if {
 		"msg": "Build task \"buildah\" does not contain any steps",
 	}}
 
-	lib.assert_equal_results(expected, deny) with input.attestations as [_mock_attestation(tasks)]
+	lib.assert_equal_results(
+		expected,
+		slsa_build_scripted_build.deny,
+	) with input.attestations as [_mock_attestation(tasks)]
 }
 
 test_empty_task_steps if {
@@ -78,7 +85,10 @@ test_empty_task_steps if {
 		"msg": "Build task \"buildah\" does not contain any steps",
 	}}
 
-	lib.assert_equal_results(expected, deny) with input.attestations as [_mock_attestation(tasks)]
+	lib.assert_equal_results(
+		expected,
+		slsa_build_scripted_build.deny,
+	) with input.attestations as [_mock_attestation(tasks)]
 }
 
 test_results_missing_value_url if {
@@ -96,7 +106,10 @@ test_results_missing_value_url if {
 		"msg": "Build task not found",
 	}}
 
-	lib.assert_equal_results(expected, deny) with input.attestations as [_mock_attestation(tasks)]
+	lib.assert_equal_results(
+		expected,
+		slsa_build_scripted_build.deny,
+	) with input.attestations as [_mock_attestation(tasks)]
 }
 
 test_results_missing_value_digest if {
@@ -114,7 +127,10 @@ test_results_missing_value_digest if {
 		"msg": "Build task not found",
 	}}
 
-	lib.assert_equal_results(expected, deny) with input.attestations as [_mock_attestation(tasks)]
+	lib.assert_equal_results(
+		expected,
+		slsa_build_scripted_build.deny,
+	) with input.attestations as [_mock_attestation(tasks)]
 }
 
 test_results_empty_value_url if {
@@ -132,7 +148,10 @@ test_results_empty_value_url if {
 		"msg": "Build task not found",
 	}}
 
-	lib.assert_equal_results(expected, deny) with input.attestations as [_mock_attestation(tasks)]
+	lib.assert_equal_results(
+		expected,
+		slsa_build_scripted_build.deny,
+	) with input.attestations as [_mock_attestation(tasks)]
 }
 
 test_results_empty_value_digest if {
@@ -150,7 +169,10 @@ test_results_empty_value_digest if {
 		"msg": "Build task not found",
 	}}
 
-	lib.assert_equal_results(expected, deny) with input.attestations as [_mock_attestation(tasks)]
+	lib.assert_equal_results(
+		expected,
+		slsa_build_scripted_build.deny,
+	) with input.attestations as [_mock_attestation(tasks)]
 }
 
 test_subject_mismatch if {
@@ -165,10 +187,14 @@ test_subject_mismatch if {
 
 	expected := {{
 		"code": "slsa_build_scripted_build.subject_build_task_matches",
-		"msg": "The attestation subject, \"some.image/foo:bar@sha256:123\", does not match the build task image, \"some.image/foo:bar@sha256:anotherdigest\"",
+		# regal ignore:line-length
+		"msg": `The attestation subject, "some.image/foo:bar@sha256:123", does not match the build task image, "some.image/foo:bar@sha256:anotherdigest"`,
 	}}
 
-	lib.assert_equal_results(expected, deny) with input.attestations as [_mock_attestation(tasks)]
+	lib.assert_equal_results(
+		expected,
+		slsa_build_scripted_build.deny,
+	) with input.attestations as [_mock_attestation(tasks)]
 }
 
 test_subject_with_tag_and_digest_is_good if {
@@ -181,13 +207,13 @@ test_subject_with_tag_and_digest_is_good if {
 		"steps": [{"entrypoint": "/bin/bash"}],
 	}]
 
-	lib.assert_empty(deny) with input.attestations as [{"statement": {
+	lib.assert_empty(slsa_build_scripted_build.deny) with input.attestations as [{"statement": {
 		"subject": [{
 			"name": "registry.io/repository/image",
 			"digest": {"sha256": "digest"},
 		}],
 		"predicate": {
-			"buildType": lib.pipelinerun_att_build_types[0],
+			"buildType": lib.tekton_pipeline_run,
 			"buildConfig": {"tasks": tasks},
 		},
 	}}]
@@ -203,13 +229,13 @@ test_subject_with_tag_and_digest_mismatch_tag_is_good if {
 		"steps": [{"entrypoint": "/bin/bash"}],
 	}]
 
-	lib.assert_empty(deny) with input.attestations as [{"statement": {
+	lib.assert_empty(slsa_build_scripted_build.deny) with input.attestations as [{"statement": {
 		"subject": [{
 			"name": "registry.io/repository/image:different",
 			"digest": {"sha256": "digest"},
 		}],
 		"predicate": {
-			"buildType": lib.pipelinerun_att_build_types[0],
+			"buildType": lib.tekton_pipeline_run,
 			"buildConfig": {"tasks": tasks},
 		},
 	}}]
@@ -227,16 +253,17 @@ test_subject_with_tag_and_digest_mismatch_digest_fails if {
 
 	expected := {{
 		"code": "slsa_build_scripted_build.subject_build_task_matches",
-		"msg": "The attestation subject, \"registry.io/repository/image@sha256:unexpected\", does not match the build task image, \"registry.io/repository/image:tag@sha256:digest\"",
+		# regal ignore:line-length
+		"msg": `The attestation subject, "registry.io/repository/image@sha256:unexpected", does not match the build task image, "registry.io/repository/image:tag@sha256:digest"`,
 	}}
 
-	lib.assert_equal_results(expected, deny) with input.attestations as [{"statement": {
+	lib.assert_equal_results(expected, slsa_build_scripted_build.deny) with input.attestations as [{"statement": {
 		"subject": [{
 			"name": "registry.io/repository/image",
 			"digest": {"sha256": "unexpected"},
 		}],
 		"predicate": {
-			"buildType": lib.pipelinerun_att_build_types[0],
+			"buildType": lib.tekton_pipeline_run,
 			"buildConfig": {"tasks": tasks},
 		},
 	}}]
@@ -250,7 +277,7 @@ _image_digest_value := "123"
 
 _image_digest := concat(":", [_image_digest_algorithm, _image_digest_value])
 
-_mock_attestation(original_tasks) = d if {
+_mock_attestation(original_tasks) := d if {
 	default_task := {
 		"name": "buildah",
 		"ref": {"kind": "Task"},
@@ -267,7 +294,7 @@ _mock_attestation(original_tasks) = d if {
 			"digest": {_image_digest_algorithm: _image_digest_value},
 		}],
 		"predicate": {
-			"buildType": lib.pipelinerun_att_build_types[0],
+			"buildType": lib.tekton_pipeline_run,
 			"buildConfig": {"tasks": tasks},
 		},
 	}}

--- a/policy/release/slsa_provenance_available_test.rego
+++ b/policy/release/slsa_provenance_available_test.rego
@@ -1,12 +1,13 @@
-package policy.release.slsa_provenance_available
+package policy.release.slsa_provenance_available_test
 
 import future.keywords.in
 
 import data.lib
+import data.policy.release.slsa_provenance_available
 
 test_expected_predicate_type {
 	attestations := _mock_attestations(["https://slsa.dev/provenance/v0.2"])
-	lib.assert_empty(deny) with input.attestations as attestations
+	lib.assert_empty(slsa_provenance_available.deny) with input.attestations as attestations
 }
 
 test_att_predicate_type {
@@ -15,15 +16,13 @@ test_att_predicate_type {
 		"code": "slsa_provenance_available.attestation_predicate_type_accepted",
 		"msg": "Attestation predicate type \"spam\" is not an expected type (https://slsa.dev/provenance/v0.2)",
 	}}
-	lib.assert_equal_results(deny, expected_deny) with input.attestations as attestations
+	lib.assert_equal_results(slsa_provenance_available.deny, expected_deny) with input.attestations as attestations
 }
 
-_mock_attestations(types) = attestations {
-	attestations := [attestation |
-		some type in types
-		attestation := {"statement": {
-			"predicateType": type,
-			"predicate": {"buildType": lib.pipelinerun_att_build_types[0]},
-		}}
-	]
-}
+_mock_attestations(types) := [attestation |
+	some type in types
+	attestation := {"statement": {
+		"predicateType": type,
+		"predicate": {"buildType": lib.tekton_pipeline_run},
+	}}
+]

--- a/policy/release/slsa_source_version_controlled.rego
+++ b/policy/release/slsa_source_version_controlled.rego
@@ -106,12 +106,13 @@ deny contains result if {
 deny contains result if {
 	some material in materials
 	commit := material.digest.sha1
-	not regex.match("^[a-f0-9]{40}$", commit)
+	not regex.match(`^[a-f0-9]{40}$`, commit)
 	result := lib.result_helper(rego.metadata.chain(), [commit])
 }
 
 materials contains material if {
-	some material in lib.pipelinerun_attestations[_].predicate.materials
+	some attestation in lib.pipelinerun_attestations
+	some material in attestation.predicate.materials
 	material.uri
 	material.digest.sha1
 }

--- a/policy/release/slsa_source_version_controlled_test.rego
+++ b/policy/release/slsa_source_version_controlled_test.rego
@@ -1,8 +1,9 @@
-package policy.release.slsa_source_version_controlled
+package policy.release.slsa_source_version_controlled_test
 
 import future.keywords.if
 
 import data.lib
+import data.policy.release.slsa_source_version_controlled
 
 test_all_good if {
 	materials := [
@@ -16,7 +17,7 @@ test_all_good if {
 		},
 	]
 
-	lib.assert_empty(deny) with input.attestations as [_mock_attestation(materials)]
+	lib.assert_empty(slsa_source_version_controlled.deny) with input.attestations as [_mock_attestation(materials)]
 }
 
 test_non_git_uri if {
@@ -42,7 +43,10 @@ test_non_git_uri if {
 		},
 	}
 
-	lib.assert_equal_results(expected, deny) with input.attestations as [_mock_attestation(materials)]
+	lib.assert_equal_results(
+		expected,
+		slsa_source_version_controlled.deny,
+	) with input.attestations as [_mock_attestation(materials)]
 }
 
 test_non_git_commit if {
@@ -79,7 +83,10 @@ test_non_git_commit if {
 		},
 	}
 
-	lib.assert_equal_results(expected, deny) with input.attestations as [_mock_attestation(materials)]
+	lib.assert_equal_results(
+		expected,
+		slsa_source_version_controlled.deny,
+	) with input.attestations as [_mock_attestation(materials)]
 }
 
 test_invalid_materials if {
@@ -97,12 +104,13 @@ test_invalid_materials if {
 		"msg": "No materials match expected format",
 	}}
 
-	lib.assert_equal_results(expected, deny) with input.attestations as [_mock_attestation(materials)]
+	lib.assert_equal_results(
+		expected,
+		slsa_source_version_controlled.deny,
+	) with input.attestations as [_mock_attestation(materials)]
 }
 
-_mock_attestation(materials) = d if {
-	d := {"statement": {"predicate": {
-		"buildType": lib.pipelinerun_att_build_types[0],
-		"materials": materials,
-	}}}
-}
+_mock_attestation(materials) := {"statement": {"predicate": {
+	"buildType": lib.tekton_pipeline_run,
+	"materials": materials,
+}}}

--- a/policy/release/step_image_registries.rego
+++ b/policy/release/step_image_registries.rego
@@ -33,8 +33,9 @@ import data.lib
 #   - attestation_type.known_attestation_type
 #
 deny contains result if {
-	some task in lib.pipelinerun_attestations[_].predicate.buildConfig.tasks
-	step := task.steps[step_index]
+	some attestation in lib.pipelinerun_attestations
+	some task in attestation.predicate.buildConfig.tasks
+	some step_index, step in task.steps
 	image_ref := step.environment.image
 	allowed_registry_prefixes := lib.rule_data("allowed_step_image_registry_prefixes")
 	not image_ref_permitted(image_ref, allowed_registry_prefixes)
@@ -63,5 +64,6 @@ deny contains result if {
 }
 
 image_ref_permitted(image_ref, allowed_prefixes) if {
-	startswith(image_ref, allowed_prefixes[_])
+	some allowed_prefix in allowed_prefixes
+	startswith(image_ref, allowed_prefix)
 }

--- a/policy/release/step_image_registries_test.rego
+++ b/policy/release/step_image_registries_test.rego
@@ -1,25 +1,24 @@
-package policy.release.step_image_registries
+package policy.release.step_image_registries_test
 
 import data.lib
+import data.policy.release.step_image_registries
 
 good_image := "registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:af7dd5b3b"
 
 bad_image := "hackz.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:af7dd5b3b"
 
-mock_data(image_ref) = d {
-	d := [{"statement": {"predicate": {
-		"buildType": lib.pipelinerun_att_build_types[0],
-		"buildConfig": {"tasks": [{"name": "mytask", "steps": [{"environment": {"image": image_ref}}]}]},
-	}}}]
-}
+mock_data(image_ref) := [{"statement": {"predicate": {
+	"buildType": lib.tekton_pipeline_run,
+	"buildConfig": {"tasks": [{"name": "mytask", "steps": [{"environment": {"image": image_ref}}]}]},
+}}}]
 
 test_image_registry_valid {
-	lib.assert_empty(deny) with input.attestations as mock_data(good_image)
+	lib.assert_empty(step_image_registries.deny) with input.attestations as mock_data(good_image)
 }
 
 test_attestation_type_invalid {
 	expected_msg := sprintf("Step 0 in task 'mytask' has disallowed image ref '%s'", [bad_image])
-	lib.assert_equal_results(deny, {{
+	lib.assert_equal_results(step_image_registries.deny, {{
 		"code": "step_image_registries.task_step_images_permitted",
 		"msg": expected_msg,
 	}}) with input.attestations as mock_data(bad_image)
@@ -30,5 +29,5 @@ test_step_image_registry_prefix_list_found {
 		"code": "step_image_registries.step_image_registry_prefix_list_provided",
 		"msg": "Missing required allowed_step_image_registry_prefixes rule data",
 	}}
-	lib.assert_equal_results(expected, deny) with data.rule_data as {}
+	lib.assert_equal_results(expected, step_image_registries.deny) with data.rule_data as {}
 }

--- a/policy/release/tasks.rego
+++ b/policy/release/tasks.rego
@@ -165,14 +165,12 @@ deny contains result if {
 
 # _missing_tasks returns a set of task names that are in the given
 # required_tasks, but not in the PipelineRun attestation.
-_missing_tasks(required_tasks) := tasks if {
-	tasks := {task |
-		some att in lib.pipelinerun_attestations
-		count(tkn.tasks(att)) > 0
+_missing_tasks(required_tasks) := {task |
+	some att in lib.pipelinerun_attestations
+	count(tkn.tasks(att)) > 0
 
-		some task in required_tasks
-		not task in tkn.tasks_names(att)
-	}
+	some task in required_tasks
+	not task in tkn.tasks_names(att)
 }
 
 # get the future tasks that are pipeline specific. If none exists

--- a/policy/release/test_test.rego
+++ b/policy/release/test_test.rego
@@ -1,59 +1,73 @@
-package policy.release.test
+package policy.release.test_test
 
 import data.lib
+import data.lib_test
+import data.policy.release.test
 
 # Because TEST_OUTPUT isn't in the task results, the lib.results_from_tests will be empty
-mock_empty_data := [lib.att_mock_helper_ref("NOT_TEST_OUTPUT", {}, "task1", _bundle)]
+mock_empty_data := [lib_test.att_mock_helper_ref("NOT_TEST_OUTPUT", {}, "task1", _bundle)]
 
 test_needs_non_empty_data {
-	lib.assert_equal_results(deny, {{
+	lib.assert_equal_results(test.deny, {{
 		"code": "test.test_data_found",
 		"msg": "No test data found",
 	}}) with input.attestations as mock_empty_data
 }
 
 # There is a test result, but the data inside it doesn't include the "result" key
-mock_without_results_data := [lib.att_mock_helper_ref(lib.task_test_result_name, {"rezult": "SUCCESS"}, "task1", _bundle)]
+mock_without_results_data := [lib_test.att_mock_helper_ref(
+	lib.task_test_result_name, {"rezult": "SUCCESS"},
+	"task1", _bundle,
+)]
 
 test_needs_tests_with_results {
-	lib.assert_equal_results(deny, {{
+	lib.assert_equal_results(test.deny, {{
 		"code": "test.test_results_found",
 		"msg": "Found tests without results",
 	}}) with input.attestations as mock_without_results_data
 }
 
 mock_without_results_data_mixed := [
-	lib.att_mock_helper_ref(lib.task_test_result_name, {"result": "SUCCESS"}, "task1", _bundle),
-	lib.att_mock_helper_ref(lib.task_test_result_name, {"rezult": "SUCCESS"}, "task2", _bundle),
+	lib_test.att_mock_helper_ref(lib.task_test_result_name, {"result": "SUCCESS"}, "task1", _bundle),
+	lib_test.att_mock_helper_ref(lib.task_test_result_name, {"rezult": "SUCCESS"}, "task2", _bundle),
 ]
 
 test_needs_tests_with_results_mixed {
-	lib.assert_equal_results(deny, {{
+	lib.assert_equal_results(test.deny, {{
 		"code": "test.test_results_found",
 		"msg": "Found tests without results",
 	}}) with input.attestations as mock_without_results_data_mixed
 }
 
-mock_a_passing_test := [lib.att_mock_helper_ref(lib.task_test_result_name, {"result": "SUCCESS"}, "task1", _bundle)]
+mock_a_passing_test := [lib_test.att_mock_helper_ref(
+	lib.task_test_result_name,
+	{"result": "SUCCESS"}, "task1", _bundle,
+)]
 
 test_success_data {
-	lib.assert_empty(deny) with input.attestations as mock_a_passing_test
+	lib.assert_empty(test.deny) with input.attestations as mock_a_passing_test
 }
 
-mock_a_failing_test := [lib.att_mock_helper_ref(lib.task_test_result_name, {"result": "FAILURE"}, "failed_1", _bundle)]
+mock_a_failing_test := [lib_test.att_mock_helper_ref(
+	lib.task_test_result_name,
+	{"result": "FAILURE"}, "failed_1", _bundle,
+)]
 
 test_failure_data {
-	lib.assert_equal_results(deny, {{
+	lib.assert_equal_results(test.deny, {{
 		"code": "test.required_tests_passed",
 		"msg": "Test \"failed_1\" did not complete successfully",
 		"term": "failed_1",
 	}}) with input.attestations as mock_a_failing_test
 }
 
-mock_an_errored_test := [lib.att_mock_helper_ref(lib.task_test_result_name, {"result": "ERROR"}, "errored_1", _bundle)]
+mock_an_errored_test := [lib_test.att_mock_helper_ref(
+	lib.task_test_result_name,
+	{"result": "ERROR"}, "errored_1", _bundle,
+)]
 
 test_error_data {
-	lib.assert_equal_results(deny, {{
+	lib.assert_equal_results(test.deny, {{
 		"code": "test.required_tests_passed",
 		"msg": "Test \"errored_1\" did not complete successfully",
 		"term": "errored_1",
@@ -63,7 +77,7 @@ test_error_data {
 mock_mixed_data := array.concat(mock_a_failing_test, mock_an_errored_test)
 
 test_mix_data {
-	lib.assert_equal_results(deny, {
+	lib.assert_equal_results(test.deny, {
 		{
 			"code": "test.required_tests_passed",
 			"msg": "Test \"failed_1\" did not complete successfully",
@@ -78,13 +92,19 @@ test_mix_data {
 }
 
 test_skipped_is_not_deny {
-	skipped_test := [lib.att_mock_helper_ref(lib.task_test_result_name, {"result": "SKIPPED"}, "skipped_1", _bundle)]
-	lib.assert_empty(deny) with input.attestations as skipped_test
+	skipped_test := [lib_test.att_mock_helper_ref(
+		lib.task_test_result_name,
+		{"result": "SKIPPED"}, "skipped_1", _bundle,
+	)]
+	lib.assert_empty(test.deny) with input.attestations as skipped_test
 }
 
 test_skipped_is_warning {
-	skipped_test := [lib.att_mock_helper_ref(lib.task_test_result_name, {"result": "SKIPPED"}, "skipped_1", _bundle)]
-	lib.assert_equal_results(warn, {{
+	skipped_test := [lib_test.att_mock_helper_ref(
+		lib.task_test_result_name,
+		{"result": "SKIPPED"}, "skipped_1", _bundle,
+	)]
+	lib.assert_equal_results(test.warn, {{
 		"code": "test.no_skipped_tests",
 		"msg": "Test \"skipped_1\" was skipped",
 		"term": "skipped_1",
@@ -92,8 +112,11 @@ test_skipped_is_warning {
 }
 
 test_warning_is_warning {
-	warning_test := [lib.att_mock_helper_ref(lib.task_test_result_name, {"result": "WARNING"}, "warning_1", _bundle)]
-	lib.assert_equal_results(warn, {{
+	warning_test := [lib_test.att_mock_helper_ref(
+		lib.task_test_result_name,
+		{"result": "WARNING"}, "warning_1", _bundle,
+	)]
+	lib.assert_equal_results(test.warn, {{
 		"code": "test.no_test_warnings",
 		"msg": "Test \"warning_1\" returned a warning",
 		"term": "warning_1",
@@ -102,18 +125,18 @@ test_warning_is_warning {
 
 test_mixed_statuses {
 	test_results := [
-		lib.att_mock_helper_ref(lib.task_test_result_name, {"result": "ERROR"}, "error_1", _bundle),
-		lib.att_mock_helper_ref(lib.task_test_result_name, {"result": "SUCCESS"}, "success_1", _bundle),
-		lib.att_mock_helper_ref(lib.task_test_result_name, {"result": "FAILURE"}, "failure_1", _bundle),
-		lib.att_mock_helper_ref(lib.task_test_result_name, {"result": "SKIPPED"}, "skipped_1", _bundle),
-		lib.att_mock_helper_ref(lib.task_test_result_name, {"result": "FAILURE"}, "failure_2", _bundle),
-		lib.att_mock_helper_ref(lib.task_test_result_name, {"result": "SKIPPED"}, "skipped_2", _bundle),
-		lib.att_mock_helper_ref(lib.task_test_result_name, {"result": "WARNING"}, "warning_1", _bundle),
-		lib.att_mock_helper_ref(lib.task_test_result_name, {"result": "ERROR"}, "error_2", _bundle),
-		lib.att_mock_helper_ref(lib.task_test_result_name, {"result": "WARNING"}, "warning_2", _bundle),
+		lib_test.att_mock_helper_ref(lib.task_test_result_name, {"result": "ERROR"}, "error_1", _bundle),
+		lib_test.att_mock_helper_ref(lib.task_test_result_name, {"result": "SUCCESS"}, "success_1", _bundle),
+		lib_test.att_mock_helper_ref(lib.task_test_result_name, {"result": "FAILURE"}, "failure_1", _bundle),
+		lib_test.att_mock_helper_ref(lib.task_test_result_name, {"result": "SKIPPED"}, "skipped_1", _bundle),
+		lib_test.att_mock_helper_ref(lib.task_test_result_name, {"result": "FAILURE"}, "failure_2", _bundle),
+		lib_test.att_mock_helper_ref(lib.task_test_result_name, {"result": "SKIPPED"}, "skipped_2", _bundle),
+		lib_test.att_mock_helper_ref(lib.task_test_result_name, {"result": "WARNING"}, "warning_1", _bundle),
+		lib_test.att_mock_helper_ref(lib.task_test_result_name, {"result": "ERROR"}, "error_2", _bundle),
+		lib_test.att_mock_helper_ref(lib.task_test_result_name, {"result": "WARNING"}, "warning_2", _bundle),
 	]
 
-	lib.assert_equal_results(deny, {
+	lib.assert_equal_results(test.deny, {
 		{
 			"code": "test.required_tests_passed",
 			"msg": "Test \"error_1\" did not complete successfully",
@@ -136,7 +159,7 @@ test_mixed_statuses {
 		},
 	}) with input.attestations as test_results
 
-	lib.assert_equal_results(warn, {
+	lib.assert_equal_results(test.warn, {
 		{
 			"code": "test.no_skipped_tests",
 			"msg": "Test \"skipped_1\" was skipped",
@@ -162,30 +185,42 @@ test_mixed_statuses {
 
 test_unsupported_test_result {
 	test_results := [
-		lib.att_mock_helper_ref(lib.task_test_result_name, {"result": "EROR"}, "error_1", _bundle),
-		lib.att_mock_helper_ref(lib.task_test_result_name, {"result": "SUCESS"}, "success_1", _bundle),
-		lib.att_mock_helper_ref(lib.task_test_result_name, {"result": "FAIL"}, "failure_1", _bundle),
-		lib.att_mock_helper_ref(lib.task_test_result_name, {"result": "SKIPED"}, "skipped_1", _bundle),
+		lib_test.att_mock_helper_ref(lib.task_test_result_name, {"result": "EROR"}, "error_1", _bundle),
+		lib_test.att_mock_helper_ref(lib.task_test_result_name, {"result": "SUCESS"}, "success_1", _bundle),
+		lib_test.att_mock_helper_ref(lib.task_test_result_name, {"result": "FAIL"}, "failure_1", _bundle),
+		lib_test.att_mock_helper_ref(lib.task_test_result_name, {"result": "SKIPED"}, "skipped_1", _bundle),
 	]
 
-	lib.assert_equal_results(deny, {
-		{"code": "test.test_results_known", "msg": "Test 'error_1' has unsupported result 'EROR'", "term": "error_1"},
-		{"code": "test.test_results_known", "msg": "Test 'failure_1' has unsupported result 'FAIL'", "term": "failure_1"},
-		{"code": "test.test_results_known", "msg": "Test 'skipped_1' has unsupported result 'SKIPED'", "term": "skipped_1"},
-		{"code": "test.test_results_known", "msg": "Test 'success_1' has unsupported result 'SUCESS'", "term": "success_1"},
+	lib.assert_equal_results(test.deny, {
+		{
+			"code": "test.test_results_known",
+			"msg": "Test 'error_1' has unsupported result 'EROR'", "term": "error_1",
+		},
+		{
+			"code": "test.test_results_known",
+			"msg": "Test 'failure_1' has unsupported result 'FAIL'", "term": "failure_1",
+		},
+		{
+			"code": "test.test_results_known",
+			"msg": "Test 'skipped_1' has unsupported result 'SKIPED'", "term": "skipped_1",
+		},
+		{
+			"code": "test.test_results_known",
+			"msg": "Test 'success_1' has unsupported result 'SUCESS'", "term": "success_1",
+		},
 	}) with input.attestations as test_results
 }
 
 test_missing_wrong_attestation_type {
-	pr := lib.att_mock_helper_ref("some-result", {"result": "value"}, "task1", _bundle)
-	tr := object.union(pr, {"statement": {"predicate": {"buildType": lib.taskrun_att_build_types[0]}}})
-	lib.assert_empty(deny) with input.attestations as [tr]
+	pr := lib_test.att_mock_helper_ref("some-result", {"result": "value"}, "task1", _bundle)
+	tr := object.union(pr, {"statement": {"predicate": {"buildType": lib.tekton_task_run}}})
+	lib.assert_empty(test.deny) with input.attestations as [tr]
 }
 
 test_wrong_attestation_type {
-	pr := lib.att_mock_helper_ref(lib.task_test_result_name, {"result": "ERROR"}, "errored_1", _bundle)
-	tr := object.union(pr, {"statement": {"predicate": {"buildType": lib.taskrun_att_build_types[0]}}})
-	lib.assert_empty(deny) with input.attestations as [tr]
+	pr := lib_test.att_mock_helper_ref(lib.task_test_result_name, {"result": "ERROR"}, "errored_1", _bundle)
+	tr := object.union(pr, {"statement": {"predicate": {"buildType": lib.tekton_task_run}}})
+	lib.assert_empty(test.deny) with input.attestations as [tr]
 }
 
 _bundle := "registry.img/spam@sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb"

--- a/policy/task/kind_test.rego
+++ b/policy/task/kind_test.rego
@@ -1,20 +1,21 @@
-package policy.task.kind
+package policy.task.kind_test
 
 import data.lib
+import data.policy.task.kind
 
 test_unexpected_kind {
-	lib.assert_equal_results(deny, {{
+	lib.assert_equal_results(kind.deny, {{
 		"code": "kind.expected_kind",
 		"msg": "Unexpected kind 'Foo' for task definition",
 	}}) with input.kind as "Foo"
 }
 
 test_expected_kind {
-	lib.assert_empty(deny) with input as {"kind": "Task"}
+	lib.assert_empty(kind.deny) with input as {"kind": "Task"}
 }
 
 test_kind_not_found {
-	lib.assert_equal_results(deny, {{
+	lib.assert_equal_results(kind.deny, {{
 		"code": "kind.kind_present",
 		"msg": "Required field 'kind' not found",
 	}}) with input as {"bad": "Foo"}

--- a/tools.go
+++ b/tools.go
@@ -3,5 +3,6 @@ package tools
 import (
 	_ "github.com/open-policy-agent/conftest"
 	_ "github.com/open-policy-agent/opa"
+	_ "github.com/styrainc/regal"
 	_ "github.com/tektoncd/cli/cmd/tkn"
 )


### PR DESCRIPTION
Integrates the Regal linter with one provision to mark `TODO` comments as a warning instead of a failure.