### PR TITLE
Do not rely on build task label for FBC images

### DIFF
--- a/policy/lib/tekton/pipeline_test.rego
+++ b/policy/lib/tekton/pipeline_test.rego
@@ -93,3 +93,8 @@ test_pipeline_label_selector_pipeline_definition if {
 	pipeline := {"metadata": {"labels": {tkn.pipeline_label: "generic"}}}
 	lib.assert_equal(tkn.pipeline_label_selector(pipeline), "generic")
 }
+
+test_fbc_pipeline_label_selector if {
+	image := {"config": {"Labels": {"operators.operatorframework.io.index.configs.v1": "/configs"}}}
+	lib.assert_equal(tkn.pipeline_label_selector({}), "fbc") with input.image as image
+}


### PR DESCRIPTION
When computing the key to select the set of required tasks we look at the built task's or the pipeline label. Given that the build task for the FBC and the Docker builds are the same, i.e. have the same label. We cannot rely on the task's label, instead we this uses the image label `operators.operatorframework.io.index.configs.v1` to classify a attestation as being an attestation of a FBC image, and subsequently select the set of required tasks for the `fbc` pipeline.

reference: EC-85