### PR TITLE
Handle duplicate acceptable bundle records

### DIFF
--- a/policy/lib/bundles.rego
+++ b/policy/lib/bundles.rego
@@ -3,6 +3,7 @@ package lib.bundles
 import future.keywords.if
 import future.keywords.in
 
+import data.lib.arrays
 import data.lib.image
 import data.lib.refs
 import data.lib.time as time_lib
@@ -149,12 +150,9 @@ _newer_version_exists(ref) if {
 	# all records in acceptable task bundles for the given repository
 	records := _task_bundles[ref.repo]
 
-	some record in records
-
-	# consider all records, if a match is found via exact digest and there
-	# exists a newer record for the same tag but it is newer, i.e. has greater
-	# effective_on value
-	record.digest == ref.digest
+	# find the record with the newest effective_on for the given digest
+	records_with_same_digest := arrays.sort_by("effective_on", [r | some r in records; r.digest == ref.digest])
+	record := records_with_same_digest[count(records_with_same_digest) - 1]
 
 	some other in records
 
@@ -174,12 +172,9 @@ _newer_version_exists(ref) if {
 	# all records in acceptable task bundles for the given repository
 	records := _task_bundles[ref.repo]
 
-	some record in records
-
-	# consider all records, if a match is found via exact digest and there
-	# exists a newer record for the same tag but it is newer, i.e. has greater
-	# effective_on value
-	record.digest == ref.digest
+	# find the record with the newest effective_on for the given digest
+	records_with_same_digest := arrays.sort_by("effective_on", [r | some r in records; r.digest == ref.digest])
+	record := records_with_same_digest[count(records_with_same_digest) - 1]
 
 	# No other record in acceptable bundles matches the tag from the record
 	# matched by the digest to the reference

--- a/policy/pipeline/task_bundle_test.rego
+++ b/policy/pipeline/task_bundle_test.rego
@@ -105,6 +105,47 @@ test_acceptable_bundle_expired if {
 		with data["task-bundles"] as task_bundles
 }
 
+test_ec316 if {
+	tasks := [{
+		"name": "my-task",
+		"taskRef": {"bundle": "registry.io/repository/image:0.3@sha256:abc"},
+	}]
+
+	acceptable_bundles := {"registry.io/repository/image": [
+		{
+			"digest": "sha256:abc",
+			"effective_on": "2024-02-02T00:00:00Z",
+			"tag": "0.1",
+		},
+		{
+			"digest": "sha256:abc",
+			"effective_on": "2024-02-02T00:00:00Z",
+			"tag": "0.2",
+		},
+		{
+			"digest": "sha256:abc",
+			"effective_on": "2024-02-02T00:00:00Z",
+			"tag": "0.3",
+		},
+		{
+			"digest": "sha256:abc",
+			"effective_on": "2024-01-21T00:00:00Z",
+			"tag": "0.3",
+		},
+		{
+			"digest": "sha256:abc",
+			"effective_on": "2024-01-21T00:00:00Z",
+			"tag": "0.3",
+		},
+	]}
+
+	lib.assert_empty(task_bundle.warn) with input.spec.tasks as tasks
+		with data["task-bundles"] as acceptable_bundles
+
+	lib.assert_empty(task_bundle.deny) with input.spec.tasks as tasks
+		with data["task-bundles"] as acceptable_bundles
+}
+
 test_missing_required_data if {
 	expected := {{
 		"code": "task_bundle.missing_required_data",

--- a/policy/release/attestation_task_bundle_test.rego
+++ b/policy/release/attestation_task_bundle_test.rego
@@ -302,6 +302,51 @@ test_warn_cases if {
 		with data.config.policy.when_ns as time.parse_rfc3339_ns("2023-10-22T00:00:00Z")
 }
 
+test_ec316 if {
+	image_ref := "registry.io/repository/image:0.3@sha256:abc"
+	attestations := [
+		mock_data({
+			"name": "my-task",
+			"ref": {"name": "my-task", "bundle": image_ref},
+		}),
+		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle("my-task", image_ref)]),
+	]
+
+	acceptable_bundles := {"registry.io/repository/image": [
+		{
+			"digest": "sha256:abc",
+			"effective_on": "2024-02-02T00:00:00Z",
+			"tag": "0.1",
+		},
+		{
+			"digest": "sha256:abc",
+			"effective_on": "2024-02-02T00:00:00Z",
+			"tag": "0.2",
+		},
+		{
+			"digest": "sha256:abc",
+			"effective_on": "2024-02-02T00:00:00Z",
+			"tag": "0.3",
+		},
+		{
+			"digest": "sha256:abc",
+			"effective_on": "2024-01-21T00:00:00Z",
+			"tag": "0.3",
+		},
+		{
+			"digest": "sha256:abc",
+			"effective_on": "2024-01-21T00:00:00Z",
+			"tag": "0.3",
+		},
+	]}
+
+	lib.assert_empty(attestation_task_bundle.warn) with input.attestations as attestations
+		with data["task-bundles"] as acceptable_bundles
+
+	lib.assert_empty(attestation_task_bundle.deny) with input.attestations as attestations
+		with data["task-bundles"] as acceptable_bundles
+}
+
 task_bundles := {"reg.com/repo": [
 	{
 		# Latest v2


### PR DESCRIPTION
Currently the acceptable bundles can hold for the same image repository multiple records with the same digest, they would also have the same tag but their effective_on would differ. This would cause the rule to report that the task bundle used is out of date as it would find two records one of which could be newer than the other.

reference: EC-316