### PR TITLE
Handle partial input.image.source data

### DIFF
--- a/policy/release/slsa_source_correlated.rego
+++ b/policy/release/slsa_source_correlated.rego
@@ -138,8 +138,8 @@ _expected_sources contains expected_source if {
 	some vcs_type, vcs_info in input.image.source
 
 	# e.g. git+https://github.com/...
-	expected_vcs_uri := sprintf("%s+%s", [vcs_type, vcs_info.url])
-	expected_revision := vcs_info.revision
+	expected_vcs_uri := sprintf("%s+%s", [vcs_type, object.get(vcs_info, ["url"], "")])
+	expected_revision := object.get(vcs_info, ["revision"], "")
 	expected_source := {
 		"expected_vcs_uri": expected_vcs_uri,
 		"expected_revision": expected_revision,

--- a/policy/release/slsa_source_correlated_test.rego
+++ b/policy/release/slsa_source_correlated_test.rego
@@ -232,6 +232,22 @@ test_deny_expected_source_code_reference_v02 {
 			_source_material_attestation("git+https://unexpected.repository", "ref"),
 			_source_material_attestation("git+https://git.repository", "unexpected"),
 		]
+
+	# missing source revision in input.image SLSA Provenance v0.2
+	lib.assert_equal_results(slsa_source_correlated.deny, {{
+		"code": "slsa_source_correlated.expected_source_code_reference",
+		"msg": `The expected source code reference "git+https://git.repository@" is not attested`,
+		"term": "git+https://git.repository@sha1:ref",
+	}}) with input.image as {"source": {"git": {"url": "https://git.repository"}}}
+		with input.attestations as [_source_material_attestation("git+https://git.repository", "ref")]
+
+	# missing source url in input.image SLSA Provenance v0.2
+	lib.assert_equal_results(slsa_source_correlated.deny, {{
+		"code": "slsa_source_correlated.expected_source_code_reference",
+		"msg": `The expected source code reference "git+@ref" is not attested`,
+		"term": "git+https://git.repository@sha1:ref",
+	}}) with input.image as {"source": {"git": {"revision": "ref"}}}
+		with input.attestations as [_source_material_attestation("git+https://git.repository", "ref")]
 }
 
 # regal ignore:rule-length
@@ -285,6 +301,22 @@ test_deny_expected_source_code_reference_v10 {
 			_source_resolved_dependencies_attestation("git+https://unexpected.repository", "ref"),
 			_source_resolved_dependencies_attestation("git+https://git.repository", "unexpected"),
 		]
+
+	# missing source revision in input.image SLSA Provenance v1.0
+	lib.assert_equal_results(slsa_source_correlated.deny, {{
+		"code": "slsa_source_correlated.expected_source_code_reference",
+		"msg": `The expected source code reference "git+https://git.repository@" is not attested`,
+		"term": "git+https://git.repository@sha1:ref",
+	}}) with input.image as {"source": {"git": {"url": "https://git.repository"}}}
+		with input.attestations as [_source_resolved_dependencies_attestation("git+https://git.repository", "ref")]
+
+	# missing source url in input.image SLSA Provenance v1.0
+	lib.assert_equal_results(slsa_source_correlated.deny, {{
+		"code": "slsa_source_correlated.expected_source_code_reference",
+		"msg": `The expected source code reference "git+@ref" is not attested`,
+		"term": "git+https://git.repository@sha1:ref",
+	}}) with input.image as {"source": {"git": {"revision": "ref"}}}
+		with input.attestations as [_source_resolved_dependencies_attestation("git+https://git.repository", "ref")]
 }
 
 test_slsa_v02_source_references {


### PR DESCRIPTION
The code assumed if `input.image.source` was present that the data structure would always contain `url` and `revision` properties. Those might be omitted as they're user-controlled inputs, e.g. from the ApplicationSnapshot.
If those properties were omitted then the helper function `_expected_sources` would return empty set as it would try to operate on undefined data, and iterating over an empty set would lead to no checks being performed.
This uses `object.get` instead of direct access to return a default value if the properties are missing, so that the set should be populated and the checks should fail to match.

ref: https://issues.redhat.com/browse/RHTAPBUGS-883