### PR TITLE
Don't publish `beta` package

### DIFF
--- a/hack/update-bundles.sh
+++ b/hack/update-bundles.sh
@@ -24,7 +24,7 @@ set -o nounset
 
 REPO_PREFIX="${REPO_PREFIX-quay.io/enterprise-contract/}"
 ROOT_DIR=$( git rev-parse --show-toplevel )
-BUNDLES="beta release pipeline task build_task"
+BUNDLES="release pipeline task build_task"
 OPA="go run github.com/enterprise-contract/ec-cli opa"
 ORAS="go run oras.land/oras/cmd/oras"
 


### PR DESCRIPTION
We no longer have one, and attempting to push causes failures[1]

[1] https://github.com/enterprise-contract/ec-policies/actions/runs/7448036295/job/20261519761