### PR TITLE
Implement effective_on support for rule_data.yml

### DIFF
--- a/policy/lib/rule_data.rego
+++ b/policy/lib/rule_data.rego
@@ -1,5 +1,7 @@
 package lib
 
+import data.lib.time as lib_time
+
 import rego.v1
 
 # Values in data.rule_data_custom or data.rule_data
@@ -108,4 +110,23 @@ rule_data(key_name) := value if {
 } else := value if {
 	# If the key is not found, default to an empty list
 	value := []
+}
+
+
+# Wraps a value from rule_data in an object that contains an effective_on time, if not already present.
+#
+rule_data_append_effective_on(key_name) := value if {
+	# Retrieve original rule_data value
+	value := rule_data(key_name)
+
+	# Check whether the value is already formatted correctly with "value" and "effective_on" fields. If so, we're done
+	is_object(value)
+	value.effective_on
+	value.value
+} else := value if {
+	# If any of the above conditions fail, then wrap the original value with effective_on data.
+	value := {
+		"value": rule_data(key_name),
+		"effective_on": lib_time.default_effective_on,
+	}
 }

--- a/policy/lib/rule_data_test.rego
+++ b/policy/lib/rule_data_test.rego
@@ -26,6 +26,40 @@ test_rule_data if {
 		with lib.rule_data_defaults as {"key3": 10}
 }
 
+test_rule_data_append_effective_on if {
+	lib.assert_equal(
+		[
+			{
+				"value": 10,
+				"effective_on": lib.time.default_effective_on,
+			},
+			{
+				"value": 20,
+				"effective_on": "2024-01-01T00:00:00Z",
+			},
+			{
+				"value": 30,
+				"effective_on": "9999-01-01T00:00:00Z",
+			},
+		],
+		[
+			lib.rule_data_append_effective_on("key0"),
+			lib.rule_data_append_effective_on("key1"),
+			lib.rule_data_append_effective_on("key2"),
+		],
+	) with data.rule_data as {
+			"key0": 10,
+			"key1": {
+				"value": 20,
+				"effective_on": "2024-01-01T00:00:00Z",
+			},
+			"key2": {
+				"value": 30,
+				"effective_on": "9999-01-01T00:00:00Z",
+			},
+		}
+}
+
 # Need this for 100% coverage
 test_rule_data_defaults if {
 	lib.assert_not_empty(lib.rule_data_defaults)


### PR DESCRIPTION
This patch implements support for an `effective_on` key in data from `rule_data.yml`.

The patch works by transforming data with `effective_on` dates into a format the rest of the codebase will understand transparently, without breaking backwards compatibility.

Examples: As long as a key is formatted as such:

```yml
key:
  - value: "ec-policies"
    effective_on: "2024-01-01T00:00:00Z"
```

it will be reformatted to look like this:

```yml
key: "ec-policies"
```

On the other hand, if the date is not yet effective, the value will be empty.