### PR TITLE
Set default value for missing task-bundles

### DIFF
--- a/policy/lib/bundles.rego
+++ b/policy/lib/bundles.rego
@@ -33,7 +33,7 @@ unpinned_task_bundle(tasks) := {task |
 default missing_task_bundles_data := false
 
 missing_task_bundles_data if {
-	count(data["task-bundles"]) == 0
+	count(_task_bundles) == 0
 }
 
 # Returns a subset of tasks that use an acceptable bundle reference, but
@@ -41,7 +41,7 @@ missing_task_bundles_data if {
 out_of_date_task_bundle(tasks) := {task |
 	some task in tasks
 
-	ref := image.parse(_bundle_ref(task, data["task-bundles"]))
+	ref := image.parse(_bundle_ref(task, _task_bundles))
 
 	_newer_version_exists(ref)
 	not _is_unacceptable(ref)
@@ -51,7 +51,7 @@ out_of_date_task_bundle(tasks) := {task |
 unacceptable_task_bundle(tasks) := {task |
 	some task in tasks
 
-	ref := image.parse(_bundle_ref(task, data["task-bundles"]))
+	ref := image.parse(_bundle_ref(task, _task_bundles))
 
 	_is_unacceptable(ref)
 }
@@ -68,7 +68,7 @@ _is_unacceptable(ref) if {
 # acceptable bundles data
 _record_exists(ref) if {
 	# all records in acceptable task bundles for the given repository
-	records := data["task-bundles"][ref.repo]
+	records := _task_bundles[ref.repo]
 
 	some record in records
 
@@ -86,7 +86,7 @@ _record_exists(ref) if {
 # tag.
 _newer_in_effect_version_exists(ref) if {
 	# all records in acceptable task bundles for the given repository
-	records := data["task-bundles"][ref.repo]
+	records := _task_bundles[ref.repo]
 
 	some record in records
 
@@ -114,7 +114,7 @@ _newer_in_effect_version_exists(ref) if {
 # specific reference to belong to the same version.
 _newer_in_effect_version_exists(ref) if {
 	# all records in acceptable task bundles for the given repository
-	records := data["task-bundles"][ref.repo]
+	records := _task_bundles[ref.repo]
 
 	some record in records
 
@@ -147,7 +147,7 @@ _newer_in_effect_version_exists(ref) if {
 # version if they have the same tag.
 _newer_version_exists(ref) if {
 	# all records in acceptable task bundles for the given repository
-	records := data["task-bundles"][ref.repo]
+	records := _task_bundles[ref.repo]
 
 	some record in records
 
@@ -172,7 +172,7 @@ _newer_version_exists(ref) if {
 # version.
 _newer_version_exists(ref) if {
 	# all records in acceptable task bundles for the given repository
-	records := data["task-bundles"][ref.repo]
+	records := _task_bundles[ref.repo]
 
 	some record in records
 
@@ -223,3 +223,9 @@ _bundle_ref(task, acceptable) := ref if {
 } else := ref_no_tag if {
 	ref_no_tag := bundle(task)
 }
+
+# _task_bundles provides a safe way to access the list of acceptable task-bundles. It prevents a
+# policy rule from incorrectly not evaluating due to missing data.
+default _task_bundles := {}
+
+_task_bundles := data["task-bundles"]

--- a/policy/lib/bundles_test.rego
+++ b/policy/lib/bundles_test.rego
@@ -72,6 +72,7 @@ test_out_of_date_task_bundle if {
 		{"name": "my-task-1", "taskRef": {"bundle": "reg.com/repo@sha256:bcd"}},
 		{"name": "my-task-3", "ref": {"bundle": "reg.com/repo@sha256:bcd"}},
 	]
+	lib.assert_empty(bundles.out_of_date_task_bundle(tasks))
 
 	lib.assert_empty(bundles.out_of_date_task_bundle(tasks)) with data["task-bundles"] as task_bundles
 
@@ -89,6 +90,9 @@ test_unacceptable_task_bundles if {
 
 	expected := lib.to_set(tasks)
 	lib.assert_equal(bundles.unacceptable_task_bundle(tasks), expected) with data["task-bundles"] as task_bundles
+
+	# By default, if a list of acceptable bundles is not provided, everything is is unacceptable.
+	lib.assert_equal(bundles.unacceptable_task_bundle(tasks), expected)
 }
 
 task_bundles := {"reg.com/repo": [
@@ -126,6 +130,7 @@ test_unacceptable_bundle_is_unacceptable if {
 test_missing_required_data if {
 	lib.assert_equal(bundles.missing_task_bundles_data, false) with data["task-bundles"] as task_bundles
 	lib.assert_equal(bundles.missing_task_bundles_data, true) with data["task-bundles"] as []
+	lib.assert_equal(bundles.missing_task_bundles_data, true)
 }
 
 test_newer_in_effect_version_exists_not_using_tags_newest if {


### PR DESCRIPTION
This prevents policy rules from incorrectly not evaluating due to missing data.