### PR TITLE
Give everyone a few more weeks to get a synk token

### DIFF
--- a/policy/release/test.rego
+++ b/policy/release/test.rego
@@ -175,7 +175,7 @@ deny contains result if {
 #   - redhat
 #   depends_on:
 #   - test.test_data_found
-#   effective_on: 2023-12-08T00:00:00Z
+#   effective_on: 2024-01-14T00:00:00Z
 #
 deny contains result if {
 	some test in resulted_in(lib.rule_data("skipped_tests_results"))


### PR DESCRIPTION
The snyk requirement graduated from a warning to a violation a few days ago and a some teams are struggling to get their snyk tokens working enabled and working.

Not sure if we want to merge this, but I'll create a PR in case we decide to do it.