### PR TITLE
Support local registries in update-bundles.sh

### DIFF
--- a/.github/workflows/push-bundles.yaml
+++ b/.github/workflows/push-bundles.yaml
@@ -52,7 +52,7 @@ jobs:
       env:
         EC_AUTOMATION_KEY: ${{ secrets.EC_AUTOMATION_KEY }}
         APP_INSTALL_ID: 32872589
-        REPO_ORG: hacbs-contract
+        REPO_PREFIX: quay.io/hacbs-contract/
       run: hack/update-bundles.sh
 
     - name: Docker login (quay.io/enterprise-contract)


### PR DESCRIPTION
This makes it possible to run the script against a local registry, or any registry really, which is really useful for development. For example:

```
$ docker run -it -d -p 5000:5000 --restart=always --name registry registry:2
$ REPO_PREFIX=localhost:5000/blah/ ./hack/update-bundles.sh
```