### PR TITLE
Use oras to build OPA bundles

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/open-policy-agent/conftest v0.47.0
 	github.com/styrainc/regal v0.13.0
 	github.com/tektoncd/cli v0.33.0
+	oras.land/oras v1.1.0
 )
 
 // address CVE-2023-2253 https://github.com/advisories/GHSA-hqxw-f8mx-cpmw
@@ -276,6 +277,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0-rc5 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/oras-project/oras-credentials-go v0.2.0 // indirect
 	github.com/package-url/packageurl-go v0.1.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -1151,6 +1151,8 @@ github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/openzipkin/zipkin-go v0.3.0 h1:XtuXmOLIXLjiU2XduuWREDT0LOKtSgos/g7i7RYyoZQ=
 github.com/openzipkin/zipkin-go v0.3.0/go.mod h1:4c3sLeE8xjNqehmF5RpAFLPLJxXscc0R4l6Zg0P1tTQ=
+github.com/oras-project/oras-credentials-go v0.2.0 h1:BvWAXo0e5unWR6Hfxyb0K04mHNHreQz/Zclw6IzCYJo=
+github.com/oras-project/oras-credentials-go v0.2.0/go.mod h1:JVdg7a5k7hzTrEeeouwag0aCv7OLrS77r7/6w3gVirU=
 github.com/package-url/packageurl-go v0.1.2 h1:0H2DQt6DHd/NeRlVwW4EZ4oEI6Bn40XlNPRqegcxuo4=
 github.com/package-url/packageurl-go v0.1.2/go.mod h1:uQd4a7Rh3ZsVg5j0lNyAfyxIeGde9yrlhjF78GzeW0c=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -2189,6 +2191,8 @@ muzzammil.xyz/jsonc v1.0.0 h1:B6kaT3wHueZ87mPz3q1nFuM1BlL32IG0wcq0/uOsQ18=
 muzzammil.xyz/jsonc v1.0.0/go.mod h1:rFv8tUUKe+QLh7v02BhfxXEf4ZHhYD7unR93HL/1Uvo=
 olympos.io/encoding/edn v0.0.0-20201019073823-d3554ca0b0a3 h1:slmdOY3vp8a7KQbHkL+FLbvbkgMqmXojpFUO/jENuqQ=
 olympos.io/encoding/edn v0.0.0-20201019073823-d3554ca0b0a3/go.mod h1:oVgVk4OWVDi43qWBEyGhXgYxt7+ED4iYNpTngSLX2Iw=
+oras.land/oras v1.1.0 h1:Ryo1914rRrbU4gYeWP8mAwdwQkwoyOHReq3NYKbd/ds=
+oras.land/oras v1.1.0/go.mod h1:81i++3cUaeZS4lnTkA//VBo7FZPSXTp1xcxjFaZ9v50=
 oras.land/oras-go/v2 v2.3.1 h1:lUC6q8RkeRReANEERLfH86iwGn55lbSWP20egdFHVec=
 oras.land/oras-go/v2 v2.3.1/go.mod h1:5AQXVEu1X/FKp1F9DMOb5ZItZBOa0y5dha0yCm4NR9c=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/tools.go
+++ b/tools.go
@@ -5,4 +5,5 @@ import (
 	_ "github.com/open-policy-agent/conftest"
 	_ "github.com/styrainc/regal"
 	_ "github.com/tektoncd/cli/cmd/tkn"
+	_ "oras.land/oras/cmd/oras"
 )


### PR DESCRIPTION
The previous approach of using `conftest push` does not work now that EC provides custom rego functions. We could wrap the `conftest` command in EC CLI, like we did for OPA via `ec opa`. However, that is a bit heavy handed.

The OPA docs[1] suggest using `opa bundle` to generate a tarball with the compiled policy rules. Then, use `oras push` to upload the tarball to an OCI registry.

The problem with the approach above is that when the OCI image containing the policy rules is fetched, the output is a tarball instead of the expected rego files. This causes conftest to not see the policy rules. I considered adding support in the EC CLI to handle this use case by simply expanding any tarballs that may have been fetched. But... this means older version of the EC CLI won't be able to consume the newer policy bundles.

Instead, this commit opts to use `oras push` directly on the rego files. This creates a policy bundle that works as expected by the EC CLI.

There is benefit in running the `opa build` command since it compiles the policy rules and verifies their integrity. For example, it checks if the policy rules use an unknown function. This is useful. So, as a sanity check, we now run `ec opa bundle` to ensure integrity, but the output is discarded.

[1] https://www.openpolicyagent.org/docs/latest/management-bundles/#building-and-publishing-policy-containers

Fixes #817