### PR TITLE
Required task must be from acceptable bundle

### DIFF
--- a/policy/lib/bundles.rego
+++ b/policy/lib/bundles.rego
@@ -57,6 +57,13 @@ unacceptable_task_bundle(tasks) := {task |
 	_is_unacceptable(ref)
 }
 
+# Returns if the task uses an acceptable bundle reference
+is_acceptable_task(task) if {
+	ref := image.parse(_bundle_ref(task, _task_bundles))
+
+	_record_exists(ref)
+}
+
 _is_unacceptable(ref) if {
 	not _record_exists(ref)
 }

--- a/policy/lib/bundles_test.rego
+++ b/policy/lib/bundles_test.rego
@@ -308,3 +308,16 @@ test_newer_version_exists_tags_as_versions_older if {
 	]}
 	bundles._newer_version_exists(ref) with data["task-bundles"] as acceptable
 }
+
+test_is_acceptable if {
+	acceptable := {"registry.io/repository/image": [{
+		"digest": "sha256:digest",
+		"tag": "",
+		"effective_on": "1962-04-11T00:00:00Z",
+	}]}
+	acceptable_task := {"name": "my-task", "taskRef": {"bundle": "registry.io/repository/image:tag@sha256:digest"}}
+	bundles.is_acceptable_task(acceptable_task) with data["task-bundles"] as acceptable
+
+	unacceptable_task := {"name": "my-task", "taskRef": {"bundle": "registry.io/other/image:tag@sha256:digest"}}
+	not bundles.is_acceptable_task(unacceptable_task) with data["task-bundles"] as acceptable
+}

--- a/policy/pipeline/required_tasks.rego
+++ b/policy/pipeline/required_tasks.rego
@@ -13,6 +13,7 @@ import future.keywords.if
 import future.keywords.in
 
 import data.lib
+import data.lib.bundles
 import data.lib.tkn
 
 # METADATA
@@ -103,8 +104,14 @@ deny contains result if {
 # _missing_tasks returns a set of task names that are in the given
 # required_tasks, but not in the pipeline definition.
 _missing_tasks(required_tasks) := {task |
+	acceptable := [task_name |
+		some task in tkn.tasks(input)
+		bundles.is_acceptable_task(task)
+		some task_name in tkn.task_names(task)
+	]
+
 	some required_task in required_tasks
-	some task in _any_missing(required_task, tkn.tasks_names(input))
+	some task in _any_missing(required_task, acceptable)
 }
 
 _any_missing(required, tasks) := missing if {

--- a/policy/pipeline/required_tasks_test.rego
+++ b/policy/pipeline/required_tasks_test.rego
@@ -10,10 +10,12 @@ import data.policy.pipeline.required_tasks
 test_required_tasks_met if {
 	pipeline := _pipeline_with_tasks_and_label(_expected_required_tasks, [], [])
 	lib.assert_empty(required_tasks.deny) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input as pipeline
 
 	pipeline_finally := _pipeline_with_tasks_and_label([], _expected_required_tasks, [])
 	lib.assert_empty(required_tasks.deny) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input as pipeline_finally
 }
 
@@ -26,16 +28,19 @@ test_required_tasks_not_met if {
 		expected,
 		required_tasks.deny,
 	) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input as pipeline
 }
 
 test_future_required_tasks_met if {
 	pipeline := _pipeline_with_tasks_and_label(_expected_future_required_tasks, [], [])
 	lib.assert_empty(required_tasks.warn) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input as pipeline
 
 	pipeline_finally := _pipeline_with_tasks_and_label([], _expected_future_required_tasks, [])
 	lib.assert_empty(required_tasks.warn) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input as pipeline_finally
 }
 
@@ -43,10 +48,12 @@ test_not_warn_if_only_future_required_tasks if {
 	tasks := _time_based_pipeline_required_tasks_future_only
 	pipeline := _pipeline_with_tasks_and_label(_expected_future_required_tasks, [], [])
 	lib.assert_empty(required_tasks.warn) with data["pipeline-required-tasks"] as tasks
+		with data["task-bundles"] as _expected_bundles
 		with input as pipeline
 
 	pipeline_finally := _pipeline_with_tasks_and_label([], _expected_future_required_tasks, [])
 	lib.assert_empty(required_tasks.warn) with data["pipeline-required-tasks"] as tasks
+		with data["task-bundles"] as _expected_bundles
 		with input as pipeline_finally
 }
 
@@ -59,6 +66,7 @@ test_future_required_tasks_not_met if {
 		expected,
 		required_tasks.warn,
 	) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input as pipeline
 }
 
@@ -66,6 +74,7 @@ test_extra_tasks_ignored if {
 	pipeline := _pipeline_with_tasks_and_label(_expected_future_required_tasks | {"spam"}, [], [])
 	all := required_tasks.deny | required_tasks.warn
 	lib.assert_empty(all) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input as pipeline
 }
 
@@ -79,20 +88,24 @@ test_missing_pipeline_label if {
 		expected,
 		required_tasks.warn,
 	) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input as pipeline
 }
 
 test_default_required_task_met if {
 	pipeline := _pipeline_with_tasks(_expected_required_tasks, [], [])
 	lib.assert_empty(required_tasks.deny) with data["required-tasks"] as _time_based_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input as pipeline
 
 	pipeline_finally := _pipeline_with_tasks([], _expected_required_tasks, [])
 	lib.assert_empty(required_tasks.deny) with data["required-tasks"] as _time_based_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input as pipeline_finally
 
 	expected_warn := _missing_pipeline_tasks_warning("fbc")
 	lib.assert_equal_results(expected_warn, required_tasks.warn) with data["required-tasks"] as _expected_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input as pipeline
 }
 
@@ -102,10 +115,12 @@ test_default_required_tasks_not_met if {
 
 	expected := _missing_default_tasks_violation(missing_tasks)
 	lib.assert_equal_results(expected, required_tasks.deny) with data["required-tasks"] as _time_based_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input as pipeline
 
 	expected_warn := _missing_pipeline_tasks_warning("fbc")
 	lib.assert_equal_results(expected_warn, required_tasks.warn) with data["required-tasks"] as _expected_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input as pipeline
 }
 
@@ -116,6 +131,7 @@ test_default_future_required_tasks_met if {
 		expected_warn,
 		required_tasks.warn,
 	) with data["required-tasks"] as _time_based_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input as pipeline
 
 	pipeline_finally := _pipeline_with_tasks([], _expected_future_required_tasks, [])
@@ -123,6 +139,7 @@ test_default_future_required_tasks_met if {
 		expected_warn,
 		required_tasks.warn,
 	) with data["required-tasks"] as _time_based_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input as pipeline_finally
 }
 
@@ -137,6 +154,7 @@ test_default_future_required_tasks_not_met if {
 		"term": "conftest-clair",
 	}}
 	lib.assert_equal_results(expected, required_tasks.warn) with data["required-tasks"] as _time_based_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input as pipeline
 }
 
@@ -145,6 +163,7 @@ test_current_equal_latest if {
 	pipeline := _pipeline_with_tasks_and_label(_expected_future_required_tasks, [], [])
 
 	lib.assert_empty(required_tasks.deny | required_tasks.warn) with data["pipeline-required-tasks"] as req_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input as pipeline
 }
 
@@ -153,6 +172,7 @@ test_current_equal_latest_also if {
 	pipeline := _pipeline_with_tasks_and_label(_expected_required_tasks, [], [])
 
 	lib.assert_empty(required_tasks.warn) with data["pipeline-required-tasks"] as req_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input as pipeline
 
 	required_tasks_denies := {"fbc": [{
@@ -164,6 +184,7 @@ test_current_equal_latest_also if {
 		expected_denies,
 		required_tasks.deny,
 	) with data["pipeline-required-tasks"] as required_tasks_denies
+		with data["task-bundles"] as _expected_bundles
 		with input as pipeline
 }
 
@@ -177,18 +198,21 @@ test_no_tasks_present if {
 		expected,
 		required_tasks.deny,
 	) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input as {"kind": "Pipeline"}
 
 	lib.assert_equal_results(
 		expected,
 		required_tasks.deny,
 	) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input as {"kind": "Pipeline", "spec": {}}
 
 	lib.assert_equal_results(
 		expected,
 		required_tasks.deny,
 	) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input as {"kind": "Pipeline", "spec": {"tasks": [], "finally": []}}
 }
 
@@ -215,6 +239,7 @@ test_parameterized if {
 
 	expected := _missing_default_tasks_violation({"label-check[POLICY_NAMESPACE=required_checks]"})
 	lib.assert_equal_results(expected, required_tasks.deny) with data["required-tasks"] as _time_based_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input as pipeline
 }
 
@@ -236,6 +261,7 @@ test_one_of_required_tasks if {
 		"effective_on": "2009-01-02T00:00:00Z",
 	}]}
 	lib.assert_empty(required_tasks.deny) with data["pipeline-required-tasks"] as data_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input as pipeline
 }
 
@@ -261,6 +287,7 @@ test_one_of_required_tasks_missing if {
 	}
 
 	lib.assert_equal_results(expected, required_tasks.deny) with data["pipeline-required-tasks"] as data_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input as pipeline
 }
 
@@ -271,6 +298,7 @@ test_future_one_of_required_tasks if {
 		"effective_on": "2099-01-02T00:00:00Z",
 	}]}
 	lib.assert_empty(required_tasks.warn) with data["pipeline-required-tasks"] as data_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input as pipeline
 }
 
@@ -298,6 +326,7 @@ test_future_one_of_required_tasks_missing if {
 		expected,
 		required_tasks.warn,
 	) with data["pipeline-required-tasks"] as data_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input as pipeline
 }
 
@@ -437,3 +466,9 @@ _time_based_required_tasks := [
 ]
 
 _bundle := "registry.img/spam@sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb"
+
+_expected_bundles := {"registry.img/spam": [{
+	"digest": "sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb",
+	"tag": "0.1",
+	"effective_on": "2000-01-01T00:00:00Z",
+}]}

--- a/policy/release/tasks.rego
+++ b/policy/release/tasks.rego
@@ -100,6 +100,36 @@ deny contains result if {
 }
 
 # METADATA
+# title: All required tasks are from acceptable bundles
+# description: >-
+#   Ensure that the all required tasks are resolved from acceptable bundles.
+# custom:
+#   short_name: required_task_unacceptable_found
+#   failure_msg: '%s is required and present but not from an acceptable bundle'
+#   solution: >-
+#     Make sure all required tasks in the build pipeline are resolved from
+#     acceptable bundles.
+#   collections:
+#   - redhat
+#   depends_on:
+#   - tasks.pipeline_has_tasks
+#
+warn contains result if {
+	some att in lib.pipelinerun_attestations
+
+	# only tasks that are unacceptable
+	some unacceptable_task in bundles.unacceptable_task_bundle(tkn.tasks(att))
+	some missing_required_name in _missing_tasks(current_required_tasks)
+	some unacceptable_task_name in tkn.task_names(unacceptable_task)
+
+	unacceptable_task_name == missing_required_name
+	result := lib.result_helper_with_term(
+		rego.metadata.chain(), [_format_missing(unacceptable_task_name, false)],
+		unacceptable_task_name,
+	)
+}
+
+# METADATA
 # title: Required tasks list for pipeline was provided
 # description: >-
 #   Produce a warning if the required tasks list rule data was not provided.

--- a/policy/release/tasks_test.rego
+++ b/policy/release/tasks_test.rego
@@ -454,6 +454,28 @@ test_future_one_of_required_tasks_missing if {
 		with input.attestations as attestation_v1
 }
 
+test_required_task_from_unacceptable if {
+	attestations := _attestations_with_tasks(_expected_required_tasks - {"buildah"}, [{
+		"name": "buildah",
+		"ref": {"name": "buildah", "kind": "Task", "bundle": "registry.io/repository/unacceptable"},
+	}])
+	expected := {
+		{
+			"code": "tasks.future_required_tasks_found",
+			"msg": "Task \"conftest-clair\" is missing and will be required in the future",
+			"term": "conftest-clair",
+		},
+		{
+			"code": "tasks.required_task_unacceptable_found",
+			"msg": "Required task \"buildah\" is required and present but not from an acceptable bundle",
+			"term": "buildah",
+		},
+	}
+	lib.assert_equal_results(expected, tasks.warn) with data["pipeline-required-tasks"] as _required_pipeline_tasks
+		with data["task-bundles"] as _expected_bundles
+		with input.attestations as attestations
+}
+
 _attestations_with_tasks(names, add_tasks) := attestations if {
 	tasks := array.concat([t | some name in names; t := _task(name)], add_tasks)
 

--- a/policy/release/tasks_test.rego
+++ b/policy/release/tasks_test.rego
@@ -76,10 +76,12 @@ test_failed_tasks if {
 test_required_tasks_met if {
 	attestations := _attestations_with_tasks(_expected_required_tasks, [])
 	lib.assert_empty(tasks.deny) with data["pipeline-required-tasks"] as _required_pipeline_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as attestations
 
 	slsav1_attestations := _slsav1_attestations_with_tasks(_expected_required_tasks, [])
 	lib.assert_empty(tasks.deny) with data["pipeline-required-tasks"] as _required_pipeline_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as slsav1_attestations
 }
 
@@ -87,19 +89,23 @@ test_required_tasks_met_no_label if {
 	attestations := _attestations_with_tasks(_expected_required_tasks, [])
 	lib.assert_empty(tasks.deny) with data["required-tasks"] as _time_based_required_tasks
 		with data["pipeline-required-tasks"] as {}
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as attestations
 
 	attestations_no_label := _attestations_with_tasks_no_label(_expected_required_tasks, [])
 	lib.assert_empty(tasks.deny) with data["required-tasks"] as _time_based_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as attestations_no_label
 
 	slsav1_attestations := _slsav1_attestations_with_tasks(_expected_required_tasks, [])
 	lib.assert_empty(tasks.deny) with data["required-tasks"] as _time_based_required_tasks
 		with data["pipeline-required-tasks"] as {}
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as slsav1_attestations
 
 	slsav1_attestations_no_label := _slsav1_attestations_with_tasks_no_label(_expected_required_tasks, [])
 	lib.assert_empty(tasks.deny) with data["required-tasks"] as _time_based_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as slsav1_attestations_no_label
 }
 
@@ -132,6 +138,7 @@ test_required_tasks_not_met if {
 		expected,
 		tasks.deny,
 	) with data["pipeline-required-tasks"] as _required_pipeline_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as attestations
 
 	slsav1_attestations := _slsav1_attestations_with_tasks(_expected_required_tasks - missing_tasks, [])
@@ -139,16 +146,19 @@ test_required_tasks_not_met if {
 		expected,
 		tasks.deny,
 	) with data["pipeline-required-tasks"] as _required_pipeline_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as slsav1_attestations
 }
 
 test_future_required_tasks_met if {
 	attestations := _attestations_with_tasks(_expected_future_required_tasks, [])
 	lib.assert_empty(tasks.warn) with data["pipeline-required-tasks"] as _required_pipeline_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as attestations
 
 	slsav1_attestations := _slsav1_attestations_with_tasks(_expected_future_required_tasks, [])
 	lib.assert_empty(tasks.warn) with data["pipeline-required-tasks"] as _required_pipeline_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as slsav1_attestations
 }
 
@@ -161,6 +171,7 @@ test_future_required_tasks_not_met if {
 		expected,
 		tasks.warn,
 	) with data["pipeline-required-tasks"] as _required_pipeline_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as attestations
 
 	slsav1_attestations := _slsav1_attestations_with_tasks(_expected_future_required_tasks - missing_tasks, [])
@@ -168,20 +179,25 @@ test_future_required_tasks_not_met if {
 		expected,
 		tasks.warn,
 	) with data["pipeline-required-tasks"] as _required_pipeline_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as slsav1_attestations
 }
 
 test_extra_tasks_ignored if {
 	attestations := _attestations_with_tasks(_expected_future_required_tasks | {"spam"}, [])
 	lib.assert_empty(tasks.deny) with data["pipeline-required-tasks"] as _required_pipeline_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as attestations
 	lib.assert_empty(tasks.warn) with data["pipeline-required-tasks"] as _required_pipeline_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as attestations
 
 	slsav1_attestations := _slsav1_attestations_with_tasks(_expected_future_required_tasks | {"spam"}, [])
 	lib.assert_empty(tasks.deny) with data["pipeline-required-tasks"] as _required_pipeline_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as slsav1_attestations
 	lib.assert_empty(tasks.warn) with data["pipeline-required-tasks"] as _required_pipeline_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as slsav1_attestations
 }
 
@@ -193,6 +209,7 @@ test_current_equal_latest if {
 	attestations := _attestations_with_tasks(_expected_future_required_tasks, [])
 
 	lib.assert_empty(tasks.deny | tasks.warn) with data["pipeline-required-tasks"] as required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as attestations
 }
 
@@ -204,17 +221,21 @@ test_current_equal_latest_also if {
 	attestations := _attestations_with_tasks(_expected_required_tasks, [])
 
 	lib.assert_empty(tasks.warn) with data["pipeline-required-tasks"] as required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as attestations
 
 	expected_denies := _missing_tasks_violation(_expected_future_required_tasks - _expected_required_tasks)
 	lib.assert_equal_results(expected_denies, tasks.deny) with data["pipeline-required-tasks"] as required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as attestations
 
 	slsav1_attestations := _slsav1_attestations_with_tasks(_expected_required_tasks, [])
 	lib.assert_empty(tasks.warn) with data["pipeline-required-tasks"] as required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as slsav1_attestations
 
 	lib.assert_equal_results(expected_denies, tasks.deny) with data["pipeline-required-tasks"] as required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as slsav1_attestations
 }
 
@@ -247,9 +268,10 @@ test_parameterized if {
 		tasks.deny,
 		expected,
 	) with data["pipeline-required-tasks"] as _required_pipeline_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as attestations
 
-	slsav1_no_param := tkn_test.slsav1_task("label-check")
+	slsav1_no_param := tkn_test.slsav1_task_bundle("label-check", _bundle)
 	slsav1_task1 := json.patch(slsav1_no_param, [{
 		"op": "replace",
 		"path": "/spec/params",
@@ -266,6 +288,7 @@ test_parameterized if {
 		tasks.deny,
 		expected,
 	) with data["pipeline-required-tasks"] as _required_pipeline_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as slsav1_attestations
 }
 
@@ -339,10 +362,12 @@ test_one_of_required_tasks if {
 		"effective_on": "2009-01-02T00:00:00Z",
 	}]}
 	lib.assert_empty(tasks.deny) with data["pipeline-required-tasks"] as data_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as attestation_v02
 
 	attestation_v1 := _slsav1_attestations_with_tasks(["a", "b", "c1", "d2", "e", "f"], [])
 	lib.assert_empty(tasks.deny) with data["pipeline-required-tasks"] as data_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as attestation_v1
 }
 
@@ -368,10 +393,12 @@ test_one_of_required_tasks_missing if {
 	}
 
 	lib.assert_equal_results(expected, tasks.deny) with data["pipeline-required-tasks"] as data_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as attestation_v02
 
 	attestation_v1 := _slsav1_attestations_with_tasks(["a", "b", "d2", "e", "f"], [])
 	lib.assert_equal_results(expected, tasks.deny) with data["pipeline-required-tasks"] as data_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as attestation_v1
 }
 
@@ -382,10 +409,12 @@ test_future_one_of_required_tasks if {
 		"effective_on": "2099-01-02T00:00:00Z",
 	}]}
 	lib.assert_empty(tasks.warn) with data["pipeline-required-tasks"] as data_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as attestation_v02
 
 	attestation_v1 := _slsav1_attestations_with_tasks(["a", "b", "c1", "d2", "e", "f"], [])
 	lib.assert_empty(tasks.warn) with data["pipeline-required-tasks"] as data_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as attestation_v1
 }
 
@@ -413,6 +442,7 @@ test_future_one_of_required_tasks_missing if {
 		expected,
 		tasks.warn,
 	) with data["pipeline-required-tasks"] as data_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as attestation_v02
 
 	attestation_v1 := _slsav1_attestations_with_tasks(["a", "b", "d2", "e", "f"], [])
@@ -420,6 +450,7 @@ test_future_one_of_required_tasks_missing if {
 		expected,
 		tasks.warn,
 	) with data["pipeline-required-tasks"] as data_required_tasks
+		with data["task-bundles"] as _expected_bundles
 		with input.attestations as attestation_v1
 }
 
@@ -434,7 +465,7 @@ _attestations_with_tasks(names, add_tasks) := attestations if {
 }
 
 _slsav1_attestations_with_tasks(names, add_tasks) := attestations if {
-	slsav1_tasks := array.concat([t | some name in names; t := tkn_test.slsav1_task(name)], add_tasks)
+	slsav1_tasks := array.concat([t | some name in names; t := tkn_test.slsav1_task_bundle(name, _bundle)], add_tasks)
 
 	attestations := [{"statement": {
 		"predicateType": "https://slsa.dev/provenance/v1",
@@ -457,7 +488,7 @@ _attestations_with_tasks_no_label(names, add_tasks) := attestations if {
 }
 
 _slsav1_attestations_with_tasks_no_label(names, add_tasks) := attestations if {
-	slsav1_tasks := array.concat([t | some name in names; t := tkn_test.slsav1_task(name)], add_tasks)
+	slsav1_tasks := array.concat([t | some name in names; t := tkn_test.slsav1_task_bundle(name, _bundle)], add_tasks)
 
 	attestations := [{"statement": {
 		"predicateType": "https://slsa.dev/provenance/v1",
@@ -593,3 +624,9 @@ _time_based_required_tasks := [
 ]
 
 _bundle := "registry.img/spam@sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb"
+
+_expected_bundles := {"registry.img/spam": [{
+	"digest": "sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb",
+	"tag": "0.1",
+	"effective_on": "2000-01-01T00:00:00Z",
+}]}


### PR DESCRIPTION
Adds an additional check that a record must exist for a bundle the required task originates from. Meaning that the task is from an acceptable bundle.

reference: EC-254