### PR TITLE
Fix function producing multiple outputs

### DIFF
--- a/policy/release/slsa_build_scripted_build_test.rego
+++ b/policy/release/slsa_build_scripted_build_test.rego
@@ -398,7 +398,54 @@ test_image_built_by_trusted_task_not_trusted if {
 
 	expected := {{
 		"code": "slsa_build_scripted_build.image_built_by_trusted_task",
-		"msg": "Image \"some.image/foo:bar@sha256:123\" not built by a trusted task: Build Task \"buildah\" is not trusted",
+		# regal ignore:line-length
+		"msg": `Image "some.image/foo:bar@sha256:123" not built by a trusted task: Build Task(s) "buildah" are not trusted`,
+	}}
+
+	lib.assert_equal_results(expected, slsa_build_scripted_build.deny) with input.image as image
+		with input.attestations as [_mock_attestation(tasks)]
+}
+
+test_image_built_by_multiple_not_trusted_tasks if {
+	tasks := [
+		{
+			"results": [
+				{"name": "IMAGE_URL", "value": _image_url},
+				{"name": "IMAGE_DIGEST", "value": _image_digest},
+			],
+			"ref": {
+				"resolver": "bundles",
+				"params": [
+					{"name": "bundle", "value": mock_bundle},
+					{"name": "name", "value": "buildah-1"},
+					{"name": "kind", "value": "task"},
+				],
+			},
+			"steps": [{"entrypoint": "/bin/bash"}],
+		},
+		{
+			"results": [
+				{"name": "IMAGE_URL", "value": _image_url},
+				{"name": "IMAGE_DIGEST", "value": _image_digest},
+			],
+			"ref": {
+				"resolver": "bundles",
+				"params": [
+					{"name": "bundle", "value": mock_bundle},
+					{"name": "name", "value": "buildah-2"},
+					{"name": "kind", "value": "task"},
+				],
+			},
+			"steps": [{"entrypoint": "/bin/bash"}],
+		},
+	]
+
+	image := {"ref": _image_ref}
+
+	expected := {{
+		"code": "slsa_build_scripted_build.image_built_by_trusted_task",
+		# regal ignore:line-length
+		"msg": `Image "some.image/foo:bar@sha256:123" not built by a trusted task: Build Task(s) "buildah-1,buildah-2" are not trusted`,
 	}}
 
 	lib.assert_equal_results(expected, slsa_build_scripted_build.deny) with input.image as image


### PR DESCRIPTION
The function `slsa_build_scripted_build.trusted_build_task_error` could produce more than one result if more than one `build_task_bundles` is untrusted. For example when multiple tasks have the same, expected, `IMAGE_DIGEST` result or if multiple tasks are in the same untrusted bundle as the build task.

This changes the function to operate on tasks instead of bundles and to concatenate any untrusted build task names, so when there are more than one tasks with the expected `IMAGE_DIGEST` result -- a single error message is returned.

This causes:

```
Error: 1 error occurred:
	* error validating image quay.io/redhat-appstudio-qe/enterprise-contract-tests:e2e-test-unpinned-task-bundle of component ec-cli: query rule: check: query rule: evaluating policy: /tmp/ec-work-556256966/policy/52241418b/policy/release/slsa_build_scripted_build.rego:161: eval_conflict_error: functions must not produce multiple outputs for same inputs
```

Caught by e2e tests in https://github.com/redhat-appstudio/infra-deployments/pull/2955