### PR TITLE
Fix and disable step_image_registires

### DIFF
--- a/policy/release/step_image_registries.rego
+++ b/policy/release/step_image_registries.rego
@@ -26,9 +26,6 @@ import data.lib
 #     Make sure the container image used in each step of the build pipeline comes from
 #     an approved registry. The approved list is under 'allowed_step_image_registry_prefixes'
 #     in the xref:ec-cli:ROOT:configuration.adoc#_data_sources[data sources].
-#   collections:
-#   - minimal
-#   - redhat
 #   depends_on:
 #   - attestation_type.known_attestation_type
 #
@@ -54,9 +51,6 @@ deny contains result if {
 #     Make sure the xref:ec-cli:ROOT:configuration.adoc#_data_sources[data sources] contains a key
 #     'allowed_step_image_registry_prefixes' that contains a list of approved registries
 #     that can be used to run tasks in the build pipeline.
-#   collections:
-#   - minimal
-#   - redhat
 #
 deny contains result if {
 	count(lib.rule_data("allowed_step_image_registry_prefixes")) == 0

--- a/policy/release/step_image_registries.rego
+++ b/policy/release/step_image_registries.rego
@@ -65,5 +65,15 @@ deny contains result if {
 
 image_ref_permitted(image_ref, allowed_prefixes) if {
 	some allowed_prefix in allowed_prefixes
-	startswith(image_ref, allowed_prefix)
+	startswith(_normalize_image_ref(image_ref), allowed_prefix)
+}
+
+_normalize_image_ref(image_ref) := normalized if {
+	parts := split(image_ref, "://")
+	parts[0] == "oci"
+	normalized := parts[1]
+} else := normalized if {
+	parts := split(image_ref, "://")
+	count(parts) == 1
+	normalized := image_ref
 }

--- a/policy/release/step_image_registries_test.rego
+++ b/policy/release/step_image_registries_test.rego
@@ -1,30 +1,50 @@
 package policy.release.step_image_registries_test
 
+import future.keywords.if
+
 import data.lib
 import data.policy.release.step_image_registries
 
 good_image := "registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:af7dd5b3b"
 
+good_oci_image := sprintf("oci://%s", [good_image])
+
 bad_image := "hackz.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:af7dd5b3b"
+
+bad_oci_image := sprintf("oci://%s", [bad_image])
+
+unexpected_image := sprintf("spam://%s", [good_image])
 
 mock_data(image_ref) := [{"statement": {"predicate": {
 	"buildType": lib.tekton_pipeline_run,
 	"buildConfig": {"tasks": [{"name": "mytask", "steps": [{"environment": {"image": image_ref}}]}]},
 }}}]
 
-test_image_registry_valid {
+test_image_registry_valid if {
 	lib.assert_empty(step_image_registries.deny) with input.attestations as mock_data(good_image)
+	lib.assert_empty(step_image_registries.deny) with input.attestations as mock_data(good_oci_image)
 }
 
-test_attestation_type_invalid {
-	expected_msg := sprintf("Step 0 in task 'mytask' has disallowed image ref '%s'", [bad_image])
+test_attestation_type_invalid if {
 	lib.assert_equal_results(step_image_registries.deny, {{
 		"code": "step_image_registries.task_step_images_permitted",
-		"msg": expected_msg,
+		"msg": sprintf("Step 0 in task 'mytask' has disallowed image ref '%s'", [bad_image]),
 	}}) with input.attestations as mock_data(bad_image)
+
+	lib.assert_equal_results(step_image_registries.deny, {{
+		"code": "step_image_registries.task_step_images_permitted",
+		"msg": sprintf("Step 0 in task 'mytask' has disallowed image ref '%s'", [bad_oci_image]),
+	}}) with input.attestations as mock_data(bad_oci_image)
 }
 
-test_step_image_registry_prefix_list_found {
+test_unexpected_image_ref if {
+	lib.assert_equal_results(step_image_registries.deny, {{
+		"code": "step_image_registries.task_step_images_permitted",
+		"msg": sprintf("Step 0 in task 'mytask' has disallowed image ref '%s'", [unexpected_image]),
+	}}) with input.attestations as mock_data(unexpected_image)
+}
+
+test_step_image_registry_prefix_list_found if {
 	expected := {{
 		"code": "step_image_registries.step_image_registry_prefix_list_provided",
 		"msg": "Missing required allowed_step_image_registry_prefixes rule data",


### PR DESCRIPTION
Starting with version 0.17, Tekton Chains adds the `oci://` prefix to the image references for each task step in the SLSA Provenance.

This change modifies the step_image_registries policies to take this into account.

Ref: RHTAPBUGS-857

This also removes step_image_registries from every collection as we know it is currently broken.

Ref: HACBS-1972