### PR TITLE
Add validation to rule data

### DIFF
--- a/policy/beta/packages.rego
+++ b/policy/beta/packages.rego
@@ -31,8 +31,26 @@ import data.lib.sbom
 deny contains result if {
 	some s in sbom.cyclonedx_sboms
 	some component in s.components
-	_contains(component.purl, lib.rule_data("disallowed_packages"))
+	_contains(component.purl, lib.rule_data(_rule_data_key))
 	result := lib.result_helper(rego.metadata.chain(), [component.purl])
+}
+
+# METADATA
+# title: Disallowed packages list is provided
+# description: >-
+#   Confirm the `disallowed_packages` rule data was provided, since it is required by the policy
+#   rules in this package.
+# custom:
+#   short_name: disallowed_packages_provided
+#   failure_msg: "%s"
+#   solution: Provide a list of disallowed packages in the expected format.
+#   collections:
+#   - redhat
+#   - policy_data
+#
+deny contains result if {
+	some error in _rule_data_errors
+	result := lib.result_helper(rego.metadata.chain(), [error])
 }
 
 _contains(needle, haystack) if {
@@ -66,3 +84,60 @@ _matches_version(version, matcher) if {
 } else := false
 
 _to_semver(v) := trim_prefix(v, "v")
+
+# Verify disallowed_packages is an array of objects
+_rule_data_errors contains msg if {
+	# match_schema expects either a marshaled JSON resource (String) or an Object. It doesn't
+	# handle an Array directly.
+	value := json.marshal(lib.rule_data(_rule_data_key))
+	some violation in json.match_schema(
+		value,
+		{
+			"$schema": "http://json-schema.org/draft-07/schema#",
+			"type": "array",
+			"uniqueItems": true,
+			"items": {
+				"type": "object",
+				"properties": {
+					"purl": {"type": "string"},
+					"format": {"enum": ["semver", "semverv"]},
+					"min": {"type": "string"},
+					"max": {"type": "string"},
+				},
+				"additionalProperties": false,
+				"anyOf": [
+					{"required": ["purl", "format", "min"]},
+					{"required": ["purl", "format", "max"]},
+				],
+			},
+		},
+	)[1]
+	msg := sprintf("Rule data %s has unexpected format: %s", [_rule_data_key, violation.error])
+}
+
+# Verify each item in disallowed_packages has a parseable PURL
+_rule_data_errors contains msg if {
+	some index, pkg in lib.rule_data(_rule_data_key)
+	purl := pkg.purl
+	not ec.purl.is_valid(purl)
+	msg := sprintf("Item at index %d in %s does not have a valid PURL: %q", [index, _rule_data_key, purl])
+}
+
+# Verify each item in disallowed_packages has a parseable min/max semver
+_rule_data_errors contains msg if {
+	some index, pkg in lib.rule_data(_rule_data_key)
+	pkg.format in {"semver", "semverv"}
+	some attr in ["min", "max"]
+
+	version := _to_semver(object.get(pkg, attr, ""))
+	version != ""
+
+	not semver.is_valid(version)
+
+	msg := sprintf(
+		"Item at index %d in %s does not have a valid %s semver value: %q",
+		[index, _rule_data_key, attr, version],
+	)
+}
+
+_rule_data_key := "disallowed_packages"

--- a/policy/release/attestation_type_test.rego
+++ b/policy/release/attestation_type_test.rego
@@ -60,3 +60,27 @@ test_deny_deprecated_policy_attestation_format if {
 	}]
 	lib.assert_equal_results(attestation_type.deny, expected) with input.attestations as attestations
 }
+
+test_rule_data_validation if {
+	d := {"known_attestation_types": [
+		# Wrong type
+		1,
+		# Duplicated items
+		"foo",
+		"foo",
+	]}
+
+	expected := {
+		{
+			"code": "attestation_type.known_attestation_types_provided",
+			"msg": "Rule data known_attestation_types has unexpected format: (Root): array items[1,2] must be unique",
+		},
+		{
+			"code": "attestation_type.known_attestation_types_provided",
+			"msg": "Rule data known_attestation_types has unexpected format: 0: Invalid type. Expected: string, given: integer",
+		},
+	}
+
+	lib.assert_equal_results(attestation_type.deny, expected) with data.rule_data as d
+		with input.attestations as mock_data("foo")
+}

--- a/policy/release/base_image_registries_test.rego
+++ b/policy/release/base_image_registries_test.rego
@@ -130,7 +130,31 @@ test_missing_result if {
 test_allowed_registries_provided if {
 	expected := {{
 		"code": "base_image_registries.allowed_registries_provided",
-		"msg": "Missing required allowed_registry_prefixes rule data",
+		"msg": "Rule data allowed_registry_prefixes has unexpected format: (Root): Array must have at least 1 items",
 	}}
 	lib.assert_equal_results(expected, base_image_registries.deny) with data.rule_data as {}
+}
+
+test_rule_data_validation if {
+	d := {"allowed_registry_prefixes": [
+		# Wrong type
+		1,
+		# Duplicated items
+		"foo",
+		"foo",
+	]}
+
+	expected := {
+		{
+			"code": "base_image_registries.allowed_registries_provided",
+			"msg": "Rule data allowed_registry_prefixes has unexpected format: (Root): array items[1,2] must be unique",
+		},
+		{
+			"code": "base_image_registries.allowed_registries_provided",
+			# regal ignore:line-length
+			"msg": "Rule data allowed_registry_prefixes has unexpected format: 0: Invalid type. Expected: string, given: integer",
+		},
+	}
+
+	lib.assert_equal_results(base_image_registries.deny, expected) with data.rule_data as d
 }

--- a/policy/release/collection/policy_data.rego
+++ b/policy/release/collection/policy_data.rego
@@ -1,0 +1,6 @@
+#
+# METADATA
+# title: policy_data
+# description: >-
+#   Include policy rules responsible for validating rule data.
+package policy.release.collection.policy_data

--- a/policy/release/cve_test.rego
+++ b/policy/release/cve_test.rego
@@ -58,14 +58,15 @@ test_success_deprecated_name if {
 }
 
 test_success_with_rule_data if {
+	counts := json.remove(_dummy_counts, ["/unknown"])
 	slsav1_task_with_result := tkn_test.slsav1_task_result_ref(
 		"clair-scan",
 		[{
 			"name": cve._result_name,
 			"type": "string",
 			"value": {
-				"vulnerabilities": _dummy_counts,
-				"unpatched_vulnerabilities": _dummy_counts,
+				"vulnerabilities": counts,
+				"unpatched_vulnerabilities": counts,
 			},
 		}],
 	)
@@ -73,8 +74,8 @@ test_success_with_rule_data if {
 		lib_test.att_mock_helper_ref(
 			cve._result_name,
 			{
-				"vulnerabilities": _dummy_counts,
-				"unpatched_vulnerabilities": _dummy_counts,
+				"vulnerabilities": counts,
+				"unpatched_vulnerabilities": counts,
 			},
 			"clair-scan",
 			_bundle,
@@ -82,30 +83,31 @@ test_success_with_rule_data if {
 		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle(slsav1_task_with_result, _bundle)]),
 	]
 	lib.assert_empty(cve.deny | cve.warn) with input.attestations as attestations
-		with data.rule_data.restrict_cve_security_levels as ["spam"]
-		with data.rule_data.warn_unpatched_cve_security_levels as ["spam"]
+		with data.rule_data.restrict_cve_security_levels as ["unknown"]
+		with data.rule_data.warn_unpatched_cve_security_levels as ["unknown"]
 }
 
 test_success_with_rule_data_deprecated_name if {
+	counts := json.remove(_dummy_counts, ["/unknown"])
 	slsav1_task_with_result := tkn_test.slsav1_task_result_ref(
 		"clair-scan",
 		[{
 			"name": cve._deprecated_result_name,
 			"type": "string",
-			"value": {"vulnerabilities": _dummy_counts},
+			"value": {"vulnerabilities": counts},
 		}],
 	)
 	attestations := [
 		lib_test.att_mock_helper_ref(
 			cve._result_name,
-			{"vulnerabilities": _dummy_counts},
+			{"vulnerabilities": counts},
 			"clair-scan",
 			_bundle,
 		),
 		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle(slsav1_task_with_result, _bundle)]),
 	]
 	lib.assert_empty(cve.deny) with input.attestations as attestations
-		with data.rule_data.restrict_cve_security_levels as ["spam"]
+		with data.rule_data.restrict_cve_security_levels as ["unknown"]
 }
 
 test_failure if {
@@ -187,7 +189,7 @@ test_failure_deprecated_name if {
 }
 
 test_failure_with_rule_data if {
-	_custom_counts := {"spam": 1, "bacon": 2, "eggs": 3}
+	_custom_counts := {"unknown": 1, "low": 2, "medium": 3}
 	slsav1_task_with_result := tkn_test.slsav1_task_result_ref(
 		"clair-scan",
 		[{
@@ -214,28 +216,28 @@ test_failure_with_rule_data if {
 	expected := {
 		{
 			"code": "cve.cve_blockers",
-			"term": "spam",
-			"msg": "Found 1 CVE vulnerabilities of spam security level",
+			"term": "unknown",
+			"msg": "Found 1 CVE vulnerabilities of unknown security level",
 		},
 		{
 			"code": "cve.cve_blockers",
-			"term": "bacon",
-			"msg": "Found 2 CVE vulnerabilities of bacon security level",
+			"term": "low",
+			"msg": "Found 2 CVE vulnerabilities of low security level",
 		},
 		{
 			"code": "cve.unpatched_cve_blockers",
-			"term": "spam",
-			"msg": "Found 1 unpatched CVE vulnerabilities of spam security level",
+			"term": "unknown",
+			"msg": "Found 1 unpatched CVE vulnerabilities of unknown security level",
 		},
 		{
 			"code": "cve.unpatched_cve_blockers",
-			"term": "bacon",
-			"msg": "Found 2 unpatched CVE vulnerabilities of bacon security level",
+			"term": "low",
+			"msg": "Found 2 unpatched CVE vulnerabilities of low security level",
 		},
 	}
 	lib.assert_equal_results(cve.deny, expected) with input.attestations as attestations
-		with data.rule_data.restrict_cve_security_levels as ["spam", "bacon"]
-		with data.rule_data.restrict_unpatched_cve_security_levels as ["spam", "bacon"]
+		with data.rule_data.restrict_cve_security_levels as ["unknown", "low"]
+		with data.rule_data.restrict_unpatched_cve_security_levels as ["unknown", "low"]
 }
 
 test_warn if {
@@ -435,6 +437,62 @@ test_missing_cve_scan_vulnerabilities if {
 		"msg": "Clair CVE scan results were not found",
 	}}
 	lib.assert_equal_results(cve.deny, expected) with input.attestations as attestations
+}
+
+test_rule_data_provided if {
+	d := {
+		"restrict_cve_security_levels": [
+			# Wrong type
+			1,
+			# Duplicated items
+			"high",
+			"high",
+		],
+		# We don't need to check the different errors for each key as they are processed the same
+		# way. But we do want to, at least, verify a single error.
+		"warn_cve_security_levels": [1],
+		"restrict_unpatched_cve_security_levels": [1],
+		"warn_unpatched_cve_security_levels": [1],
+	}
+
+	expected := {
+		{
+			"code": "cve.rule_data_provided",
+			"msg": "Rule data restrict_cve_security_levels has unexpected format: (Root): array items[1,2] must be unique",
+		},
+		{
+			"code": "cve.rule_data_provided",
+			# regal ignore:line-length
+			"msg": "Rule data restrict_cve_security_levels has unexpected format: 0: 0 must be one of the following: \"critical\", \"high\", \"medium\", \"low\", \"unknown\"",
+		},
+		{
+			"code": "cve.rule_data_provided",
+			# regal ignore:line-length
+			"msg": "Rule data restrict_unpatched_cve_security_levels has unexpected format: 0: 0 must be one of the following: \"critical\", \"high\", \"medium\", \"low\", \"unknown\"",
+		},
+		{
+			"code": "cve.rule_data_provided",
+			# regal ignore:line-length
+			"msg": "Rule data warn_cve_security_levels has unexpected format: 0: 0 must be one of the following: \"critical\", \"high\", \"medium\", \"low\", \"unknown\"",
+		},
+		{
+			"code": "cve.rule_data_provided",
+			# regal ignore:line-length
+			"msg": "Rule data warn_unpatched_cve_security_levels has unexpected format: 0: 0 must be one of the following: \"critical\", \"high\", \"medium\", \"low\", \"unknown\"",
+		},
+	}
+
+	attestations := [lib_test.att_mock_helper_ref(
+		cve._result_name,
+		{
+			"vulnerabilities": _dummy_counts_zero_high,
+			"unpatched_vulnerabilities": _dummy_counts_zero_high,
+		},
+		"clair-scan",
+		_bundle,
+	)]
+	lib.assert_equal_results(cve.deny, expected) with input.attestations as attestations
+		with data.rule_data as d
 }
 
 _bundle := "registry.img/spam@sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb"

--- a/policy/release/github_certificate_test.rego
+++ b/policy/release/github_certificate_test.rego
@@ -116,6 +116,54 @@ test_missing_extensions if {
 	lib.assert_equal_results(github_certificate.warn, expected) with input.image.signatures as [{"certificate": bad_cert}]
 }
 
+test_rule_data_provided if {
+	d := {
+		"allowed_gh_workflow_repos": [
+			# Wrong type
+			1,
+			# Duplicated items
+			"lcarva/festoji",
+			"lcarva/festoji",
+		],
+		# We don't need to check the different errors for each key as they are processed the same
+		# way. But we do want to, at least, verify a single error.
+		"allowed_gh_workflow_refs": [1, "refs/heads/master"],
+		"allowed_gh_workflow_names": [1, "Package"],
+		"allowed_gh_workflow_triggers": [1, "push"],
+	}
+
+	expected := {
+		{
+			"code": "github_certificate.rule_data_provided",
+			"msg": "Rule data allowed_gh_workflow_repos has unexpected format: (Root): array items[1,2] must be unique",
+		},
+		{
+			"code": "github_certificate.rule_data_provided",
+			# regal ignore:line-length
+			"msg": "Rule data allowed_gh_workflow_repos has unexpected format: 0: Invalid type. Expected: string, given: integer",
+		},
+		{
+			"code": "github_certificate.rule_data_provided",
+			# regal ignore:line-length
+			"msg": "Rule data allowed_gh_workflow_refs has unexpected format: 0: Invalid type. Expected: string, given: integer",
+		},
+		{
+			"code": "github_certificate.rule_data_provided",
+			# regal ignore:line-length
+			"msg": "Rule data allowed_gh_workflow_names has unexpected format: 0: Invalid type. Expected: string, given: integer",
+		},
+		{
+			"code": "github_certificate.rule_data_provided",
+			# regal ignore:line-length
+			"msg": "Rule data allowed_gh_workflow_triggers has unexpected format: 0: Invalid type. Expected: string, given: integer",
+		},
+	}
+
+	signatures := [{"certificate": good_cert}]
+	lib.assert_equal_results(github_certificate.deny, expected) with data.rule_data as d
+		with input.image.signatures as signatures
+}
+
 # This is a certificate used when signing an image on GitHub. It
 # contains all the expected Fulcio GitHub extensions.
 good_cert := `-----BEGIN CERTIFICATE-----

--- a/policy/release/java.rego
+++ b/policy/release/java.rego
@@ -42,7 +42,7 @@ import data.lib
 #   - java.trusted_dependencies_source_list_provided
 #
 deny contains result if {
-	allowed := {a | some a in lib.rule_data("allowed_java_component_sources")}
+	allowed := {a | some a in lib.rule_data(_rule_data_key)}
 	foreign := _java_component_sources - allowed
 	count(foreign) > 0
 	result := lib.result_helper(rego.metadata.chain(), [concat(",", foreign), concat(",", allowed)])
@@ -55,22 +55,43 @@ deny contains result if {
 #   required by the policy rules in this package.
 # custom:
 #   short_name: trusted_dependencies_source_list_provided
-#   failure_msg: Missing required allowed_java_component_sources rule data
+#   failure_msg: "%s"
 #   solution: >-
 #     Add a data source that contains allowable source repositories for build dependencies.
 #     The source must be located under a key named 'allowed_java_component_sources'. More
 #     information on adding xref:ec-cli:ROOT:configuration.adoc#_data_sources[data sources].
 #   collections:
 #   - redhat
+#   - policy_data
 #   depends_on:
 #   - attestation_type.known_attestation_type
 #
 deny contains result if {
-	count(lib.rule_data("allowed_java_component_sources")) == 0
-	result := lib.result_helper(rego.metadata.chain(), [])
+	some error in _rule_data_errors
+	result := lib.result_helper(rego.metadata.chain(), [error])
 }
 
 _java_component_sources contains name if {
 	some result in lib.results_named(lib.java_sbom_component_count_result_name)
 	some name, _ in result.value
 }
+
+# Verify allowed_java_component_sources is a non-empty list of strings
+_rule_data_errors contains msg if {
+	# match_schema expects either a marshaled JSON resource (String) or an Object. It doesn't
+	# handle an Array directly.
+	value := json.marshal(lib.rule_data(_rule_data_key))
+	some violation in json.match_schema(
+		value,
+		{
+			"$schema": "http://json-schema.org/draft-07/schema#",
+			"type": "array",
+			"items": {"type": "string"},
+			"uniqueItems": true,
+			"minItems": 1,
+		},
+	)[1]
+	msg := sprintf("Rule data %s has unexpected format: %s", [_rule_data_key, violation.error])
+}
+
+_rule_data_key := "allowed_java_component_sources"

--- a/policy/release/java_test.rego
+++ b/policy/release/java_test.rego
@@ -44,12 +44,36 @@ test_has_foreign if {
 	lib.assert_equal_results(java.deny, expected) with input.attestations as attestations
 }
 
-test_trusted_dependency_source_list_provided if {
+test_trusted_dependency_source_list_provided_not_empty if {
 	expected := {{
 		"code": "java.trusted_dependencies_source_list_provided",
-		"msg": "Missing required allowed_java_component_sources rule data",
+		"msg": "Rule data allowed_java_component_sources has unexpected format: (Root): Array must have at least 1 items",
 	}}
 	lib.assert_equal_results(expected, java.deny) with data.rule_data as {}
+}
+
+test_trusted_dependency_source_list_provided_format if {
+	d := {"allowed_java_component_sources": [
+		# Wrong type
+		1,
+		# Duplicated items
+		"foo",
+		"foo",
+	]}
+
+	expected := {
+		{
+			"code": "java.trusted_dependencies_source_list_provided",
+			"msg": "Rule data allowed_java_component_sources has unexpected format: (Root): array items[1,2] must be unique",
+		},
+		{
+			"code": "java.trusted_dependencies_source_list_provided",
+			# regal ignore:line-length
+			"msg": "Rule data allowed_java_component_sources has unexpected format: 0: Invalid type. Expected: string, given: integer",
+		},
+	}
+
+	lib.assert_equal_results(java.deny, expected) with data.rule_data as d
 }
 
 _bundle := "registry.img/spam@sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb"

--- a/policy/release/labels_test.rego
+++ b/policy/release/labels_test.rego
@@ -131,6 +131,102 @@ test_fbc_disallowed_inherited_image_labels if {
 		with data.rule_data as _rule_data
 }
 
+test_rule_data_provided if {
+	d := {
+		"required_labels": [
+			# Wrong type
+			1,
+			# Duplicated items
+			{"name": "name", "description": "label-description"},
+			{"name": "name", "description": "label-description"},
+			# Additional properties
+			{"name": "name", "description": "label-description", "foo": "bar"},
+		],
+		"fbc_required_labels": [1],
+		"optional_labels": [1],
+		"fbc_optional_labels": [1],
+		"disallowed_inherited_labels": [
+			# Wrong type
+			1,
+			# Duplicated items
+			{"name": "name"},
+			{"name": "name"},
+			# Additional properties
+			{"name": "name", "foo": "bar"},
+		],
+		"fbc_disallowed_inherited_labels": [1],
+		"deprecated_labels": [
+			# Wrong type
+			1,
+			# Duplicated items
+			{"name": "deprecated-name", "replacement": "label-replacement"},
+			{"name": "deprecated-name", "replacement": "label-replacement"},
+			# Additional properties
+			{"name": "deprecated-name", "replacement": "label-description", "foo": "bar"},
+		],
+	}
+
+	expected := {
+		{
+			"code": "labels.rule_data_provided",
+			"msg": "Rule data deprecated_labels has unexpected format: (Root): array items[1,2] must be unique",
+		},
+		{
+			"code": "labels.rule_data_provided",
+			"msg": "Rule data deprecated_labels has unexpected format: 0: Invalid type. Expected: object, given: integer",
+		},
+		{
+			"code": "labels.rule_data_provided",
+			"msg": "Rule data deprecated_labels has unexpected format: 3: Additional property foo is not allowed",
+		},
+		{
+			"code": "labels.rule_data_provided",
+			"msg": "Rule data disallowed_inherited_labels has unexpected format: (Root): array items[1,2] must be unique",
+		},
+		{
+			"code": "labels.rule_data_provided",
+			# regal ignore:line-length
+			"msg": "Rule data disallowed_inherited_labels has unexpected format: 0: Invalid type. Expected: object, given: integer",
+		},
+		{
+			"code": "labels.rule_data_provided",
+			"msg": "Rule data disallowed_inherited_labels has unexpected format: 3: Additional property foo is not allowed",
+		},
+		{
+			"code": "labels.rule_data_provided",
+			# regal ignore:line-length
+			"msg": "Rule data fbc_disallowed_inherited_labels has unexpected format: 0: Invalid type. Expected: object, given: integer",
+		},
+		{
+			"code": "labels.rule_data_provided",
+			"msg": "Rule data fbc_optional_labels has unexpected format: 0: Invalid type. Expected: object, given: integer",
+		},
+		{
+			"code": "labels.rule_data_provided",
+			"msg": "Rule data fbc_required_labels has unexpected format: 0: Invalid type. Expected: object, given: integer",
+		},
+		{
+			"code": "labels.rule_data_provided",
+			"msg": "Rule data optional_labels has unexpected format: 0: Invalid type. Expected: object, given: integer",
+		},
+		{
+			"code": "labels.rule_data_provided",
+			"msg": "Rule data required_labels has unexpected format: (Root): array items[1,2] must be unique",
+		},
+		{
+			"code": "labels.rule_data_provided",
+			"msg": "Rule data required_labels has unexpected format: 0: Invalid type. Expected: object, given: integer",
+		},
+		{
+			"code": "labels.rule_data_provided",
+			"msg": "Rule data required_labels has unexpected format: 3: Additional property foo is not allowed",
+		},
+	}
+
+	lib.assert_equal_results(labels.deny, expected) with input.image as _image
+		with data.rule_data as d
+}
+
 _image := {
 	"config": {"Labels": {
 		"name": "test-image",

--- a/policy/release/schedule.rego
+++ b/policy/release/schedule.rego
@@ -51,3 +51,78 @@ deny contains result if {
 	today in disallowed
 	result := lib.result_helper(rego.metadata.chain(), [today, concat(", ", disallowed)])
 }
+
+# METADATA
+# title: Rule data provided
+# description: >-
+#   Confirm the expected rule data keys have been provided in the expected format. The keys are
+#   `disallowed_weekdays` and `disallowed_dates`.
+# custom:
+#   short_name: rule_data_provided
+#   failure_msg: '%s'
+#   solution: If provided, ensure the rule data is in the expected format.
+#   collections:
+#   - redhat
+#   - policy_data
+#
+deny contains result if {
+	some error in _rule_data_errors
+	result := lib.result_helper(rego.metadata.chain(), [error])
+}
+
+_rule_data_errors contains msg if {
+	key := "disallowed_weekdays"
+
+	# JSON Schema doesn't allow case insensitive enum types. So here we define a list of all the
+	# weekdays as "title-case", lower case, and upper case.
+	titled_weekdays := ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+	weekdays := array.concat(
+		array.concat(
+			titled_weekdays,
+			[lower(d) | some d in titled_weekdays],
+		),
+		[upper(d) | some d in titled_weekdays],
+	)
+
+	# match_schema expects either a marshaled JSON resource (String) or an Object. It doesn't
+	# handle an Array directly.
+	value := json.marshal(lib.rule_data(key))
+	some violation in json.match_schema(
+		value,
+		{
+			"$schema": "http://json-schema.org/draft-07/schema#",
+			"type": "array",
+			"items": {"enum": weekdays},
+			"uniqueItems": true,
+		},
+	)[1]
+	msg := sprintf("Rule data %s has unexpected format: %s", [key, violation.error])
+}
+
+_rule_data_errors contains msg if {
+	# IMPORTANT: Although the JSON schema spec does allow specifying a regular expression to match
+	# values, via the "pattern" attribute, rego's JSON schema validator does not:
+	# https://github.com/open-policy-agent/opa/issues/6089
+	key := "disallowed_dates"
+
+	# match_schema expects either a marshaled JSON resource (String) or an Object. It doesn't
+	# handle an Array directly.
+	value := json.marshal(lib.rule_data(key))
+	some violation in json.match_schema(
+		value,
+		{
+			"$schema": "http://json-schema.org/draft-07/schema#",
+			"type": "array",
+			"items": {"type": "string"},
+			"uniqueItems": true,
+		},
+	)[1]
+	msg := sprintf("Rule data %s has unexpected format: %s", [key, violation.error])
+}
+
+_rule_data_errors contains msg if {
+	key := "disallowed_dates"
+	some index, date in lib.rule_data(key)
+	not time.parse_ns("2006-01-02", date)
+	msg := sprintf("Rule data %s has unexpected format: %d: Invalid date %q", [key, index, date])
+}

--- a/policy/release/schedule_test.rego
+++ b/policy/release/schedule_test.rego
@@ -81,6 +81,82 @@ test_date_restriction if {
 		with data.config.policy.when_ns as time.parse_rfc3339_ns("2024-02-03T00:00:00Z")
 }
 
+test_rule_data_format_disallowed_weekdays if {
+	d := {"disallowed_weekdays": [
+		# Wrong type
+		1,
+		# Duplicated items
+		"monday",
+		"monday",
+		# Unsupported mixed case
+		"mOnDaY",
+	]}
+
+	expected := {
+		{
+			"code": "schedule.rule_data_provided",
+			# regal ignore:line-length
+			"msg": "Rule data disallowed_weekdays has unexpected format: 0: 0 must be one of the following: \"Sunday\", \"Monday\", \"Tuesday\", \"Wednesday\", \"Thursday\", \"Friday\", \"Saturday\", \"sunday\", \"monday\", \"tuesday\", \"wednesday\", \"thursday\", \"friday\", \"saturday\", \"SUNDAY\", \"MONDAY\", \"TUESDAY\", \"WEDNESDAY\", \"THURSDAY\", \"FRIDAY\", \"SATURDAY\"",
+		},
+		{
+			"code": "schedule.rule_data_provided",
+			"msg": "Rule data disallowed_weekdays has unexpected format: (Root): array items[1,2] must be unique",
+		},
+		{
+			"code": "schedule.rule_data_provided",
+			# regal ignore:line-length
+			"msg": "Rule data disallowed_weekdays has unexpected format: 3: 3 must be one of the following: \"Sunday\", \"Monday\", \"Tuesday\", \"Wednesday\", \"Thursday\", \"Friday\", \"Saturday\", \"sunday\", \"monday\", \"tuesday\", \"wednesday\", \"thursday\", \"friday\", \"saturday\", \"SUNDAY\", \"MONDAY\", \"TUESDAY\", \"WEDNESDAY\", \"THURSDAY\", \"FRIDAY\", \"SATURDAY\"",
+		},
+	}
+
+	lib.assert_equal_results(schedule.deny, expected) with data.rule_data as d
+		with data.config.policy.when_ns as sunday
+}
+
+test_rule_data_format_disallowed_dates if {
+	d := {"disallowed_dates": [
+		# Wrong type
+		1,
+		# Duplicated items
+		"2023-01-01",
+		"2023-01-01",
+		# Not enough digits
+		"23-01-01",
+		"2023-1-01",
+		"2023-01-1",
+	]}
+
+	expected := {
+		{
+			"code": "schedule.rule_data_provided",
+			"msg": "Rule data disallowed_dates has unexpected format: 0: Invalid date '\\x01'",
+		},
+		{
+			"code": "schedule.rule_data_provided",
+			"msg": "Rule data disallowed_dates has unexpected format: 0: Invalid type. Expected: string, given: integer",
+		},
+		{
+			"code": "schedule.rule_data_provided",
+			"msg": "Rule data disallowed_dates has unexpected format: (Root): array items[1,2] must be unique",
+		},
+		{
+			"code": "schedule.rule_data_provided",
+			"msg": "Rule data disallowed_dates has unexpected format: 3: Invalid date \"23-01-01\"",
+		},
+		{
+			"code": "schedule.rule_data_provided",
+			"msg": "Rule data disallowed_dates has unexpected format: 4: Invalid date \"2023-1-01\"",
+		},
+		{
+			"code": "schedule.rule_data_provided",
+			"msg": "Rule data disallowed_dates has unexpected format: 5: Invalid date \"2023-01-1\"",
+		},
+	}
+
+	lib.assert_equal_results(schedule.deny, expected) with data.rule_data as d
+		with data.config.policy.when_ns as sunday
+}
+
 sunday := time.parse_rfc3339_ns("2023-01-01T00:00:00Z")
 
 monday := time.parse_rfc3339_ns("2023-01-02T00:00:00Z")

--- a/policy/release/slsa_build_build_service_test.rego
+++ b/policy/release/slsa_build_build_service_test.rego
@@ -41,6 +41,30 @@ test_accepted_slsa_builder_id if {
 	) with input.attestations as [_mock_attestation(builder_id)]
 }
 
+test_rule_data_format if {
+	d := {"allowed_builder_ids": [
+		# Wrong type
+		1,
+		# Duplicated items
+		"foo",
+		"foo",
+	]}
+
+	expected := {
+		{
+			"code": "slsa_build_build_service.allowed_builder_ids_provided",
+			"msg": "Rule data allowed_builder_ids has unexpected format: 0: Invalid type. Expected: string, given: integer",
+		},
+		{
+			"code": "slsa_build_build_service.allowed_builder_ids_provided",
+			"msg": "Rule data allowed_builder_ids has unexpected format: (Root): array items[1,2] must be unique",
+		},
+	}
+
+	lib.assert_equal_results(slsa_build_build_service.deny, expected) with data.rule_data as d
+		with input.attestations as [_mock_attestation("foo")]
+}
+
 _mock_attestation(builder_id) := {"statement": {"predicate": {
 	"builder": {"id": builder_id},
 	"buildType": lib.tekton_pipeline_run,

--- a/policy/release/slsa_provenance_available_test.rego
+++ b/policy/release/slsa_provenance_available_test.rego
@@ -20,6 +20,30 @@ test_att_predicate_type if {
 	lib.assert_equal_results(slsa_provenance_available.deny, expected_deny) with input.attestations as attestations
 }
 
+test_rule_data_format if {
+	d := {"allowed_predicate_types": [
+		# Wrong type
+		1,
+		# Duplicated items
+		"foo",
+		"foo",
+	]}
+
+	expected := {
+		{
+			"code": "slsa_provenance_available.allowed_predicate_types_provided",
+			"msg": "Rule data allowed_predicate_types has unexpected format: 0: Invalid type. Expected: string, given: integer",
+		},
+		{
+			"code": "slsa_provenance_available.allowed_predicate_types_provided",
+			"msg": "Rule data allowed_predicate_types has unexpected format: (Root): array items[1,2] must be unique",
+		},
+	}
+
+	lib.assert_equal_results(slsa_provenance_available.deny, expected) with data.rule_data as d
+		with input.attestations as _mock_attestations("foo")
+}
+
 _mock_attestations(types) := [attestation |
 	some type in types
 	attestation := {"statement": {

--- a/policy/release/slsa_source_correlated_test.rego
+++ b/policy/release/slsa_source_correlated_test.rego
@@ -384,6 +384,40 @@ test_slsa_v10_source_references if {
 	]
 }
 
+test_rule_data_provided if {
+	d := {
+		"supported_digests": [
+			# Wrong type
+			1,
+			# Duplicated items
+			"sha1",
+			"sha1",
+		],
+		# We don't need to check the different errors for each key as they are processed the same
+		# way. But we do want to, at least, verify a single error.
+		"supported_vcs": [1, "git"],
+	}
+
+	violations := {
+		{
+			"code": "slsa_source_correlated.rule_data_provided",
+			"msg": "Rule data supported_digests has unexpected format: 0: Invalid type. Expected: string, given: integer",
+		},
+		{
+			"code": "slsa_source_correlated.rule_data_provided",
+			"msg": "Rule data supported_digests has unexpected format: (Root): array items[1,2] must be unique",
+		},
+		{
+			"code": "slsa_source_correlated.rule_data_provided",
+			"msg": "Rule data supported_vcs has unexpected format: 0: Invalid type. Expected: string, given: integer",
+		},
+	}
+
+	lib.assert_equal_results(slsa_source_correlated.deny, violations) with data.rule_data as d
+		with input.image as expected
+		with input.attestations as [_source_material_attestation("git+https://git.repository", "ref")]
+}
+
 expected := {"source": {"git": {"url": "https://git.repository", "revision": "ref"}}}
 
 # SLSA Provenance v0.2

--- a/policy/release/step_image_registries.rego
+++ b/policy/release/step_image_registries.rego
@@ -34,7 +34,7 @@ deny contains result if {
 	some task in lib.tasks_from_pipelinerun
 	some step_index, step in tkn.task_steps(task)
 	image_ref := tkn.task_step_image_ref(step)
-	allowed_registry_prefixes := lib.rule_data("allowed_step_image_registry_prefixes")
+	allowed_registry_prefixes := lib.rule_data(_rule_data_key)
 	not image_ref_permitted(image_ref, allowed_registry_prefixes)
 	result := lib.result_helper(rego.metadata.chain(), [step_index, tkn.task_name(task), image_ref])
 }
@@ -46,15 +46,17 @@ deny contains result if {
 #   required by the policy rules in this package.
 # custom:
 #   short_name: step_image_registry_prefix_list_provided
-#   failure_msg: Missing required allowed_step_image_registry_prefixes rule data
+#   failure_msg: "%s"
 #   solution: >-
 #     Make sure the xref:ec-cli:ROOT:configuration.adoc#_data_sources[data sources] contains a key
 #     'allowed_step_image_registry_prefixes' that contains a list of approved registries
 #     that can be used to run tasks in the build pipeline.
+#   collections:
+#   - policy_data
 #
 deny contains result if {
-	count(lib.rule_data("allowed_step_image_registry_prefixes")) == 0
-	result := lib.result_helper(rego.metadata.chain(), [])
+	some error in _rule_data_errors
+	result := lib.result_helper(rego.metadata.chain(), [error])
 }
 
 image_ref_permitted(image_ref, allowed_prefixes) if {
@@ -71,3 +73,22 @@ _normalize_image_ref(image_ref) := normalized if {
 	count(parts) == 1
 	normalized := image_ref
 }
+
+_rule_data_errors contains msg if {
+	# match_schema expects either a marshaled JSON resource (String) or an Object. It doesn't
+	# handle an Array directly.
+	value := json.marshal(lib.rule_data(_rule_data_key))
+	some violation in json.match_schema(
+		value,
+		{
+			"$schema": "http://json-schema.org/draft-07/schema#",
+			"type": "array",
+			"items": {"type": "string"},
+			"uniqueItems": true,
+			"minItems": 1,
+		},
+	)[1]
+	msg := sprintf("Rule data %s has unexpected format: %s", [_rule_data_key, violation.error])
+}
+
+_rule_data_key := "allowed_step_image_registry_prefixes"

--- a/policy/release/step_image_registries_test.rego
+++ b/policy/release/step_image_registries_test.rego
@@ -69,10 +69,36 @@ test_unexpected_image_ref if {
 	}}) with input.attestations as [mock_data(unexpected_image)]
 }
 
-test_step_image_registry_prefix_list_found if {
+test_step_image_registry_prefix_list_empty if {
 	expected := {{
 		"code": "step_image_registries.step_image_registry_prefix_list_provided",
-		"msg": "Missing required allowed_step_image_registry_prefixes rule data",
+		# regal ignore:line-length
+		"msg": "Rule data allowed_step_image_registry_prefixes has unexpected format: (Root): Array must have at least 1 items",
 	}}
 	lib.assert_equal_results(expected, step_image_registries.deny) with data.rule_data as {}
+}
+
+test_step_image_registry_prefix_list_format if {
+	d := {"allowed_step_image_registry_prefixes": [
+		# Wrong type
+		1,
+		# Duplicated items
+		"registry.local/",
+		"registry.local/",
+	]}
+
+	expected := {
+		{
+			"code": "step_image_registries.step_image_registry_prefix_list_provided",
+			# regal ignore:line-length
+			"msg": "Rule data allowed_step_image_registry_prefixes has unexpected format: 0: Invalid type. Expected: string, given: integer",
+		},
+		{
+			"code": "step_image_registries.step_image_registry_prefix_list_provided",
+			# regal ignore:line-length
+			"msg": "Rule data allowed_step_image_registry_prefixes has unexpected format: (Root): array items[1,2] must be unique",
+		},
+	}
+
+	lib.assert_equal_results(expected, step_image_registries.deny) with data.rule_data as d
 }

--- a/policy/release/test_test.rego
+++ b/policy/release/test_test.rego
@@ -434,4 +434,69 @@ test_wrong_attestation_type if {
 	lib.assert_empty(test.deny) with input.attestations as [tr, tr_slsav1]
 }
 
+test_rule_data_provided if {
+	d := {
+		"supported_tests_results": [
+			# Wrong type
+			1,
+			# Duplicated items
+			"SUCCESS",
+			"SUCCESS",
+		],
+		"failed_tests_results": [1],
+		"erred_tests_results": [1],
+		"skipped_tests_results": [1],
+		"warned_tests_results": [1],
+		"informative_tests": [
+			# Wrong type
+			1,
+			# Duplicated items
+			"SUCCESS",
+			"SUCCESS",
+		],
+	}
+
+	expected := {
+		{
+			"code": "test.rule_data_provided",
+			# regal ignore:line-length
+			"msg": "Rule data erred_tests_results has unexpected format: 0: 0 must be one of the following: \"SUCCESS\", \"FAILURE\", \"WARNING\", \"SKIPPED\", \"ERROR\"",
+		},
+		{
+			"code": "test.rule_data_provided",
+			# regal ignore:line-length
+			"msg": "Rule data failed_tests_results has unexpected format: 0: 0 must be one of the following: \"SUCCESS\", \"FAILURE\", \"WARNING\", \"SKIPPED\", \"ERROR\"",
+		},
+		{
+			"code": "test.rule_data_provided",
+			"msg": "Rule data informative_tests has unexpected format: (Root): array items[1,2] must be unique",
+		},
+		{
+			"code": "test.rule_data_provided",
+			"msg": "Rule data informative_tests has unexpected format: 0: Invalid type. Expected: string, given: integer",
+		},
+		{
+			"code": "test.rule_data_provided",
+			# regal ignore:line-length
+			"msg": "Rule data skipped_tests_results has unexpected format: 0: 0 must be one of the following: \"SUCCESS\", \"FAILURE\", \"WARNING\", \"SKIPPED\", \"ERROR\"",
+		},
+		{
+			"code": "test.rule_data_provided",
+			"msg": "Rule data supported_tests_results has unexpected format: (Root): array items[1,2] must be unique",
+		},
+		{
+			"code": "test.rule_data_provided",
+			# regal ignore:line-length
+			"msg": "Rule data supported_tests_results has unexpected format: 0: 0 must be one of the following: \"SUCCESS\", \"FAILURE\", \"WARNING\", \"SKIPPED\", \"ERROR\"",
+		},
+		{
+			"code": "test.rule_data_provided",
+			# regal ignore:line-length
+			"msg": "Rule data warned_tests_results has unexpected format: 0: 0 must be one of the following: \"SUCCESS\", \"FAILURE\", \"WARNING\", \"SKIPPED\", \"ERROR\"",
+		},
+	}
+
+	lib.assert_equal_results(test.deny, expected) with data.rule_data as d
+}
+
 _bundle := "registry.img/spam@sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb"


### PR DESCRIPTION
This commit enhances the validation performed on rule data. It defines a JSON Schema for each value and provides a policy rules to execute them.

Ref: EC-132