### PR TITLE
Ensure unknown tasks fail acceptable bundle checks

### DIFF
--- a/policy/lib/bundles.rego
+++ b/policy/lib/bundles.rego
@@ -90,7 +90,8 @@ bundle(task) := refs.task_ref(task).bundle
 # _collection returns an array representing the full list of records to
 # be taken into consideration when evaluating policy rules for bundle
 # references. Any irrelevant records are filtered out from the array.
+# (The else condition is for when data["task-bundles"][ref.repo] doesn't exist.)
 _collection(ref) := items {
 	full_collection := data["task-bundles"][ref.repo]
 	items := time_lib.acceptable_items(full_collection)
-}
+} else := []

--- a/policy/pipeline/task_bundle_test.rego
+++ b/policy/pipeline/task_bundle_test.rego
@@ -42,7 +42,7 @@ test_bundle_unpinned {
 test_bundle_reference_valid {
 	tasks := [{
 		"name": "my-task",
-		"taskRef": {"bundle": "quay.io/redhat-appstudio/hacbs-templates-bundle:latest@sha256:abc"},
+		"taskRef": {"bundle": "reg.com/repo:latest@sha256:abc"},
 	}]
 
 	lib.assert_empty(task_bundle.deny) with input.spec.tasks as tasks with data["task-bundles"] as task_bundles


### PR DESCRIPTION
The attestation_task_bundle.task_ref_bundles_acceptable check should produce a failure if the task bundle reference is not found at all in the available `data.task-bundles` data. Previously it was only failing if the repo was present in data.task-bundles and the task's digest wasn't in the list.

Also some extra test coverage is added to exercise the different failure conditions.

Resolves: https://issues.redhat.com/browse/EC-206