### PR TITLE
Switch to using the pipeline task name instead of the taskRef name

### DIFF
--- a/policy/lib/tekton/task.rego
+++ b/policy/lib/tekton/task.rego
@@ -97,6 +97,19 @@ task_names(task) := names if {
 # task name from a v0.2 and v1.0 attestation
 task_name(task) := refs.task_ref(task).name
 
+# returns a slsav0.2 pipeline task name
+# the name field (which is the taskRun name) for slsav1.0 is metadata.name
+# so this only passes for slsav0.2
+pipeline_task_name(task) := task.name
+
+# returns a slsav1.0 pipeline task name
+pipeline_task_name(task) := name if {
+	not task.name
+	some label, value in task.metadata.labels
+	label == "tekton.dev/pipelineTask"
+	name := value
+}
+
 # _task_params returns an object where keys are parameter names
 # and values are parameter values.
 # Handle parameters of a task from a PipelineRun attestation.

--- a/policy/lib/tekton/task_test.rego
+++ b/policy/lib/tekton/task_test.rego
@@ -465,6 +465,35 @@ test_task_step_image_ref if {
 	)
 }
 
+test_pipeline_task_slsav1 if {
+	slsav1_task_spec := {"metadata": {
+		"name": "clone-build-push-run-cb7ch-build-push",
+		"labels": {
+			"app.kubernetes.io/managed-by": "tekton-pipelines",
+			"app.kubernetes.io/version": "0.5",
+			"tekton.dev/memberOf": "tasks",
+			"tekton.dev/pipeline": "clone-build-push-run-cb7ch",
+			"tekton.dev/pipelineRun": "clone-build-push-run-cb7ch",
+			"tekton.dev/pipelineTask": "build-push",
+			"tekton.dev/task": "buildah",
+		},
+	}}
+	lib.assert_equal(tkn.pipeline_task_name(slsav1_task_spec), "build-push")
+	lib.assert_equal(tkn.pipeline_task_name(slsav1_task("my-pipeline")), "my-pipeline")
+}
+
+test_pipeline_task_slsav02 if {
+	slsav02_inline_task_spec := {
+		"name": "copy-settings",
+		"after": ["clone-repository"],
+		"ref": {},
+	}
+	lib.assert_equal(tkn.pipeline_task_name(slsav02_inline_task_spec), "copy-settings")
+
+	task := {"name": "git-clone-p", "ref": {"name": "git-clone"}}
+	lib.assert_equal(tkn.pipeline_task_name(task), "git-clone-p")
+}
+
 _expected_latest := {
 	"effective_on": "2099-01-02T00:00:00Z",
 	"tasks": [
@@ -560,9 +589,12 @@ _bundle := "registry.img/spam@sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e
 slsav1_task(name) := task if {
 	parts := regex.split(`[\[\]=]`, name)
 	not parts[1]
-	pipeline_task_name := sprintf("%s-p", [name])
+	pipeline_task_name := sprintf("%s", [name])
 	unnamed_task := {
-		"metadata": {"name": pipeline_task_name},
+		"metadata": {
+			"name": pipeline_task_name,
+			"labels": {"tekton.dev/pipelineTask": pipeline_task_name},
+		},
 		"spec": slsav1_attestation_local_spec,
 		"status": {"conditions": [{
 			"type": "Succeeded",
@@ -582,9 +614,12 @@ slsav1_task(name) := task if {
 	# regal ignore:redundant-existence-check
 	parts[1]
 	task_name := parts[0]
-	pipeline_task_name := sprintf("%s-p", [task_name])
+	pipeline_task_name := sprintf("%s", [task_name])
 	unnamed_task := {
-		"metadata": {"name": pipeline_task_name},
+		"metadata": {
+			"name": pipeline_task_name,
+			"labels": {"tekton.dev/pipelineTask": pipeline_task_name},
+		},
 		"spec": slsav1_attestation_local_spec,
 		"status": {"conditions": [{
 			"type": "Succeeded",

--- a/policy/release/attestation_task_bundle.rego
+++ b/policy/release/attestation_task_bundle.rego
@@ -36,7 +36,7 @@ import data.lib.tkn
 #
 deny contains result if {
 	some task in bundles.disallowed_task_reference(lib.tasks_from_pipelinerun)
-	result := lib.result_helper(rego.metadata.chain(), [tkn.task_name(task)])
+	result := lib.result_helper(rego.metadata.chain(), [tkn.pipeline_task_name(task)])
 }
 
 # METADATA
@@ -56,7 +56,7 @@ deny contains result if {
 #
 deny contains result if {
 	some task in bundles.empty_task_bundle_reference(lib.tasks_from_pipelinerun)
-	result := lib.result_helper(rego.metadata.chain(), [tkn.task_name(task)])
+	result := lib.result_helper(rego.metadata.chain(), [tkn.pipeline_task_name(task)])
 }
 
 # METADATA
@@ -76,7 +76,7 @@ deny contains result if {
 #
 warn contains result if {
 	some task in bundles.unpinned_task_bundle(lib.tasks_from_pipelinerun)
-	result := lib.result_helper(rego.metadata.chain(), [tkn.task_name(task), bundles.bundle(task)])
+	result := lib.result_helper(rego.metadata.chain(), [tkn.pipeline_task_name(task), bundles.bundle(task)])
 }
 
 # METADATA
@@ -97,7 +97,7 @@ warn contains result if {
 #
 warn contains result if {
 	some task in bundles.out_of_date_task_bundle(lib.tasks_from_pipelinerun)
-	result := lib.result_helper(rego.metadata.chain(), [tkn.task_name(task), bundles.bundle(task)])
+	result := lib.result_helper(rego.metadata.chain(), [tkn.pipeline_task_name(task), bundles.bundle(task)])
 }
 
 # METADATA
@@ -119,7 +119,7 @@ warn contains result if {
 #
 deny contains result if {
 	some task in bundles.unacceptable_task_bundle(lib.tasks_from_pipelinerun)
-	result := lib.result_helper(rego.metadata.chain(), [tkn.task_name(task), bundles.bundle(task)])
+	result := lib.result_helper(rego.metadata.chain(), [tkn.pipeline_task_name(task), bundles.bundle(task)])
 }
 
 # METADATA

--- a/policy/release/attestation_task_bundle_test.rego
+++ b/policy/release/attestation_task_bundle_test.rego
@@ -163,12 +163,12 @@ test_acceptable_bundle_out_of_date_past if {
 	images := ["reg.com/repo@sha256:bcd", "reg.com/repo@sha256:cde"]
 	attestations := [
 		lib_test.mock_slsav02_attestation_bundles(images),
-		lib_test.mock_slsav1_attestation_bundles(images),
+		lib_test.mock_slsav1_attestation_bundles(images, "task-run-0"),
 	]
 
 	lib.assert_equal_results(attestation_task_bundle.warn, {{
 		"code": "attestation_task_bundle.task_ref_bundles_current",
-		"msg": "Pipeline task 'my-task' uses an out of date task bundle 'reg.com/repo@sha256:bcd'",
+		"msg": "Pipeline task 'task-run-0' uses an out of date task bundle 'reg.com/repo@sha256:bcd'",
 	}}) with input.attestations as attestations
 		with data["task-bundles"] as task_bundles
 		with data.config.policy.when_ns as time.parse_rfc3339_ns("2022-03-12T00:00:00Z")
@@ -183,14 +183,14 @@ test_acceptable_bundle_expired if {
 	image := ["reg.com/repo@sha256:def"]
 	attestations := [
 		lib_test.mock_slsav02_attestation_bundles(image),
-		lib_test.mock_slsav1_attestation_bundles(image),
+		lib_test.mock_slsav1_attestation_bundles(image, "task-run-0"),
 	]
 	lib.assert_empty(attestation_task_bundle.warn) with input.attestations as attestations
 		with data["task-bundles"] as task_bundles
 
 	lib.assert_equal_results(attestation_task_bundle.deny, {{
 		"code": "attestation_task_bundle.task_ref_bundles_acceptable",
-		"msg": "Pipeline task 'my-task' uses an unacceptable task bundle 'reg.com/repo@sha256:def'",
+		"msg": "Pipeline task 'task-run-0' uses an unacceptable task bundle 'reg.com/repo@sha256:def'",
 	}}) with input.attestations as attestations
 		with data["task-bundles"] as task_bundles
 }
@@ -237,7 +237,7 @@ test_warn_cases if {
 		with data["task-bundles"] as bundles
 		with data.config.policy.when_ns as time.parse_rfc3339_ns("2023-11-05T00:00:00Z")
 
-	attestation_97f216 := mock_data({"ref": {
+	attestation_97f216 := mock_data({"name": "buildah", "ref": {
 		"name": "buildah",
 		"bundle": "q.io/r//task-buildah@sha256:97f216",
 	}})
@@ -266,7 +266,7 @@ test_warn_cases if {
 		with data["task-bundles"] as bundles
 		with data.config.policy.when_ns as time.parse_rfc3339_ns("2023-10-25T00:00:00Z")
 
-	attestation_487b82 := mock_data({"ref": {
+	attestation_487b82 := mock_data({"name": "buildah", "ref": {
 		"name": "buildah",
 		"bundle": "q.io/r//task-buildah@sha256:487b82",
 	}})

--- a/policy/release/lib/attestations_test.rego
+++ b/policy/release/lib/attestations_test.rego
@@ -124,10 +124,10 @@ mock_slsav1_attestation_with_tasks(tasks) := {"statement": {
 	}},
 }}
 
-mock_slsav1_attestation_bundles(bundles) := a if {
+mock_slsav1_attestation_bundles(bundles, task_name) := a if {
 	tasks := [task |
 		some bundle in bundles
-		task := tkn_test.slsav1_task_bundle("my-task", bundle)
+		task := tkn_test.slsav1_task_bundle(task_name, bundle)
 	]
 	a := mock_slsav1_attestation_with_tasks(tasks)
 }

--- a/policy/release/step_image_registries.rego
+++ b/policy/release/step_image_registries.rego
@@ -36,7 +36,7 @@ deny contains result if {
 	image_ref := tkn.task_step_image_ref(step)
 	allowed_registry_prefixes := lib.rule_data(_rule_data_key)
 	not image_ref_permitted(image_ref, allowed_registry_prefixes)
-	result := lib.result_helper(rego.metadata.chain(), [step_index, tkn.task_name(task), image_ref])
+	result := lib.result_helper(rego.metadata.chain(), [step_index, tkn.pipeline_task_name(task), image_ref])
 }
 
 # METADATA

--- a/policy/release/tasks.rego
+++ b/policy/release/tasks.rego
@@ -68,7 +68,10 @@ deny contains result if {
 	some task in tkn.tasks(att)
 	some status in _status(task)
 	status != "Succeeded"
-	result := lib.result_helper_with_term(rego.metadata.chain(), [tkn.task_name(task), status], tkn.task_name(task))
+	result := lib.result_helper_with_term(
+		rego.metadata.chain(),
+		[tkn.pipeline_task_name(task), status], tkn.pipeline_task_name(task),
+	)
 }
 
 # METADATA

--- a/policy/release/tasks_test.rego
+++ b/policy/release/tasks_test.rego
@@ -476,7 +476,7 @@ _task(name) := task if {
 	# regal ignore:redundant-existence-check
 	parts[1]
 	task_name := parts[0]
-	pipeline_task_name := sprintf("%s-p", [task_name])
+	pipeline_task_name := sprintf("%s", [task_name])
 
 	task := {
 		"name": pipeline_task_name,
@@ -489,7 +489,7 @@ _task(name) := task if {
 _task(name) := task if {
 	parts := regex.split(`[\[\]=]`, name)
 	not parts[1]
-	pipeline_task_name := sprintf("%s-p", [name])
+	pipeline_task_name := sprintf("%s", [name])
 	task := {
 		"name": pipeline_task_name,
 		"status": "Succeeded",


### PR DESCRIPTION
The taskRef name can be excluded if a task is defined inline, but the pipeline task name is always required.

This change only affects the message on a failed rule.

https://issues.redhat.com/browse/RHTAPBUGS-1076