### PR TITLE
slsav1.0 refactor

### DIFF
--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -7,7 +7,11 @@ rules:
     file-length:
       level: warning
     line-length:
+<<<<<<< HEAD
       max-line-length: 130
   idiomatic:
     no-defined-entrypoint:
       level: ignore
+=======
+      level: warning
+>>>>>>> c4d3317 (regal lint is in conflict with opa fmt on the line-length)

--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -7,11 +7,7 @@ rules:
     file-length:
       level: warning
     line-length:
-<<<<<<< HEAD
-      max-line-length: 130
+      level: warning
   idiomatic:
     no-defined-entrypoint:
       level: ignore
-=======
-      level: warning
->>>>>>> c4d3317 (regal lint is in conflict with opa fmt on the line-length)

--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -8,6 +8,8 @@ rules:
       level: warning
     line-length:
       level: warning
+    rule-length:
+      max-rule-length: 50
   idiomatic:
     no-defined-entrypoint:
       level: ignore

--- a/policy/lib/refs.rego
+++ b/policy/lib/refs.rego
@@ -37,7 +37,7 @@ task_ref(task) := i {
 		"url": _param(r, "url", ""),
 		"revision": _param(r, "revision", ""),
 		"pathInRepo": _param(r, "pathInRepo", ""),
-		"name":  object.get(r, "name", ""),
+		"name": object.get(r, "name", ""),
 		"kind": lower(object.get(r, "kind", "task")),
 	}
 } else = i {

--- a/policy/lib/refs.rego
+++ b/policy/lib/refs.rego
@@ -37,7 +37,7 @@ task_ref(task) := i {
 		"url": _param(r, "url", ""),
 		"revision": _param(r, "revision", ""),
 		"pathInRepo": _param(r, "pathInRepo", ""),
-		"name": _param(r, "pathInRepo", ""),
+		"name":  object.get(r, "name", ""),
 		"kind": lower(object.get(r, "kind", "task")),
 	}
 } else = i {

--- a/policy/lib/refs.rego
+++ b/policy/lib/refs.rego
@@ -38,6 +38,7 @@ task_ref(task) := i {
 		"revision": _param(r, "revision", ""),
 		"pathInRepo": _param(r, "pathInRepo", ""),
 		"name": _param(r, "pathInRepo", ""),
+		"kind": lower(object.get(r, "kind", "task")),
 	}
 } else = i {
 	# Handle local reference

--- a/policy/lib/refs.rego
+++ b/policy/lib/refs.rego
@@ -37,6 +37,7 @@ task_ref(task) := i {
 		"url": _param(r, "url", ""),
 		"revision": _param(r, "revision", ""),
 		"pathInRepo": _param(r, "pathInRepo", ""),
+		"name": _param(r, "pathInRepo", ""),
 	}
 } else = i {
 	# Handle local reference

--- a/policy/lib/refs_test.rego
+++ b/policy/lib/refs_test.rego
@@ -93,6 +93,8 @@ test_git_resolver_in_slsav1_pipelinerun {
 	info := {
 		"url": "https://github.com/enterprise-contract/hacbs-docker-build.git",
 		"revision": "main", "pathInRepo": "pipelines/git-clone.yaml",
+		"name": "pipelines/git-clone.yaml",
+		"kind": "task"
 	}
 	lib.assert_equal(refs.task_ref(ref), info)
 }

--- a/policy/lib/refs_test.rego
+++ b/policy/lib/refs_test.rego
@@ -73,6 +73,7 @@ test_slsav1_local_ref {
 
 test_git_resolver_in_slsav1_pipelinerun {
 	ref := {"spec": {"taskRef": {
+		"name": "git-clone",
 		"kind": "Task",
 		"resolver": "git",
 		"params": [
@@ -93,7 +94,7 @@ test_git_resolver_in_slsav1_pipelinerun {
 	info := {
 		"url": "https://github.com/enterprise-contract/hacbs-docker-build.git",
 		"revision": "main", "pathInRepo": "pipelines/git-clone.yaml",
-		"name": "pipelines/git-clone.yaml",
+		"name": "git-clone",
 		"kind": "task",
 	}
 	lib.assert_equal(refs.task_ref(ref), info)

--- a/policy/lib/refs_test.rego
+++ b/policy/lib/refs_test.rego
@@ -94,7 +94,7 @@ test_git_resolver_in_slsav1_pipelinerun {
 		"url": "https://github.com/enterprise-contract/hacbs-docker-build.git",
 		"revision": "main", "pathInRepo": "pipelines/git-clone.yaml",
 		"name": "pipelines/git-clone.yaml",
-		"kind": "task"
+		"kind": "task",
 	}
 	lib.assert_equal(refs.task_ref(ref), info)
 }

--- a/policy/lib/tekton/task.rego
+++ b/policy/lib/tekton/task.rego
@@ -129,14 +129,10 @@ _task_params(task) := params if {
 task_param(task, name) := _task_params(task)[name]
 
 # slsa v0.2 results
-_task_results(task) := results if {
-	results := task.results
-}
+_task_results(task) := task.results
 
 # slsa v1.0 results
-_task_results(task) := results if {
-	results := task.status.taskResults
-}
+_task_results(task) := task.status.taskResults
 
 # task_result returns the value of the given result in the task.
 task_result(task, name) := value if {
@@ -147,24 +143,16 @@ task_result(task, name) := value if {
 }
 
 # slsa v0.2 task steps
-task_steps(task) := steps if {
-	steps := task.steps
-}
+task_steps(task) := task.steps
 
 # slsa v1.0 task steps
-task_steps(task) := steps if {
-	steps := task.status.taskSpec.steps
-}
+task_steps(task) := task.status.taskSpec.steps
 
 # slsa v0.2 step image
-task_step_image_ref(step) := image_ref if {
-	image_ref := step.environment.image
-}
+task_step_image_ref(step) := step.environment.image
 
 # slsa v1.0 step image
-task_step_image_ref(step) := image_ref if {
-	image_ref := step.image
-}
+task_step_image_ref(step) := step.image
 
 # build_task returns the build task found in the attestation
 build_task(attestation) := task if {

--- a/policy/lib/tekton/task.rego
+++ b/policy/lib/tekton/task.rego
@@ -163,7 +163,7 @@ task_data(task) := info if {
 	r := refs.task_ref(task)
 	info := {"name": r.name, "bundle": r.bundle}
 } else := info if {
-	info := {"name": task.name}
+	info := {"name": task_name(task)}
 }
 
 _key_value(obj, name) := value if {

--- a/policy/lib/tekton/task.rego
+++ b/policy/lib/tekton/task.rego
@@ -152,7 +152,7 @@ task_steps(task) := task.status.taskSpec.steps
 task_step_image_ref(step) := step.environment.image
 
 # slsa v1.0 step image
-task_step_image_ref(step) := step.image
+task_step_image_ref(step) := step.imageID
 
 # build_task returns the build task found in the attestation
 build_task(attestation) := task if {

--- a/policy/lib/tekton/task.rego
+++ b/policy/lib/tekton/task.rego
@@ -56,7 +56,7 @@ _maybe_tasks(pipeline) := _tasks if {
 # handle tasks from a slsav1 attestation
 _maybe_tasks(slsav1) := _tasks if {
 	slsav1.predicate.buildDefinition
-	_tasks := {json.unmarshal(dep.content) |
+	_tasks := {json.unmarshal(base64.decode(dep.content)) |
 		some dep in slsav1.predicate.buildDefinition.resolvedDependencies
 		_slsav1_tekton(dep)
 	}

--- a/policy/lib/tekton/task.rego
+++ b/policy/lib/tekton/task.rego
@@ -128,12 +128,42 @@ _task_params(task) := params if {
 # task_param returns the value of the given parameter in the task.
 task_param(task, name) := _task_params(task)[name]
 
+# slsa v0.2 results
+_task_results(task) := results if {
+	results := task.results
+}
+
+# slsa v1.0 results
+_task_results(task) := results if {
+	results := task.status.taskResults
+}
+
 # task_result returns the value of the given result in the task.
 task_result(task, name) := value if {
-	some result in task.results
+	some result in _task_results(task)
 	result_name := _key_value(result, "name")
 	result_name == name
 	value := _key_value(result, "value")
+}
+
+# slsa v0.2 task steps
+task_steps(task) := steps if {
+	steps := task.steps
+}
+
+# slsa v1.0 task steps
+task_steps(task) := steps if {
+	steps := task.status.taskSpec.steps
+}
+
+# slsa v0.2 step image
+task_step_image_ref(step) := image_ref if {
+	image_ref := step.environment.image
+}
+
+# slsa v1.0 step image
+task_step_image_ref(step) := image_ref if {
+	image_ref := step.image
 }
 
 # build_task returns the build task found in the attestation

--- a/policy/lib/tekton/task_test.rego
+++ b/policy/lib/tekton/task_test.rego
@@ -33,7 +33,7 @@ test_tasks_from_attestation if {
 
 # regal ignore:rule-length
 test_tasks_from_slsav1_tekton_attestation if {
-	content := json.marshal(slsav1_attestation_local_spec)
+	content := base64.encode(json.marshal(slsav1_attestation_local_spec))
 	task := {
 		"name": "pipelineTask",
 		"uri": "oci://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
@@ -84,21 +84,21 @@ test_tasks_from_slsav1_tekton_attestation if {
 
 # regal ignore:rule-length
 test_tasks_from_slsav1_tekton_mixture_attestation if {
-	task1 := json.marshal(json.patch(slsav1_attestation_local_spec, [{
+	task1 := base64.encode(json.marshal(json.patch(slsav1_attestation_local_spec, [{
 		"op": "add",
 		"path": "/taskRef/name",
 		"value": "task1",
-	}]))
-	task2 := json.marshal(json.patch(slsav1_attestation_local_spec, [{
+	}])))
+	task2 := base64.encode(json.marshal(json.patch(slsav1_attestation_local_spec, [{
 		"op": "add",
 		"path": "/taskRef/name",
 		"value": "task2",
-	}]))
-	task3 := json.marshal(json.patch(slsav1_attestation_local_spec, [{
+	}])))
+	task3 := base64.encode(json.marshal(json.patch(slsav1_attestation_local_spec, [{
 		"op": "add",
 		"path": "/taskRef/name",
 		"value": "task3",
-	}]))
+	}])))
 
 	git_init := {
 		"name": "task",
@@ -388,7 +388,7 @@ test_missing_required_tasks_data if {
 test_task_step_image_ref if {
 	lib.assert_equal(
 		"redhat.io/openshift/rhel8@sha256:af7dd5b3b",
-		tkn.task_step_image_ref({"name": "mystep", "image": "redhat.io/openshift/rhel8@sha256:af7dd5b3b"}),
+		tkn.task_step_image_ref({"name": "mystep", "imageID": "redhat.io/openshift/rhel8@sha256:af7dd5b3b"}),
 	)
 	lib.assert_equal(
 		"redhat.io/openshift/rhel8@sha256:af7dd5b3b",
@@ -599,6 +599,6 @@ resolved_dependencies(tasks) := [r |
 	some task in tasks
 	r := {
 		"name": "pipelineTask",
-		"content": json.marshal(task),
+		"content": base64.encode(json.marshal(task)),
 	}
 ]

--- a/policy/lib/tekton/task_test.rego
+++ b/policy/lib/tekton/task_test.rego
@@ -520,11 +520,32 @@ slsav1_task(name) := task if {
 }
 
 slsav1_task_bundle(name, bundle) := task if {
+	not name.spec
 	task := json.patch(slsav1_task(name), [{
 		"op": "add",
 		"path": "/spec/taskRef/bundle",
 		"value": bundle,
 	}])
+}
+
+slsav1_task_bundle(name, bundle) := task if {
+	name.spec
+	task := json.patch(name, [{
+		"op": "add",
+		"path": "/spec/taskRef/bundle",
+		"value": bundle,
+	}])
+}
+
+# results are an array of dictionaries with keys, "name", "type", "value"
+slsav1_task_result(name, results) := task if {
+	task := json.patch(slsav1_task(name), [
+		{
+			"op": "add",
+			"path": "/status/taskResults",
+			"value": results
+		}
+	])
 }
 
 resolved_dependencies(tasks) := [r |

--- a/policy/lib/tekton/task_test.rego
+++ b/policy/lib/tekton/task_test.rego
@@ -373,7 +373,7 @@ test_task_names_local if {
 }
 
 test_task_data_no_bundle_ref if {
-	lib.assert_equal({"name": "name"}, tkn.task_data({"name": "name"}))
+	lib.assert_equal({"name": "name"}, tkn.task_data({"ref": {"name": "name"}}))
 }
 
 test_missing_required_tasks_data if {
@@ -516,6 +516,16 @@ slsav1_task(name) := task if {
 			"path": "/spec/params",
 			"value": [{"name": parts[1], "value": parts[2]}],
 		},
+	])
+}
+
+slsav1_task_bundle(name, bundle) := task {
+	task := json.patch(slsav1_task(name), [
+		{
+			"op": "add",
+			"path": "/spec/taskRef/bundle",
+			"value": bundle,
+		}
 	])
 }
 

--- a/policy/lib/tekton/task_test.rego
+++ b/policy/lib/tekton/task_test.rego
@@ -519,14 +519,12 @@ slsav1_task(name) := task if {
 	])
 }
 
-slsav1_task_bundle(name, bundle) := task {
-	task := json.patch(slsav1_task(name), [
-		{
-			"op": "add",
-			"path": "/spec/taskRef/bundle",
-			"value": bundle,
-		}
-	])
+slsav1_task_bundle(name, bundle) := task if {
+	task := json.patch(slsav1_task(name), [{
+		"op": "add",
+		"path": "/spec/taskRef/bundle",
+		"value": bundle,
+	}])
 }
 
 resolved_dependencies(tasks) := [r |

--- a/policy/lib/tekton/task_test.rego
+++ b/policy/lib/tekton/task_test.rego
@@ -235,6 +235,10 @@ test_task_result if {
 	task := {"results": [{"name": "SPAM", "value": "maps"}]}
 	lib.assert_equal("maps", tkn.task_result(task, "SPAM"))
 	not tkn.task_result(task, "missing")
+
+	slsav1_task := {"status": {"taskResults": [{"name": "SPAM", "value": "maps"}]}}
+	lib.assert_equal("maps", tkn.task_result(slsav1_task, "SPAM"))
+	not tkn.task_result(slsav1_task, "missing")
 }
 
 test_tasks_from_attestation_with_spam if {

--- a/policy/lib/tekton/task_test.rego
+++ b/policy/lib/tekton/task_test.rego
@@ -385,6 +385,17 @@ test_missing_required_tasks_data if {
 	lib.assert_equal(tkn.missing_required_tasks_data, false) with data["required-tasks"] as _time_based_required_tasks
 }
 
+test_task_step_image_ref if {
+	lib.assert_equal(
+		"redhat.io/openshift/rhel8@sha256:af7dd5b3b",
+		tkn.task_step_image_ref({"name": "mystep", "image": "redhat.io/openshift/rhel8@sha256:af7dd5b3b"}),
+	)
+	lib.assert_equal(
+		"redhat.io/openshift/rhel8@sha256:af7dd5b3b",
+		tkn.task_step_image_ref({"environment": {"image": "redhat.io/openshift/rhel8@sha256:af7dd5b3b"}}),
+	)
+}
+
 _expected_latest := {
 	"effective_on": "2099-01-02T00:00:00Z",
 	"tasks": [
@@ -543,8 +554,9 @@ slsav1_task_bundle(name, bundle) := task if {
 	}])
 }
 
-slsav1_task_steps(name, steps) := task if {
-	task := json.patch(slsav1_task(name), [
+slsav1_task_steps(name, steps) := json.patch(
+	slsav1_task(name),
+	[
 		{
 			"op": "add",
 			"path": "/status/taskSpec",
@@ -555,26 +567,28 @@ slsav1_task_steps(name, steps) := task if {
 			"path": "/status/taskSpec/steps",
 			"value": steps,
 		},
-	])
-}
+	],
+)
 
 # results are an array of dictionaries with keys, "name", "type", "value"
-slsav1_task_result(name, results) := task if {
-	task := json.patch(slsav1_task(name), [{
+slsav1_task_result(name, results) := json.patch(
+	slsav1_task(name),
+	[{
 		"op": "add",
 		"path": "/status/taskResults",
 		"value": results,
-	}])
-}
+	}],
+)
 
 # results are an array of dictionaries with keys, "name", "type", "value"
-slsav1_task_result_ref(name, results) := task if {
-	task := json.patch(slsav1_task(name), [{
+slsav1_task_result_ref(name, results) := json.patch(
+	slsav1_task(name),
+	[{
 		"op": "add",
 		"path": "/status/taskResults",
 		"value": _marshal_slsav1_results(results),
-	}])
-}
+	}],
+)
 
 _marshal_slsav1_results(results) := [r |
 	some result in results

--- a/policy/lib/tekton/task_test.rego
+++ b/policy/lib/tekton/task_test.rego
@@ -539,14 +539,26 @@ slsav1_task_bundle(name, bundle) := task if {
 
 # results are an array of dictionaries with keys, "name", "type", "value"
 slsav1_task_result(name, results) := task if {
-	task := json.patch(slsav1_task(name), [
-		{
-			"op": "add",
-			"path": "/status/taskResults",
-			"value": results
-		}
-	])
+	task := json.patch(slsav1_task(name), [{
+		"op": "add",
+		"path": "/status/taskResults",
+		"value": results,
+	}])
 }
+
+# results are an array of dictionaries with keys, "name", "type", "value"
+slsav1_task_result_ref(name, results) := task if {
+	task := json.patch(slsav1_task(name), [{
+		"op": "add",
+		"path": "/status/taskResults",
+		"value": _marshal_slsav1_results(results),
+	}])
+}
+
+_marshal_slsav1_results(results) := [r |
+	some result in results
+	r := {"name": result.name, "type": result.type, "value": json.marshal(result.value)}
+]
 
 resolved_dependencies(tasks) := [r |
 	some task in tasks

--- a/policy/lib/tekton/task_test.rego
+++ b/policy/lib/tekton/task_test.rego
@@ -519,6 +519,7 @@ slsav1_task(name) := task if {
 	])
 }
 
+# create a task and add a bundle to it
 slsav1_task_bundle(name, bundle) := task if {
 	not name.spec
 	task := json.patch(slsav1_task(name), [{
@@ -528,6 +529,7 @@ slsav1_task_bundle(name, bundle) := task if {
 	}])
 }
 
+# add a bundle to an existing task
 slsav1_task_bundle(name, bundle) := task if {
 	name.spec
 	task := json.patch(name, [{
@@ -535,6 +537,21 @@ slsav1_task_bundle(name, bundle) := task if {
 		"path": "/spec/taskRef/bundle",
 		"value": bundle,
 	}])
+}
+
+slsav1_task_steps(name, steps) := task if {
+	task := json.patch(slsav1_task(name), [
+		{
+			"op": "add",
+			"path": "/status/taskSpec",
+			"value": {},
+		},
+		{
+			"op": "add",
+			"path": "/status/taskSpec/steps",
+			"value": steps,
+		},
+	])
 }
 
 # results are an array of dictionaries with keys, "name", "type", "value"

--- a/policy/release/attestation_task_bundle.rego
+++ b/policy/release/attestation_task_bundle.rego
@@ -17,6 +17,7 @@ import future.keywords.if
 import future.keywords.in
 
 import data.lib
+import data.lib.tkn
 import data.lib.bundles
 
 # METADATA
@@ -34,8 +35,8 @@ import data.lib.bundles
 #   - attestation_type.known_attestation_type
 #
 deny contains result if {
-	some bundle in bundles.disallowed_task_reference(lib.tasks_from_pipelinerun)
-	result := lib.result_helper(rego.metadata.chain(), [bundle.name])
+	some task in bundles.disallowed_task_reference(lib.tasks_from_pipelinerun)
+	result := lib.result_helper(rego.metadata.chain(), [tkn.task_name(task)])
 }
 
 # METADATA
@@ -55,8 +56,7 @@ deny contains result if {
 #
 deny contains result if {
 	some task in bundles.empty_task_bundle_reference(lib.tasks_from_pipelinerun)
-	name := task.name
-	result := lib.result_helper(rego.metadata.chain(), [name])
+	result := lib.result_helper(rego.metadata.chain(), [tkn.task_name(task)])
 }
 
 # METADATA
@@ -76,7 +76,7 @@ deny contains result if {
 #
 warn contains result if {
 	some task in bundles.unpinned_task_bundle(lib.tasks_from_pipelinerun)
-	result := lib.result_helper(rego.metadata.chain(), [task.name, bundles.bundle(task)])
+	result := lib.result_helper(rego.metadata.chain(), [tkn.task_name(task), bundles.bundle(task)])
 }
 
 # METADATA
@@ -97,7 +97,7 @@ warn contains result if {
 #
 warn contains result if {
 	some task in bundles.out_of_date_task_bundle(lib.tasks_from_pipelinerun)
-	result := lib.result_helper(rego.metadata.chain(), [task.name, bundles.bundle(task)])
+	result := lib.result_helper(rego.metadata.chain(), [tkn.task_name(task), bundles.bundle(task)])
 }
 
 # METADATA
@@ -119,7 +119,7 @@ warn contains result if {
 #
 deny contains result if {
 	some task in bundles.unacceptable_task_bundle(lib.tasks_from_pipelinerun)
-	result := lib.result_helper(rego.metadata.chain(), [task.name, bundles.bundle(task)])
+	result := lib.result_helper(rego.metadata.chain(), [tkn.task_name(task), bundles.bundle(task)])
 }
 
 # METADATA

--- a/policy/release/attestation_task_bundle.rego
+++ b/policy/release/attestation_task_bundle.rego
@@ -17,8 +17,8 @@ import future.keywords.if
 import future.keywords.in
 
 import data.lib
-import data.lib.tkn
 import data.lib.bundles
+import data.lib.tkn
 
 # METADATA
 # title: Tasks defined using bundle references

--- a/policy/release/attestation_task_bundle_test.rego
+++ b/policy/release/attestation_task_bundle_test.rego
@@ -155,24 +155,6 @@ test_acceptable_bundles_provided {
 	lib.assert_equal_results(expected, attestation_task_bundle.deny) with data["task-bundles"] as []
 }
 
-mock_attestation(bundles) := a {
-	tasks := [task |
-		some index, bundle in bundles
-		task := {
-			"name": sprintf("task-run-%d", [index]),
-			"ref": {
-				"name": "my-task",
-				"bundle": bundle,
-			},
-		}
-	]
-
-	a := [{"statement": {"predicate": {
-		"buildConfig": {"tasks": tasks},
-		"buildType": lib.tekton_pipeline_run,
-	}}}]
-}
-
 task_bundles := {"reg.com/repo": [
 	{
 		# Latest bundle, allowed

--- a/policy/release/attestation_task_bundle_test.rego
+++ b/policy/release/attestation_task_bundle_test.rego
@@ -4,81 +4,102 @@ import future.keywords.in
 
 import data.lib
 import data.policy.release.attestation_task_bundle
+import data.lib.tkn_test
+import data.lib_test
 
-mock_data(task) := [{"statement": {"predicate": {
+mock_data(task) := {"statement": {"predicate": {
 	"buildConfig": {"tasks": [task]},
 	"buildType": lib.tekton_pipeline_run,
-}}}]
+}}}
 
 test_bundle_not_exists {
 	name := "my-task"
-	d := mock_data({
-		"name": name,
-		"ref": {"name": "good-task"},
-	})
+	attestations := [
+		mock_data({
+			"name": name,
+			"ref": {"name": "my-task"},
+		}),
+		lib_test.mock_slsav1_attestation(
+			[tkn_test.slsav1_task("my-task")]
+		)
+	]
 
 	expected_msg := "Pipeline task 'my-task' does not contain a bundle reference"
 	lib.assert_equal_results(attestation_task_bundle.deny, {{
 		"code": "attestation_task_bundle.tasks_defined_in_bundle",
 		"msg": expected_msg,
-	}}) with input.attestations as d with data["task-bundles"] as task_bundles
+	}}) with input.attestations as attestations with data["task-bundles"] as task_bundles
 
-	lib.assert_empty(attestation_task_bundle.warn) with input.attestations as d
+	lib.assert_empty(attestation_task_bundle.warn) with input.attestations as attestations
 }
 
 test_bundle_not_exists_empty_string {
 	name := "my-task"
 	image := ""
-	d := mock_data({
-		"name": name,
-		"ref": {"name": "good-task", "bundle": image},
-	})
+
+	attestations := [
+		mock_data({
+			"name": name,
+			"ref": {"name": "my-task", "bundle": image},
+		}),
+		lib_test.mock_slsav1_attestation([tkn_test.slsav1_task_bundle("my-task", image)])
+	]
 
 	expected_msg := sprintf("Pipeline task '%s' uses an empty bundle image reference", [name])
 	lib.assert_equal_results(attestation_task_bundle.deny, {{
 		"code": "attestation_task_bundle.task_ref_bundles_not_empty",
 		"msg": expected_msg,
-	}}) with input.attestations as d with data["task-bundles"] as task_bundles
+	}}) with input.attestations as attestations with data["task-bundles"] as task_bundles
 
-	lib.assert_empty(attestation_task_bundle.warn) with input.attestations as d
+	lib.assert_empty(attestation_task_bundle.warn) with input.attestations as attestations
 }
 
 test_bundle_unpinned {
 	name := "my-task"
 	image := "reg.com/repo:latest"
-	d := mock_data({
-		"name": name,
-		"ref": {
-			"name": "good-task",
-			"bundle": image,
-		},
-	})
+	attestations := [
+		mock_data({
+			"name": name,
+			"ref": {
+				"name": "my-task",
+				"bundle": image,
+			},
+		}),
+		lib_test.mock_slsav1_attestation([tkn_test.slsav1_task_bundle("my-task", image)])
+	]
 
 	expected_msg := sprintf("Pipeline task '%s' uses an unpinned task bundle reference '%s'", [name, image])
 	lib.assert_equal_results(attestation_task_bundle.warn, {{
 		"code": "attestation_task_bundle.task_ref_bundles_pinned",
 		"msg": expected_msg,
-	}}) with input.attestations as d
+	}}) with input.attestations as attestations
 }
 
 test_bundle_reference_valid {
 	name := "my-task"
 	image := "quay.io/redhat-appstudio/hacbs-templates-bundle:latest@sha256:abc"
-	d := mock_data({
-		"name": name,
-		"ref": {
-			"name": "good-task",
-			"bundle": image,
-		},
-	})
+	attestations := [
+		mock_data({
+			"name": name,
+			"ref": {
+				"name": "my-task",
+				"bundle": image,
+			},
+		}),
+		lib_test.mock_slsav1_attestation([tkn_test.slsav1_task_bundle("my-task", image)])
+	]
 
-	lib.assert_empty(attestation_task_bundle.warn) with input.attestations as d
-	lib.assert_empty(attestation_task_bundle.deny) with input.attestations as d with data["task-bundles"] as task_bundles
+	lib.assert_empty(attestation_task_bundle.warn) with input.attestations as attestations
+	lib.assert_empty(attestation_task_bundle.deny) with input.attestations as attestations with data["task-bundles"] as task_bundles
 }
 
 # All good when the most recent bundle is used.
 test_acceptable_bundle_up_to_date {
-	attestations := mock_attestation(["reg.com/repo@sha256:abc"])
+	image := "reg.com/repo@sha256:abc"
+	attestations := [
+		lib_test.mock_slsav02_attestation_bundles([image]),
+		lib_test.mock_slsav1_attestation([tkn_test.slsav1_task_bundle("my-task", image)])
+	]
 
 	lib.assert_empty(attestation_task_bundle.warn) with input.attestations as attestations
 		with data["task-bundles"] as task_bundles
@@ -89,16 +110,20 @@ test_acceptable_bundle_up_to_date {
 
 # Warn about out of date bundles that are still acceptable.
 test_acceptable_bundle_out_of_date_past {
-	attestations := mock_attestation(["reg.com/repo@sha256:bcd", "reg.com/repo@sha256:cde"])
+	images := ["reg.com/repo@sha256:bcd", "reg.com/repo@sha256:cde"]
+	attestations := [
+		lib_test.mock_slsav02_attestation_bundles(images),
+		lib_test.mock_slsav1_attestation_bundles(images),
+	]
 
 	lib.assert_equal_results(attestation_task_bundle.warn, {
 		{
 			"code": "attestation_task_bundle.task_ref_bundles_current",
-			"msg": "Pipeline task 'task-run-0' uses an out of date task bundle 'reg.com/repo@sha256:bcd'",
+			"msg": "Pipeline task 'my-task' uses an out of date task bundle 'reg.com/repo@sha256:bcd'",
 		},
 		{
 			"code": "attestation_task_bundle.task_ref_bundles_current",
-			"msg": "Pipeline task 'task-run-1' uses an out of date task bundle 'reg.com/repo@sha256:cde'",
+			"msg": "Pipeline task 'my-task' uses an out of date task bundle 'reg.com/repo@sha256:cde'",
 		},
 	}) with input.attestations as attestations
 		with data["task-bundles"] as task_bundles
@@ -109,13 +134,17 @@ test_acceptable_bundle_out_of_date_past {
 
 # Deny bundles that are no longer active.
 test_acceptable_bundle_expired {
-	attestations := mock_attestation(["reg.com/repo@sha256:def"])
+	image := ["reg.com/repo@sha256:def"]
+	attestations := [
+		lib_test.mock_slsav02_attestation_bundles(image),
+		lib_test.mock_slsav1_attestation_bundles(image),
+	]
 	lib.assert_empty(attestation_task_bundle.warn) with input.attestations as attestations
 		with data["task-bundles"] as task_bundles
 
 	lib.assert_equal_results(attestation_task_bundle.deny, {{
 		"code": "attestation_task_bundle.task_ref_bundles_acceptable",
-		"msg": "Pipeline task 'task-run-0' uses an unacceptable task bundle 'reg.com/repo@sha256:def'",
+		"msg": "Pipeline task 'my-task' uses an unacceptable task bundle 'reg.com/repo@sha256:def'",
 	}}) with input.attestations as attestations
 		with data["task-bundles"] as task_bundles
 }

--- a/policy/release/attestation_task_bundle_test.rego
+++ b/policy/release/attestation_task_bundle_test.rego
@@ -3,9 +3,9 @@ package policy.release.attestation_task_bundle_test
 import future.keywords.in
 
 import data.lib
-import data.policy.release.attestation_task_bundle
 import data.lib.tkn_test
 import data.lib_test
+import data.policy.release.attestation_task_bundle
 
 mock_data(task) := {"statement": {"predicate": {
 	"buildConfig": {"tasks": [task]},
@@ -19,9 +19,7 @@ test_bundle_not_exists {
 			"name": name,
 			"ref": {"name": "my-task"},
 		}),
-		lib_test.mock_slsav1_attestation_with_tasks(
-			[tkn_test.slsav1_task("my-task")]
-		)
+		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task("my-task")]),
 	]
 
 	expected_msg := "Pipeline task 'my-task' does not contain a bundle reference"
@@ -42,7 +40,7 @@ test_bundle_not_exists_empty_string {
 			"name": name,
 			"ref": {"name": "my-task", "bundle": image},
 		}),
-		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle("my-task", image)])
+		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle("my-task", image)]),
 	]
 
 	expected_msg := sprintf("Pipeline task '%s' uses an empty bundle image reference", [name])
@@ -65,7 +63,7 @@ test_bundle_unpinned {
 				"bundle": image,
 			},
 		}),
-		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle("my-task", image)])
+		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle("my-task", image)]),
 	]
 
 	expected_msg := sprintf("Pipeline task '%s' uses an unpinned task bundle reference '%s'", [name, image])
@@ -86,7 +84,7 @@ test_bundle_reference_valid {
 				"bundle": image,
 			},
 		}),
-		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle("my-task", image)])
+		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle("my-task", image)]),
 	]
 
 	lib.assert_empty(attestation_task_bundle.warn) with input.attestations as attestations
@@ -98,7 +96,7 @@ test_acceptable_bundle_up_to_date {
 	image := "reg.com/repo@sha256:abc"
 	attestations := [
 		lib_test.mock_slsav02_attestation_bundles([image]),
-		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle("my-task", image)])
+		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle("my-task", image)]),
 	]
 
 	lib.assert_empty(attestation_task_bundle.warn) with input.attestations as attestations

--- a/policy/release/attestation_task_bundle_test.rego
+++ b/policy/release/attestation_task_bundle_test.rego
@@ -19,7 +19,7 @@ test_bundle_not_exists {
 			"name": name,
 			"ref": {"name": "my-task"},
 		}),
-		lib_test.mock_slsav1_attestation(
+		lib_test.mock_slsav1_attestation_with_tasks(
 			[tkn_test.slsav1_task("my-task")]
 		)
 	]
@@ -42,7 +42,7 @@ test_bundle_not_exists_empty_string {
 			"name": name,
 			"ref": {"name": "my-task", "bundle": image},
 		}),
-		lib_test.mock_slsav1_attestation([tkn_test.slsav1_task_bundle("my-task", image)])
+		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle("my-task", image)])
 	]
 
 	expected_msg := sprintf("Pipeline task '%s' uses an empty bundle image reference", [name])
@@ -65,7 +65,7 @@ test_bundle_unpinned {
 				"bundle": image,
 			},
 		}),
-		lib_test.mock_slsav1_attestation([tkn_test.slsav1_task_bundle("my-task", image)])
+		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle("my-task", image)])
 	]
 
 	expected_msg := sprintf("Pipeline task '%s' uses an unpinned task bundle reference '%s'", [name, image])
@@ -86,7 +86,7 @@ test_bundle_reference_valid {
 				"bundle": image,
 			},
 		}),
-		lib_test.mock_slsav1_attestation([tkn_test.slsav1_task_bundle("my-task", image)])
+		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle("my-task", image)])
 	]
 
 	lib.assert_empty(attestation_task_bundle.warn) with input.attestations as attestations
@@ -98,7 +98,7 @@ test_acceptable_bundle_up_to_date {
 	image := "reg.com/repo@sha256:abc"
 	attestations := [
 		lib_test.mock_slsav02_attestation_bundles([image]),
-		lib_test.mock_slsav1_attestation([tkn_test.slsav1_task_bundle("my-task", image)])
+		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle("my-task", image)])
 	]
 
 	lib.assert_empty(attestation_task_bundle.warn) with input.attestations as attestations

--- a/policy/release/buildah_build_task_test.rego
+++ b/policy/release/buildah_build_task_test.rego
@@ -20,11 +20,11 @@ test_buildah_tasks if {
 	tasks := [
 		{
 			"name": "pipelineTask",
-			"content": json.marshal(tkn_test.slsav1_attestation_local_spec),
+			"content": base64.encode(json.marshal(tkn_test.slsav1_attestation_local_spec)),
 		},
 		{
 			"name": "pipelineTask",
-			"content": json.marshal(tkn_test.slsav1_attestation_local_spec),
+			"content": base64.encode(json.marshal(tkn_test.slsav1_attestation_local_spec)),
 		},
 	]
 	slsav1_attestation := json.patch(
@@ -136,27 +136,27 @@ test_multiple_buildah_tasks if {
 	tasks := [
 		{
 			"name": "task",
-			"content": json.marshal(json.patch(tkn_test.slsav1_attestation_local_spec, [{
+			"content": base64.encode(json.marshal(json.patch(tkn_test.slsav1_attestation_local_spec, [{
 				"op": "add",
 				"path": "/taskRef/name",
 				"value": "task1",
-			}])),
+			}]))),
 		},
 		{
 			"name": "pipelineTask",
-			"content": json.marshal(json.patch(tkn_test.slsav1_attestation_local_spec, [{
+			"content": base64.encode(json.marshal(json.patch(tkn_test.slsav1_attestation_local_spec, [{
 				"op": "add",
 				"path": "/taskRef/name",
 				"value": "task1",
-			}])),
+			}]))),
 		},
 		{
 			"name": "pipeline",
-			"content": json.marshal(json.patch(tkn_test.slsav1_attestation_local_spec, [{
+			"content": base64.encode(json.marshal(json.patch(tkn_test.slsav1_attestation_local_spec, [{
 				"op": "add",
 				"path": "/taskRef/name",
 				"value": "task1",
-			}])),
+			}]))),
 		},
 	]
 	slsav1_attestation := json.patch(_slsav1_attestation("buildah", [{}]), [{
@@ -193,19 +193,19 @@ test_multiple_buildah_tasks_one_without_params if {
 	tasks := [
 		{
 			"name": "task",
-			"content": json.marshal(json.patch(tkn_test.slsav1_attestation_local_spec, [{
+			"content": base64.encode(json.marshal(json.patch(tkn_test.slsav1_attestation_local_spec, [{
 				"op": "add",
 				"path": "/taskRef/name",
 				"value": "task1",
-			}])),
+			}]))),
 		},
 		{
 			"name": "pipelineTask",
-			"content": json.marshal(json.patch(tkn_test.slsav1_attestation_local_spec, [{
+			"content": base64.encode(json.marshal(json.patch(tkn_test.slsav1_attestation_local_spec, [{
 				"op": "add",
 				"path": "/params",
 				"value": [{}],
-			}])),
+			}]))),
 		},
 	]
 	slsav1_attestation := json.patch(_slsav1_attestation("buildah", [{}]), [{
@@ -243,19 +243,19 @@ test_multiple_buildah_tasks_one_with_external_dockerfile if {
 	tasks := [
 		{
 			"name": "task",
-			"content": json.marshal(json.patch(tkn_test.slsav1_attestation_local_spec, [{
+			"content": base64.encode(json.marshal(json.patch(tkn_test.slsav1_attestation_local_spec, [{
 				"op": "add",
 				"path": "params",
 				"value": [{"name": "DOCKERFILE", "value": "Dockerfile"}],
-			}])),
+			}]))),
 		},
 		{
 			"name": "pipelineTask",
-			"content": json.marshal(json.patch(tkn_test.slsav1_attestation_local_spec, [{
+			"content": base64.encode(json.marshal(json.patch(tkn_test.slsav1_attestation_local_spec, [{
 				"op": "add",
 				"path": "/params",
 				"value": [{"name": "DOCKERFILE", "value": "http://Dockerfile"}],
-			}])),
+			}]))),
 		},
 	]
 	slsav1_attestation := json.patch(_slsav1_attestation("buildah", {}), [{
@@ -277,7 +277,7 @@ _attestation(task_name, params) := {"statement": {"predicate": {
 }}}
 
 _slsav1_attestation(task_name, params) := attestation if {
-	content := json.marshal(json.patch(tkn_test.slsav1_attestation_local_spec, [
+	content := base64.encode(json.marshal(json.patch(tkn_test.slsav1_attestation_local_spec, [
 		{
 			"op": "replace",
 			"path": "/params",
@@ -288,7 +288,7 @@ _slsav1_attestation(task_name, params) := attestation if {
 			"path": "/taskRef/name",
 			"value": task_name,
 		},
-	]))
+	])))
 	attestation := {"statement": {
 		"predicateType": "https://slsa.dev/provenance/v1",
 		"predicate": {"buildDefinition": {

--- a/policy/release/cve_test.rego
+++ b/policy/release/cve_test.rego
@@ -5,37 +5,70 @@ import future.keywords.if
 import future.keywords.in
 
 import data.lib
+import data.lib.tkn_test
 import data.lib_test
 import data.policy.release.cve
 
 test_success if {
-	attestations := [lib_test.att_mock_helper_ref(
-		cve._result_name,
-		{"vulnerabilities": {"critical": 0, "high": 0, "medium": 20, "low": 300}},
+	slsav1_task_with_result := tkn_test.slsav1_task_result_ref(
 		"clair-scan",
-		_bundle,
-	)]
+		[{
+			"name": cve._result_name,
+			"type": "string",
+			"value": {"vulnerabilities": {"critical": 0, "high": 0, "medium": 20, "low": 300}},
+		}],
+	)
+	attestations := [
+		lib_test.att_mock_helper_ref(
+			cve._result_name,
+			{"vulnerabilities": {"critical": 0, "high": 0, "medium": 20, "low": 300}},
+			"clair-scan",
+			_bundle,
+		),
+		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle(slsav1_task_with_result, _bundle)]),
+	]
 	lib.assert_empty(cve.deny) with input.attestations as attestations
 }
 
 test_success_with_rule_data if {
-	attestations := [lib_test.att_mock_helper_ref(
-		cve._result_name,
-		{"vulnerabilities": {"critical": 1, "high": 1, "medium": 20, "low": 300}},
+	slsav1_task_with_result := tkn_test.slsav1_task_result_ref(
 		"clair-scan",
-		_bundle,
-	)]
+		[{
+			"name": cve._result_name,
+			"type": "string",
+			"value": {"vulnerabilities": {"critical": 1, "high": 1, "medium": 20, "low": 300}},
+		}],
+	)
+	attestations := [
+		lib_test.att_mock_helper_ref(
+			cve._result_name,
+			{"vulnerabilities": {"critical": 1, "high": 1, "medium": 20, "low": 300}},
+			"clair-scan",
+			_bundle,
+		),
+		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle(slsav1_task_with_result, _bundle)]),
+	]
 	lib.assert_empty(cve.deny) with input.attestations as attestations
 		with data.rule_data.restrict_cve_security_levels as ["spam"]
 }
 
 test_failure if {
+	slsav1_task_with_result := tkn_test.slsav1_task_result_ref(
+		"clair-scan",
+		[{
+			"name": cve._result_name,
+			"type": "string",
+			"value": {"vulnerabilities": {"critical": 1, "high": 10, "medium": 20, "low": 300}},
+		}],
+	)
 	attestations := [lib_test.att_mock_helper_ref(
 		cve._result_name,
 		{"vulnerabilities": {"critical": 1, "high": 10, "medium": 20, "low": 300}},
 		"clair-scan",
 		_bundle,
-	)]
+		),
+		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle(slsav1_task_with_result, _bundle)]),
+	]
 	expected := {
 		{
 			"code": "cve.cve_blockers",
@@ -52,12 +85,22 @@ test_failure if {
 }
 
 test_failure_with_rule_data if {
+	slsav1_task_with_result := tkn_test.slsav1_task_result_ref(
+		"clair-scan",
+		[{
+			"name": cve._result_name,
+			"type": "string",
+			"value": {"vulnerabilities": {"spam": 1, "bacon": 2, "eggs": 3}},
+		}],
+	)
 	attestations := [lib_test.att_mock_helper_ref(
 		cve._result_name,
 		{"vulnerabilities": {"spam": 1, "bacon": 2, "eggs": 3}},
 		"clair-scan",
 		_bundle,
-	)]
+		),
+		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle(slsav1_task_with_result, _bundle)]),
+	]
 	expected := {
 		{
 			"code": "cve.cve_blockers",
@@ -75,22 +118,42 @@ test_failure_with_rule_data if {
 }
 
 test_warn if {
+	slsav1_task_with_result := tkn_test.slsav1_task_result_ref(
+		"clair-scan",
+		[{
+			"name": cve._result_name,
+			"type": "string",
+			"value":{"vulnerabilities": {"critical": 1, "high": 10, "medium": 20, "low": 300}},
+		}],
+	)
 	attestations := [lib_test.att_mock_helper_ref(
 		cve._result_name,
 		{"vulnerabilities": {"critical": 1, "high": 10, "medium": 20, "low": 300}},
 		"clair-scan",
 		_bundle,
-	)]
+		),
+		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle(slsav1_task_with_result, _bundle)]),
+	]
 	lib.assert_empty(cve.warn) with input.attestations as attestations
 }
 
 test_warn_with_rule_data if {
+	slsav1_task_with_result := tkn_test.slsav1_task_result_ref(
+		"clair-scan",
+		[{
+			"name": cve._result_name,
+			"type": "string",
+			"value":{"vulnerabilities": {"critical": 1, "high": 10, "medium": 20, "low": 300}},
+		}],
+	)
 	attestations := [lib_test.att_mock_helper_ref(
 		cve._result_name,
 		{"vulnerabilities": {"critical": 1, "high": 10, "medium": 20, "low": 300}},
 		"clair-scan",
 		_bundle,
-	)]
+		),
+		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle(slsav1_task_with_result, _bundle)]),
+	]
 	expected := {
 		{
 			"code": "cve.cve_warnings",
@@ -108,12 +171,22 @@ test_warn_with_rule_data if {
 }
 
 test_missing_cve_scan_result if {
+	slsav1_task_with_result := tkn_test.slsav1_task_result_ref(
+		"clair-scan",
+		[{
+			"name": "WRONG_RESULT_NAME",
+			"type": "string",
+			"value":{"vulnerabilities": {"critical": 1, "high": 1, "medium": 20, "low": 300}},
+		}],
+	)
 	attestations := [lib_test.att_mock_helper_ref(
 		"WRONG_RESULT_NAME",
 		{"vulnerabilities": {"critical": 1, "high": 1, "medium": 20, "low": 300}},
 		"clair-scan",
 		_bundle,
-	)]
+		),
+		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle(slsav1_task_with_result, _bundle)]),
+	]
 	expected := {{
 		"code": "cve.cve_results_found",
 		"msg": "Clair CVE scan results were not found",
@@ -122,12 +195,22 @@ test_missing_cve_scan_result if {
 }
 
 test_missing_cve_scan_vulnerabilities if {
+	slsav1_task_with_result := tkn_test.slsav1_task_result_ref(
+		"clair-scan",
+		[{
+			"name": cve._result_name,
+			"type": "string",
+			"value":{"seitilibarenluv": {"critical": 1, "high": 1, "medium": 20, "low": 300}},
+		}],
+	)
 	attestations := [lib_test.att_mock_helper_ref(
 		cve._result_name,
 		{"seitilibarenluv": {"critical": 1, "high": 1, "medium": 20, "low": 300}},
 		"clair-scan",
 		_bundle,
-	)]
+		),
+		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle(slsav1_task_with_result, _bundle)]),
+	]
 	expected := {{
 		"code": "cve.cve_results_found",
 		"msg": "Clair CVE scan results were not found",

--- a/policy/release/cve_test.rego
+++ b/policy/release/cve_test.rego
@@ -61,11 +61,12 @@ test_failure if {
 			"value": {"vulnerabilities": {"critical": 1, "high": 10, "medium": 20, "low": 300}},
 		}],
 	)
-	attestations := [lib_test.att_mock_helper_ref(
-		cve._result_name,
-		{"vulnerabilities": {"critical": 1, "high": 10, "medium": 20, "low": 300}},
-		"clair-scan",
-		_bundle,
+	attestations := [
+		lib_test.att_mock_helper_ref(
+			cve._result_name,
+			{"vulnerabilities": {"critical": 1, "high": 10, "medium": 20, "low": 300}},
+			"clair-scan",
+			_bundle,
 		),
 		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle(slsav1_task_with_result, _bundle)]),
 	]
@@ -93,11 +94,12 @@ test_failure_with_rule_data if {
 			"value": {"vulnerabilities": {"spam": 1, "bacon": 2, "eggs": 3}},
 		}],
 	)
-	attestations := [lib_test.att_mock_helper_ref(
-		cve._result_name,
-		{"vulnerabilities": {"spam": 1, "bacon": 2, "eggs": 3}},
-		"clair-scan",
-		_bundle,
+	attestations := [
+		lib_test.att_mock_helper_ref(
+			cve._result_name,
+			{"vulnerabilities": {"spam": 1, "bacon": 2, "eggs": 3}},
+			"clair-scan",
+			_bundle,
 		),
 		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle(slsav1_task_with_result, _bundle)]),
 	]
@@ -123,14 +125,15 @@ test_warn if {
 		[{
 			"name": cve._result_name,
 			"type": "string",
-			"value":{"vulnerabilities": {"critical": 1, "high": 10, "medium": 20, "low": 300}},
+			"value": {"vulnerabilities": {"critical": 1, "high": 10, "medium": 20, "low": 300}},
 		}],
 	)
-	attestations := [lib_test.att_mock_helper_ref(
-		cve._result_name,
-		{"vulnerabilities": {"critical": 1, "high": 10, "medium": 20, "low": 300}},
-		"clair-scan",
-		_bundle,
+	attestations := [
+		lib_test.att_mock_helper_ref(
+			cve._result_name,
+			{"vulnerabilities": {"critical": 1, "high": 10, "medium": 20, "low": 300}},
+			"clair-scan",
+			_bundle,
 		),
 		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle(slsav1_task_with_result, _bundle)]),
 	]
@@ -143,14 +146,15 @@ test_warn_with_rule_data if {
 		[{
 			"name": cve._result_name,
 			"type": "string",
-			"value":{"vulnerabilities": {"critical": 1, "high": 10, "medium": 20, "low": 300}},
+			"value": {"vulnerabilities": {"critical": 1, "high": 10, "medium": 20, "low": 300}},
 		}],
 	)
-	attestations := [lib_test.att_mock_helper_ref(
-		cve._result_name,
-		{"vulnerabilities": {"critical": 1, "high": 10, "medium": 20, "low": 300}},
-		"clair-scan",
-		_bundle,
+	attestations := [
+		lib_test.att_mock_helper_ref(
+			cve._result_name,
+			{"vulnerabilities": {"critical": 1, "high": 10, "medium": 20, "low": 300}},
+			"clair-scan",
+			_bundle,
 		),
 		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle(slsav1_task_with_result, _bundle)]),
 	]
@@ -176,14 +180,15 @@ test_missing_cve_scan_result if {
 		[{
 			"name": "WRONG_RESULT_NAME",
 			"type": "string",
-			"value":{"vulnerabilities": {"critical": 1, "high": 1, "medium": 20, "low": 300}},
+			"value": {"vulnerabilities": {"critical": 1, "high": 1, "medium": 20, "low": 300}},
 		}],
 	)
-	attestations := [lib_test.att_mock_helper_ref(
-		"WRONG_RESULT_NAME",
-		{"vulnerabilities": {"critical": 1, "high": 1, "medium": 20, "low": 300}},
-		"clair-scan",
-		_bundle,
+	attestations := [
+		lib_test.att_mock_helper_ref(
+			"WRONG_RESULT_NAME",
+			{"vulnerabilities": {"critical": 1, "high": 1, "medium": 20, "low": 300}},
+			"clair-scan",
+			_bundle,
 		),
 		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle(slsav1_task_with_result, _bundle)]),
 	]
@@ -200,14 +205,15 @@ test_missing_cve_scan_vulnerabilities if {
 		[{
 			"name": cve._result_name,
 			"type": "string",
-			"value":{"seitilibarenluv": {"critical": 1, "high": 1, "medium": 20, "low": 300}},
+			"value": {"seitilibarenluv": {"critical": 1, "high": 1, "medium": 20, "low": 300}},
 		}],
 	)
-	attestations := [lib_test.att_mock_helper_ref(
-		cve._result_name,
-		{"seitilibarenluv": {"critical": 1, "high": 1, "medium": 20, "low": 300}},
-		"clair-scan",
-		_bundle,
+	attestations := [
+		lib_test.att_mock_helper_ref(
+			cve._result_name,
+			{"seitilibarenluv": {"critical": 1, "high": 1, "medium": 20, "low": 300}},
+			"clair-scan",
+			_bundle,
 		),
 		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle(slsav1_task_with_result, _bundle)]),
 	]

--- a/policy/release/external_parameters.rego
+++ b/policy/release/external_parameters.rego
@@ -25,7 +25,7 @@ import data.lib
 #   failure_msg: PipelineRun params, %v, do not match expectation, %v.
 #
 deny contains result if {
-	some provenance in lib.pipelinerun_slsa_provenance_v1
+	some provenance in lib.pipelinerun_attestations
 	param_names := {name |
 		some p in provenance.predicate.buildDefinition.externalParameters.runSpec.params
 		p.value != ""
@@ -46,7 +46,7 @@ deny contains result if {
 #   failure_msg: PipelineRun uses shared volumes, %v.
 #
 deny contains result if {
-	some provenance in lib.pipelinerun_slsa_provenance_v1
+	some provenance in lib.pipelinerun_attestations
 	shared_workspaces := {w |
 		some w in provenance.predicate.buildDefinition.externalParameters.runSpec.workspaces
 		w.persistentVolumeClaim

--- a/policy/release/java_test.rego
+++ b/policy/release/java_test.rego
@@ -1,26 +1,33 @@
 package policy.release.java_test
 
 import data.lib
+import data.lib.tkn_test
 import data.lib_test
 import data.policy.release.java
 
 test_all_good {
-	attestations := [lib_test.att_mock_helper_ref(
-		lib.java_sbom_component_count_result_name,
-		{"redhat": 12, "rebuilt": 42},
-		"java-task-1",
-		_bundle,
-	)]
+	attestations := [
+		lib_test.att_mock_helper_ref(
+			lib.java_sbom_component_count_result_name,
+			{"redhat": 12, "rebuilt": 42},
+			"java-task-1",
+			_bundle,
+		),
+		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_result_ref("java-task-2", [{"name": lib.java_sbom_component_count_result_name, "type": "string", "value": {"redhat": 12, "rebuilt": 42}}])]),
+	]
 	lib.assert_empty(java.deny) with input.attestations as attestations
 }
 
 test_has_foreign {
-	attestations := [lib_test.att_mock_helper_ref(
-		lib.java_sbom_component_count_result_name,
-		{"redhat": 12, "rebuilt": 42, "central": 1},
-		"java-task-1",
-		_bundle,
-	)]
+	attestations := [
+		lib_test.att_mock_helper_ref(
+			lib.java_sbom_component_count_result_name,
+			{"redhat": 12, "rebuilt": 42, "central": 1},
+			"java-task-1",
+			_bundle,
+		),
+		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_result_ref("java-task-2", [{"name": lib.java_sbom_component_count_result_name, "type": "string", "value": {"redhat": 12, "rebuilt": 42, "central": 1}}])]),
+	]
 	expected := {{
 		"code": "java.no_foreign_dependencies",
 		"msg": "Found Java dependencies from 'central', expecting to find only from 'rebuilt,redhat'",

--- a/policy/release/lib/attestations.rego
+++ b/policy/release/lib/attestations.rego
@@ -87,14 +87,10 @@ tasks_from_pipelinerun := [task |
 ]
 
 # slsa v0.2 results
-task_results(task) := results if {
-	results := task.results
-}
+task_results(task) := task.results
 
 # slsa v1.0 results
-task_results(task) := results if {
-	results := task.status.taskResults
-}
+task_results(task) := task.status.taskResults
 
 # All results from the attested PipelineRun with the provided name. Results are
 # expected to contain a JSON value. The return object contains the following

--- a/policy/release/lib/attestations.rego
+++ b/policy/release/lib/attestations.rego
@@ -1,7 +1,7 @@
 package lib
 
-import future.keywords.in
 import future.keywords.if
+import future.keywords.in
 
 import data.lib.tkn
 
@@ -77,7 +77,7 @@ taskrun_attestations := [statement |
 	statement.predicate.buildType in taskrun_att_build_types
 ]
 
-_statement(att) := statement {
+_statement(att) := statement if {
 	statement := att.statement
 } else = att
 
@@ -122,7 +122,7 @@ results_named(name) := [r |
 # Attempts to json.unmarshal the given value. If not possible, the given
 # value is returned as is. This is helpful when interpreting certain values
 # in attestations created by Tekton Chains.
-unmarshal(raw) := value {
+unmarshal(raw) := value if {
 	json.is_valid(raw)
 	value := json.unmarshal(raw)
 } else = raw
@@ -132,21 +132,21 @@ unmarshal(raw) := value {
 results_from_tests := results_named(task_test_result_name)
 
 # Check for a task by name. Return the task if found
-task_in_pipelinerun(name) := task {
+task_in_pipelinerun(name) := task if {
 	some task in tasks_from_pipelinerun
 	task.name == name
 	task
 }
 
 # Check for a task result by name
-result_in_task(task_name, result_name) {
+result_in_task(task_name, result_name) if {
 	task := task_in_pipelinerun(task_name)
 	some task_result in task.results
 	task_result.name == result_name
 }
 
 # Check for a Succeeded status from a task
-task_succeeded(name) {
+task_succeeded(name) if {
 	task := task_in_pipelinerun(name)
 	task.status == "Succeeded"
 }

--- a/policy/release/lib/attestations_test.rego
+++ b/policy/release/lib/attestations_test.rego
@@ -114,7 +114,7 @@ att_mock_task_helper(task) := [{"statement": {"predicate": {
 }}}]
 
 # make working with tasks and resolvedDeps easier
-mock_slsav1_attestation(tasks) := {"statement": {
+mock_slsav1_attestation_with_tasks(tasks) := {"statement": {
 		"predicateType": "https://slsa.dev/provenance/v1",
 		"predicate": {"buildDefinition": {
 			"buildType": lib.tekton_slsav1_pipeline_run,
@@ -123,12 +123,21 @@ mock_slsav1_attestation(tasks) := {"statement": {
 		}}
 }}
 
+mock_slsav1_attestation := {"statement": {
+		"predicateType": "https://slsa.dev/provenance/v1",
+		"predicate": {"buildDefinition": {
+			"buildType": lib.tekton_slsav1_pipeline_run,
+			"externalParameters": {"runSpec": {"pipelineSpec": {}}},
+			"resolvedDependencies": [{}]
+		}}
+}}
+
 mock_slsav1_attestation_bundles(bundles) := a {
 	tasks := [task |
 		some bundle in bundles
 		task := tkn_test.slsav1_task_bundle("my-task", bundle)
 	]
-	a := mock_slsav1_attestation(tasks)
+	a := mock_slsav1_attestation_with_tasks(tasks)
 }
 
 mock_slsav02_attestation_bundles(bundles) := a {

--- a/policy/release/lib/attestations_test.rego
+++ b/policy/release/lib/attestations_test.rego
@@ -3,8 +3,8 @@ package lib_test
 import future.keywords.in
 
 import data.lib
-import data.lib.tkn_test
 import data.lib.bundles_test
+import data.lib.tkn_test
 import data.lib_test
 
 pr_build_type := "tekton.dev/v1beta1/PipelineRun"
@@ -26,12 +26,12 @@ mock_tr_att_legacy := {"statement": {"predicate": {"buildType": tr_build_type_le
 garbage_att := {"statement": {"predicate": {"buildType": "garbage"}}}
 
 valid_slsav1_att := {"statement": {
-		"predicateType": "https://slsa.dev/provenance/v1",
-		"predicate": {"buildDefinition": {
-			"buildType": "https://tekton.dev/chains/v2/slsa-tekton",
-			"externalParameters": {"runSpec": {"pipelineSpec": {}}},
-			"resolvedDependencies": []
-		}}
+	"predicateType": "https://slsa.dev/provenance/v1",
+	"predicate": {"buildDefinition": {
+		"buildType": "https://tekton.dev/chains/v2/slsa-tekton",
+		"externalParameters": {"runSpec": {"pipelineSpec": {}}},
+		"resolvedDependencies": [],
+	}},
 }}
 
 # This is used through the tests to generate an attestation of a PipelineRun
@@ -115,21 +115,21 @@ att_mock_task_helper(task) := [{"statement": {"predicate": {
 
 # make working with tasks and resolvedDeps easier
 mock_slsav1_attestation_with_tasks(tasks) := {"statement": {
-		"predicateType": "https://slsa.dev/provenance/v1",
-		"predicate": {"buildDefinition": {
-			"buildType": lib.tekton_slsav1_pipeline_run,
-			"externalParameters": {"runSpec": {"pipelineSpec": {}}},
-			"resolvedDependencies": tkn_test.resolved_dependencies(tasks)
-		}}
+	"predicateType": "https://slsa.dev/provenance/v1",
+	"predicate": {"buildDefinition": {
+		"buildType": lib.tekton_slsav1_pipeline_run,
+		"externalParameters": {"runSpec": {"pipelineSpec": {}}},
+		"resolvedDependencies": tkn_test.resolved_dependencies(tasks),
+	}},
 }}
 
 mock_slsav1_attestation := {"statement": {
-		"predicateType": "https://slsa.dev/provenance/v1",
-		"predicate": {"buildDefinition": {
-			"buildType": lib.tekton_slsav1_pipeline_run,
-			"externalParameters": {"runSpec": {"pipelineSpec": {}}},
-			"resolvedDependencies": [{}]
-		}}
+	"predicateType": "https://slsa.dev/provenance/v1",
+	"predicate": {"buildDefinition": {
+		"buildType": lib.tekton_slsav1_pipeline_run,
+		"externalParameters": {"runSpec": {"pipelineSpec": {}}},
+		"resolvedDependencies": [{}],
+	}},
 }}
 
 mock_slsav1_attestation_bundles(bundles) := a {
@@ -160,19 +160,16 @@ mock_slsav02_attestation_bundles(bundles) := a {
 
 test_tasks_from_pipelinerun {
 	slsa1_task := tkn_test.slsav1_task("buildah")
-	slsa1_att := [json.patch(valid_slsav1_att, [
-		{
-			"op": "replace",
-			"path": "/statement/predicate/buildDefinition/resolvedDependencies",
-			"value": tkn_test.resolved_dependencies([slsa1_task])
-		}
-	])]
+	slsa1_att := [json.patch(valid_slsav1_att, [{
+		"op": "replace",
+		"path": "/statement/predicate/buildDefinition/resolvedDependencies",
+		"value": tkn_test.resolved_dependencies([slsa1_task]),
+	}])]
 	lib.assert_equal([slsa1_task], lib.tasks_from_pipelinerun) with input.attestations as slsa1_att
 
 	slsa02_task := {"name": "my-task", "ref": {"kind": "task"}}
 	slsa02_att := att_mock_task_helper(slsa02_task)
 	lib.assert_equal([slsa02_task], lib.tasks_from_pipelinerun) with input.attestations as slsa02_att
-
 }
 
 test_pr_attestations {
@@ -362,9 +359,7 @@ test_result_in_task {
 			"name": result_name,
 			"value": "result value",
 		}],
-		"ref": {
-			"kind": "task"
-		}
+		"ref": {"kind": "task"},
 	})
 
 	lib.result_in_task(task_name, result_name) with input.attestations as d
@@ -379,9 +374,7 @@ test_result_not_in_task {
 			"name": "result name",
 			"value": "result value",
 		}],
-		"ref": {
-			"kind": "task"
-		}
+		"ref": {"kind": "task"},
 	})
 
 	not lib.result_in_task(task_name, result_name) with input.attestations as d
@@ -392,9 +385,7 @@ test_task_succeeded {
 	d := att_mock_task_helper({
 		"name": task_name,
 		"status": "Succeeded",
-		"ref": {
-			"kind": "task"
-		}
+		"ref": {"kind": "task"},
 	})
 
 	lib.task_succeeded(task_name) with input.attestations as d
@@ -405,9 +396,7 @@ test_task_not_succeeded {
 	d := att_mock_task_helper({
 		"name": task_name,
 		"status": "Failed",
-		"ref": {
-			"kind": "task"
-		}
+		"ref": {"kind": "task"},
 	})
 
 	not lib.task_succeeded(task_name) with input.attestations as d

--- a/policy/release/lib/attestations_test.rego
+++ b/policy/release/lib/attestations_test.rego
@@ -341,6 +341,19 @@ test_results_from_tests {
 		"mytask", bundles_test.acceptable_bundle_ref,
 	)
 	lib.assert_equal([expected], lib.results_from_tests) with input.attestations as [att2]
+
+	att3 := mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle(
+		tkn_test.slsav1_task_result(
+			"mytask",
+			[{
+				"name": lib.task_test_result_name,
+				"type": "string",
+				"value": json.marshal({"result": "SUCCESS", "foo": "bar"}),
+			}],
+		),
+		bundles_test.acceptable_bundle_ref,
+	)])
+	lib.assert_equal([expected], lib.results_from_tests) with input.attestations as [att3]
 }
 
 test_task_not_in_pipelinerun {

--- a/policy/release/lib/attestations_test.rego
+++ b/policy/release/lib/attestations_test.rego
@@ -123,15 +123,6 @@ mock_slsav1_attestation_with_tasks(tasks) := {"statement": {
 	}},
 }}
 
-mock_slsav1_attestation := {"statement": {
-	"predicateType": "https://slsa.dev/provenance/v1",
-	"predicate": {"buildDefinition": {
-		"buildType": lib.tekton_slsav1_pipeline_run,
-		"externalParameters": {"runSpec": {"pipelineSpec": {}}},
-		"resolvedDependencies": [{}],
-	}},
-}}
-
 mock_slsav1_attestation_bundles(bundles) := a {
 	tasks := [task |
 		some bundle in bundles

--- a/policy/release/step_image_registries.rego
+++ b/policy/release/step_image_registries.rego
@@ -12,6 +12,7 @@ import future.keywords.if
 import future.keywords.in
 
 import data.lib
+import data.lib.tkn
 
 # METADATA
 # title: Task steps ran on permitted container images
@@ -30,13 +31,12 @@ import data.lib
 #   - attestation_type.known_attestation_type
 #
 deny contains result if {
-	some attestation in lib.pipelinerun_attestations
-	some task in attestation.predicate.buildConfig.tasks
-	some step_index, step in task.steps
-	image_ref := step.environment.image
+	some task in lib.tasks_from_pipelinerun
+	some step_index, step in tkn.task_steps(task)
+	image_ref := tkn.task_step_image_ref(step)
 	allowed_registry_prefixes := lib.rule_data("allowed_step_image_registry_prefixes")
 	not image_ref_permitted(image_ref, allowed_registry_prefixes)
-	result := lib.result_helper(rego.metadata.chain(), [step_index, task.name, image_ref])
+	result := lib.result_helper(rego.metadata.chain(), [step_index, tkn.task_name(task), image_ref])
 }
 
 # METADATA

--- a/policy/release/step_image_registries_test.rego
+++ b/policy/release/step_image_registries_test.rego
@@ -3,6 +3,8 @@ package policy.release.step_image_registries_test
 import future.keywords.if
 
 import data.lib
+import data.lib.tkn_test
+import data.lib_test
 import data.policy.release.step_image_registries
 
 good_image := "registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:af7dd5b3b"
@@ -15,26 +17,42 @@ bad_oci_image := sprintf("oci://%s", [bad_image])
 
 unexpected_image := sprintf("spam://%s", [good_image])
 
-mock_data(image_ref) := [{"statement": {"predicate": {
+mock_data(image_ref) := {"statement": {"predicate": {
 	"buildType": lib.tekton_pipeline_run,
-	"buildConfig": {"tasks": [{"name": "mytask", "steps": [{"environment": {"image": image_ref}}]}]},
-}}}]
+	"buildConfig": {"tasks": [{"name": "mytask", "ref": {"kind": "task", "name": "mytask"}, "steps": [{"environment": {"image": image_ref}}]}]},
+}}}
+
+mock_slsav1_data(image_ref) := lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_steps("mytask", [{"name": "mystep", "image": image_ref}])])
 
 test_image_registry_valid if {
-	lib.assert_empty(step_image_registries.deny) with input.attestations as mock_data(good_image)
-	lib.assert_empty(step_image_registries.deny) with input.attestations as mock_data(good_oci_image)
+	attestations := [
+		mock_data(good_image),
+		mock_data(good_oci_image),
+		mock_slsav1_data(good_image),
+		mock_slsav1_data(good_oci_image)
+	]
+	lib.assert_empty(step_image_registries.deny) with input.attestations as attestations
+	lib.assert_empty(step_image_registries.deny) with input.attestations as attestations
 }
 
 test_attestation_type_invalid if {
+	bad_attestations := [
+		mock_data(bad_image),
+		mock_slsav1_data(bad_image)
+	]
 	lib.assert_equal_results(step_image_registries.deny, {{
 		"code": "step_image_registries.task_step_images_permitted",
 		"msg": sprintf("Step 0 in task 'mytask' has disallowed image ref '%s'", [bad_image]),
-	}}) with input.attestations as mock_data(bad_image)
+	}}) with input.attestations as bad_attestations
 
+	bad_oci_attestations := [
+		mock_data(bad_oci_image),
+		mock_slsav1_data(bad_oci_image)
+	]
 	lib.assert_equal_results(step_image_registries.deny, {{
 		"code": "step_image_registries.task_step_images_permitted",
 		"msg": sprintf("Step 0 in task 'mytask' has disallowed image ref '%s'", [bad_oci_image]),
-	}}) with input.attestations as mock_data(bad_oci_image)
+	}}) with input.attestations as bad_oci_attestations
 }
 
 test_unexpected_image_ref if {

--- a/policy/release/step_image_registries_test.rego
+++ b/policy/release/step_image_registries_test.rego
@@ -29,7 +29,7 @@ test_image_registry_valid if {
 		mock_data(good_image),
 		mock_data(good_oci_image),
 		mock_slsav1_data(good_image),
-		mock_slsav1_data(good_oci_image)
+		mock_slsav1_data(good_oci_image),
 	]
 	lib.assert_empty(step_image_registries.deny) with input.attestations as attestations
 	lib.assert_empty(step_image_registries.deny) with input.attestations as attestations
@@ -38,7 +38,7 @@ test_image_registry_valid if {
 test_attestation_type_invalid if {
 	bad_attestations := [
 		mock_data(bad_image),
-		mock_slsav1_data(bad_image)
+		mock_slsav1_data(bad_image),
 	]
 	lib.assert_equal_results(step_image_registries.deny, {{
 		"code": "step_image_registries.task_step_images_permitted",
@@ -47,7 +47,7 @@ test_attestation_type_invalid if {
 
 	bad_oci_attestations := [
 		mock_data(bad_oci_image),
-		mock_slsav1_data(bad_oci_image)
+		mock_slsav1_data(bad_oci_image),
 	]
 	lib.assert_equal_results(step_image_registries.deny, {{
 		"code": "step_image_registries.task_step_images_permitted",

--- a/policy/release/tasks.rego
+++ b/policy/release/tasks.rego
@@ -40,7 +40,7 @@ import data.lib.tkn
 #   - attestation_type.known_attestation_type
 #
 deny contains result if {
-	some att in _pipelineruns
+	some att in lib.pipelinerun_attestations
 	count(tkn.tasks(att)) == 0
 	result := lib.result_helper(rego.metadata.chain(), [])
 }
@@ -64,7 +64,7 @@ deny contains result if {
 #   - tasks.pipeline_has_tasks
 #
 deny contains result if {
-	some att in _pipelineruns
+	some att in lib.pipelinerun_attestations
 	some task in tkn.tasks(att)
 	some status in _status(task)
 	status != "Succeeded"
@@ -166,7 +166,7 @@ deny contains result if {
 # _missing_tasks returns a set of task names that are in the given
 # required_tasks, but not in the PipelineRun attestation.
 _missing_tasks(required_tasks) := {task |
-	some att in _pipelineruns
+	some att in lib.pipelinerun_attestations
 	count(tkn.tasks(att)) > 0
 
 	some task in required_tasks
@@ -176,7 +176,7 @@ _missing_tasks(required_tasks) := {task |
 # get the future tasks that are pipeline specific. If none exists
 # get the default list
 latest_required_tasks := task_data if {
-	some att in _pipelineruns
+	some att in lib.pipelinerun_attestations
 	count(tkn.tasks(att)) > 0
 	task_data := tkn.latest_required_pipeline_tasks(att)
 } else := task_data if {
@@ -186,7 +186,7 @@ latest_required_tasks := task_data if {
 # get current required tasks. fall back to the default list if
 # no label exists in the attestation
 current_required_tasks := task_data if {
-	some att in _pipelineruns
+	some att in lib.pipelinerun_attestations
 	count(tkn.tasks(att)) > 0
 	task_data := tkn.current_required_pipeline_tasks(att)
 } else := task_data if {
@@ -195,7 +195,7 @@ current_required_tasks := task_data if {
 
 ## get the required task data for a pipeline with a label
 required_pipeline_task_data := task_data if {
-	some att in _pipelineruns
+	some att in lib.pipelinerun_attestations
 	count(tkn.tasks(att)) > 0
 	task_data := tkn.required_task_list(att)
 }
@@ -228,15 +228,4 @@ _slsav1_status(condition) := status if {
 _slsav1_status(condition) := status if {
 	condition.status == "False"
 	status := "Failed"
-}
-
-_pipelineruns := att if {
-	v1_0 := [a |
-		some a in lib.pipelinerun_slsa_provenance_v1
-	]
-	v0_1 := [a |
-		some a in lib.pipelinerun_attestations
-	]
-
-	att := array.concat(v1_0, v0_1)
 }

--- a/policy/release/test_test.rego
+++ b/policy/release/test_test.rego
@@ -1,82 +1,128 @@
 package policy.release.test_test
 
 import data.lib
+import data.lib.tkn_test
 import data.lib_test
 import data.policy.release.test
 
 # Because TEST_OUTPUT isn't in the task results, the lib.results_from_tests will be empty
-mock_empty_data := [lib_test.att_mock_helper_ref("NOT_TEST_OUTPUT", {}, "task1", _bundle)]
-
 test_needs_non_empty_data {
+	slsav1_task := tkn_test.slsav1_task_result_ref("task2", [{"name": "NOT_TEST_OUTPUT", "type": "string", "value": {}}])
+	attestations := [
+		lib_test.att_mock_helper_ref("NOT_TEST_OUTPUT", {}, "task1", _bundle),
+		lib_test.mock_slsav1_attestation_with_tasks([slsav1_task]),
+	]
 	lib.assert_equal_results(test.deny, {{
 		"code": "test.test_data_found",
 		"msg": "No test data found",
-	}}) with input.attestations as mock_empty_data
+	}}) with input.attestations as attestations
 }
 
 # There is a test result, but the data inside it doesn't include the "result" key
-mock_without_results_data := [lib_test.att_mock_helper_ref(
-	lib.task_test_result_name, {"rezult": "SUCCESS"},
-	"task1", _bundle,
-)]
-
 test_needs_tests_with_results {
+	slsav1_task := tkn_test.slsav1_task_result_ref("task2", [{"name": lib.task_test_result_name, "type": "string", "value": {"rezult": "SUCCESS"}}])
+	attestations := [
+		lib_test.att_mock_helper_ref(
+			lib.task_test_result_name, {"rezult": "SUCCESS"},
+			"task1", _bundle,
+		),
+		lib_test.mock_slsav1_attestation_with_tasks([slsav1_task]),
+	]
 	lib.assert_equal_results(test.deny, {{
 		"code": "test.test_results_found",
 		"msg": "Found tests without results",
-	}}) with input.attestations as mock_without_results_data
+	}}) with input.attestations as attestations
 }
-
-mock_without_results_data_mixed := [
-	lib_test.att_mock_helper_ref(lib.task_test_result_name, {"result": "SUCCESS"}, "task1", _bundle),
-	lib_test.att_mock_helper_ref(lib.task_test_result_name, {"rezult": "SUCCESS"}, "task2", _bundle),
-]
 
 test_needs_tests_with_results_mixed {
+	slsav1_bad_task := tkn_test.slsav1_task_result_ref("task3", [{"name": lib.task_test_result_name, "type": "string", "value": {"rezult": "SUCCESS"}}])
+	slsav1_good_task := tkn_test.slsav1_task_result_ref("task4", [{"name": lib.task_test_result_name, "type": "string", "value": {"result": "SUCCESS"}}])
+
+	attestations := [
+		lib_test.att_mock_helper_ref(lib.task_test_result_name, {"result": "SUCCESS"}, "task1", _bundle),
+		lib_test.att_mock_helper_ref(lib.task_test_result_name, {"rezult": "SUCCESS"}, "task2", _bundle),
+		lib_test.mock_slsav1_attestation_with_tasks([slsav1_good_task, slsav1_bad_task]),
+	]
 	lib.assert_equal_results(test.deny, {{
 		"code": "test.test_results_found",
 		"msg": "Found tests without results",
-	}}) with input.attestations as mock_without_results_data_mixed
+	}}) with input.attestations as attestations
 }
-
-mock_a_passing_test := [lib_test.att_mock_helper_ref(
-	lib.task_test_result_name,
-	{"result": "SUCCESS"}, "task1", _bundle,
-)]
 
 test_success_data {
-	lib.assert_empty(test.deny) with input.attestations as mock_a_passing_test
+	slsav1_good_task := tkn_test.slsav1_task_result_ref("task1", [{"name": lib.task_test_result_name, "type": "string", "value": {"result": "SUCCESS"}}])
+	attestations := [
+		lib_test.att_mock_helper_ref(lib.task_test_result_name, {"result": "SUCCESS"}, "task1", _bundle),
+		lib_test.mock_slsav1_attestation_with_tasks([slsav1_good_task]),
+	]
+	lib.assert_empty(test.deny) with input.attestations as attestations
 }
 
-mock_a_failing_test := [lib_test.att_mock_helper_ref(
+mock_a_failing_test := lib_test.att_mock_helper_ref(
 	lib.task_test_result_name,
 	{"result": "FAILURE"}, "failed_1", _bundle,
-)]
+)
 
 test_failure_data {
-	lib.assert_equal_results(test.deny, {{
-		"code": "test.required_tests_passed",
-		"msg": "Test \"failed_1\" did not complete successfully",
-		"term": "failed_1",
-	}}) with input.attestations as mock_a_failing_test
+	slsav1_task := tkn_test.slsav1_task_result_ref("task1", [{"name": lib.task_test_result_name, "type": "string", "value": {"result": "FAILURE"}}])
+	attestations := [
+		lib_test.att_mock_helper_ref(
+			lib.task_test_result_name,
+			{"result": "FAILURE"}, "failed_1", _bundle,
+		),
+		lib_test.mock_slsav1_attestation_with_tasks([slsav1_task]),
+	]
+	lib.assert_equal_results(test.deny, {
+		{
+			"code": "test.required_tests_passed",
+			"msg": "Test \"failed_1\" did not complete successfully",
+			"term": "failed_1",
+		},
+		{
+			"code": "test.required_tests_passed",
+			"msg": "Test \"task1\" did not complete successfully",
+			"term": "task1",
+		},
+	}) with input.attestations as attestations
 }
 
-mock_an_errored_test := [lib_test.att_mock_helper_ref(
+mock_an_errored_test := lib_test.att_mock_helper_ref(
 	lib.task_test_result_name,
 	{"result": "ERROR"}, "errored_1", _bundle,
-)]
+)
 
 test_error_data {
-	lib.assert_equal_results(test.deny, {{
-		"code": "test.required_tests_passed",
-		"msg": "Test \"errored_1\" did not complete successfully",
-		"term": "errored_1",
-	}}) with input.attestations as mock_an_errored_test
+	slsav1_task := tkn_test.slsav1_task_result_ref("errored_2", [{"name": lib.task_test_result_name, "type": "string", "value": {"result": "ERROR"}}])
+	attestations := [
+		lib_test.att_mock_helper_ref(
+			lib.task_test_result_name,
+			{"result": "ERROR"}, "errored_1", _bundle,
+		),
+		lib_test.mock_slsav1_attestation_with_tasks([slsav1_task]),
+	]
+	lib.assert_equal_results(test.deny, {
+		{
+			"code": "test.required_tests_passed",
+			"msg": "Test \"errored_1\" did not complete successfully",
+			"term": "errored_1",
+		},
+		{
+			"code": "test.required_tests_passed",
+			"msg": "Test \"errored_2\" did not complete successfully",
+			"term": "errored_2",
+		},
+	}) with input.attestations as attestations
 }
 
-mock_mixed_data := array.concat(mock_a_failing_test, mock_an_errored_test)
-
 test_mix_data {
+	slsav1_errored_task := tkn_test.slsav1_task_result_ref("errored_2", [{"name": lib.task_test_result_name, "type": "string", "value": {"result": "ERROR"}}])
+	slsav1_failed_task := tkn_test.slsav1_task_result_ref("failed_2", [{"name": lib.task_test_result_name, "type": "string", "value": {"result": "FAILURE"}}])
+	attestations := [
+		mock_a_failing_test,
+		mock_an_errored_test,
+		lib_test.mock_slsav1_attestation_with_tasks([slsav1_failed_task]),
+		lib_test.mock_slsav1_attestation_with_tasks([slsav1_errored_task]),
+	]
 	lib.assert_equal_results(test.deny, {
 		{
 			"code": "test.required_tests_passed",
@@ -88,39 +134,72 @@ test_mix_data {
 			"msg": "Test \"errored_1\" did not complete successfully",
 			"term": "errored_1",
 		},
-	}) with input.attestations as mock_mixed_data
+		{
+			"code": "test.required_tests_passed",
+			"msg": "Test \"failed_2\" did not complete successfully",
+			"term": "failed_2",
+		},
+		{
+			"code": "test.required_tests_passed",
+			"msg": "Test \"errored_2\" did not complete successfully",
+			"term": "errored_2",
+		},
+	}) with input.attestations as attestations
 }
 
 test_skipped_is_not_deny {
-	skipped_test := [lib_test.att_mock_helper_ref(
-		lib.task_test_result_name,
-		{"result": "SKIPPED"}, "skipped_1", _bundle,
-	)]
-	lib.assert_empty(test.deny) with input.attestations as skipped_test
+	attestations := [
+		lib_test.att_mock_helper_ref(
+			lib.task_test_result_name,
+			{"result": "SKIPPED"}, "skipped_1", _bundle,
+		),
+		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_result_ref("skipped_2", [{"name": lib.task_test_result_name, "type": "string", "value": {"result": "SKIPPED"}}])]),
+	]
+	lib.assert_empty(test.deny) with input.attestations as attestations
 }
 
 test_skipped_is_warning {
-	skipped_test := [lib_test.att_mock_helper_ref(
-		lib.task_test_result_name,
-		{"result": "SKIPPED"}, "skipped_1", _bundle,
-	)]
-	lib.assert_equal_results(test.warn, {{
-		"code": "test.no_skipped_tests",
-		"msg": "Test \"skipped_1\" was skipped",
-		"term": "skipped_1",
-	}}) with input.attestations as skipped_test
+	attestations := [
+		lib_test.att_mock_helper_ref(
+			lib.task_test_result_name,
+			{"result": "SKIPPED"}, "skipped_1", _bundle,
+		),
+		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_result_ref("skipped_2", [{"name": lib.task_test_result_name, "type": "string", "value": {"result": "SKIPPED"}}])]),
+	]
+	lib.assert_equal_results(test.warn, {
+		{
+			"code": "test.no_skipped_tests",
+			"msg": "Test \"skipped_1\" was skipped",
+			"term": "skipped_1",
+		},
+		{
+			"code": "test.no_skipped_tests",
+			"msg": "Test \"skipped_2\" was skipped",
+			"term": "skipped_2",
+		},
+	}) with input.attestations as attestations
 }
 
 test_warning_is_warning {
-	warning_test := [lib_test.att_mock_helper_ref(
-		lib.task_test_result_name,
-		{"result": "WARNING"}, "warning_1", _bundle,
-	)]
-	lib.assert_equal_results(test.warn, {{
-		"code": "test.no_test_warnings",
-		"msg": "Test \"warning_1\" returned a warning",
-		"term": "warning_1",
-	}}) with input.attestations as warning_test
+	attestations := [
+		lib_test.att_mock_helper_ref(
+			lib.task_test_result_name,
+			{"result": "WARNING"}, "warning_1", _bundle,
+		),
+		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_result_ref("warning_2", [{"name": lib.task_test_result_name, "type": "string", "value": {"result": "WARNING"}}])]),
+	]
+	lib.assert_equal_results(test.warn, {
+		{
+			"code": "test.no_test_warnings",
+			"msg": "Test \"warning_1\" returned a warning",
+			"term": "warning_1",
+		},
+		{
+			"code": "test.no_test_warnings",
+			"msg": "Test \"warning_2\" returned a warning",
+			"term": "warning_2",
+		},
+	}) with input.attestations as attestations
 }
 
 # regal ignore:rule-length
@@ -135,6 +214,11 @@ test_mixed_statuses {
 		lib_test.att_mock_helper_ref(lib.task_test_result_name, {"result": "WARNING"}, "warning_1", _bundle),
 		lib_test.att_mock_helper_ref(lib.task_test_result_name, {"result": "ERROR"}, "error_2", _bundle),
 		lib_test.att_mock_helper_ref(lib.task_test_result_name, {"result": "WARNING"}, "warning_2", _bundle),
+		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_result_ref("success_20", [{"name": lib.task_test_result_name, "type": "string", "value": {"result": "SUCCESS"}}])]),
+		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_result_ref("failure_20", [{"name": lib.task_test_result_name, "type": "string", "value": {"result": "FAILURE"}}])]),
+		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_result_ref("error_20", [{"name": lib.task_test_result_name, "type": "string", "value": {"result": "ERROR"}}])]),
+		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_result_ref("warning_20", [{"name": lib.task_test_result_name, "type": "string", "value": {"result": "WARNING"}}])]),
+		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_result_ref("skipped_20", [{"name": lib.task_test_result_name, "type": "string", "value": {"result": "SKIPPED"}}])]),
 	]
 
 	lib.assert_equal_results(test.deny, {
@@ -157,6 +241,16 @@ test_mixed_statuses {
 			"code": "test.required_tests_passed",
 			"msg": "Test \"failure_2\" did not complete successfully",
 			"term": "failure_2",
+		},
+		{
+			"code": "test.required_tests_passed",
+			"msg": "Test \"failure_20\" did not complete successfully",
+			"term": "failure_20",
+		},
+		{
+			"code": "test.required_tests_passed",
+			"msg": "Test \"error_20\" did not complete successfully",
+			"term": "error_20",
 		},
 	}) with input.attestations as test_results
 
@@ -181,6 +275,16 @@ test_mixed_statuses {
 			"msg": "Test \"warning_2\" returned a warning",
 			"term": "warning_2",
 		},
+		{
+			"code": "test.no_test_warnings",
+			"msg": "Test \"warning_20\" returned a warning",
+			"term": "warning_20",
+		},
+		{
+			"code": "test.no_skipped_tests",
+			"msg": "Test \"skipped_20\" was skipped",
+			"term": "skipped_20",
+		},
 	}) with input.attestations as test_results
 }
 
@@ -190,6 +294,7 @@ test_unsupported_test_result {
 		lib_test.att_mock_helper_ref(lib.task_test_result_name, {"result": "SUCESS"}, "success_1", _bundle),
 		lib_test.att_mock_helper_ref(lib.task_test_result_name, {"result": "FAIL"}, "failure_1", _bundle),
 		lib_test.att_mock_helper_ref(lib.task_test_result_name, {"result": "SKIPED"}, "skipped_1", _bundle),
+		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_result_ref("skipped_20", [{"name": lib.task_test_result_name, "type": "string", "value": {"result": "SKIPED"}}])]),
 	]
 
 	lib.assert_equal_results(test.deny, {
@@ -209,19 +314,28 @@ test_unsupported_test_result {
 			"code": "test.test_results_known",
 			"msg": "Test 'success_1' has unsupported result 'SUCESS'", "term": "success_1",
 		},
+		{
+			"code": "test.test_results_known",
+			"msg": "Test 'skipped_20' has unsupported result 'SKIPED'", "term": "skipped_20",
+		},
 	}) with input.attestations as test_results
 }
 
 test_missing_wrong_attestation_type {
 	pr := lib_test.att_mock_helper_ref("some-result", {"result": "value"}, "task1", _bundle)
 	tr := object.union(pr, {"statement": {"predicate": {"buildType": lib.tekton_task_run}}})
-	lib.assert_empty(test.deny) with input.attestations as [tr]
+	pr_slsav1 := lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_result_ref("skipped_20", [{"name": lib.task_test_result_name, "type": "string", "value": {"result": "SKIPED"}}])])
+	tr_slsav1 := object.union(pr_slsav1, {"statement": {"predicate": {"buildDefinition": {"buildType": lib.tekton_task_run}}}})
+
+	lib.assert_empty(test.deny) with input.attestations as [tr, tr_slsav1]
 }
 
 test_wrong_attestation_type {
 	pr := lib_test.att_mock_helper_ref(lib.task_test_result_name, {"result": "ERROR"}, "errored_1", _bundle)
 	tr := object.union(pr, {"statement": {"predicate": {"buildType": lib.tekton_task_run}}})
-	lib.assert_empty(test.deny) with input.attestations as [tr]
+	pr_slsav1 := lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_result_ref("skipped_20", [{"name": lib.task_test_result_name, "type": "string", "value": {"result": "ERROR"}}])])
+	tr_slsav1 := object.union(pr_slsav1, {"statement": {"predicate": {"buildDefinition": {"buildType": lib.tekton_task_run}}}})
+	lib.assert_empty(test.deny) with input.attestations as [tr, tr_slsav1]
 }
 
 _bundle := "registry.img/spam@sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb"


### PR DESCRIPTION
Refactor all policies that verify an attestation to work with slsav1.0.

- **IMPORTANT**: The task information here is pulled from the `content` field in `resolvedDependencies`. It is the `taskRun` that is stored there.
- This mostly changes libraries to support accessing v0.2 and v1.0 attestations and updating the policy tests to support v1.0.
- Update regal lint to warn on line-length too long. `opa fmt` in many cases is ok with a line-length that `regal lint` is not. So there is a conflict between the two.

https://issues.redhat.com/browse/HACBS-2303