### PR TITLE
Consolidate pruning of stale acceptable bundles

### DIFF
--- a/policy/lib/bundles_test.rego
+++ b/policy/lib/bundles_test.rego
@@ -133,94 +133,6 @@ test_missing_required_data if {
 	lib.assert_equal(bundles.missing_task_bundles_data, true)
 }
 
-test_newer_in_effect_version_exists_not_using_tags_newest if {
-	ref := image.parse("registry.io/repository/image:tag@sha256:digest")
-	acceptable := {"registry.io/repository/image": [{
-		"digest": "sha256:digest",
-		"tag": "",
-		"effective_on": "2262-04-11T00:00:00Z",
-	}]}
-	not bundles._newer_in_effect_version_exists(ref) with data["task-bundles"] as acceptable
-}
-
-test_newer_in_effect_version_exists_not_using_tags_older if {
-	ref := image.parse("registry.io/repository/image:tag@sha256:digest")
-	acceptable := {"registry.io/repository/image": [
-		{
-			"digest": "sha256:newer",
-			"tag": "",
-			"effective_on": "2022-04-11T00:00:00Z",
-		},
-		{
-			"digest": "sha256:digest",
-			"tag": "",
-			"effective_on": "1962-04-11T00:00:00Z",
-		},
-	]}
-	bundles._newer_in_effect_version_exists(ref) with data["task-bundles"] as acceptable
-}
-
-test_newer_in_effect_version_exists_tags_differ_newest if {
-	ref := image.parse("registry.io/repository/image:tag@sha256:digest")
-	acceptable := {"registry.io/repository/image": [{
-		"digest": "sha256:digest",
-		"tag": "different",
-		"effective_on": "2262-04-11T00:00:00Z",
-	}]}
-	not bundles._newer_in_effect_version_exists(ref) with data["task-bundles"] as acceptable
-}
-
-test_newer_in_effect_version_exists_tags_differ_older if {
-	ref := image.parse("registry.io/repository/image:tag@sha256:digest")
-	acceptable := {"registry.io/repository/image": [
-		{
-			"digest": "sha256:newer",
-			"tag": "newer",
-			"effective_on": "2022-04-11T00:00:00Z",
-		},
-		{
-			"digest": "sha256:digest",
-			"tag": "different",
-			"effective_on": "1962-04-11T00:00:00Z",
-		},
-	]}
-	bundles._newer_in_effect_version_exists(ref) with data["task-bundles"] as acceptable
-}
-
-test_newer_in_effect_version_exists_tags_as_versions_newest if {
-	ref := image.parse("registry.io/repository/image:v1@sha256:digest")
-	acceptable := {"registry.io/repository/image": [
-		{
-			"digest": "sha256:digest",
-			"tag": "v1",
-			"effective_on": "2262-04-11T00:00:00Z",
-		},
-		{
-			"digest": "sha256:different",
-			"tag": "v1",
-			"effective_on": "2162-04-11T00:00:00Z",
-		},
-	]}
-	not bundles._newer_in_effect_version_exists(ref) with data["task-bundles"] as acceptable
-}
-
-test_newer_in_effect_version_exists_tags_as_versions_older if {
-	ref := image.parse("registry.io/repository/image:v1@sha256:digest")
-	acceptable := {"registry.io/repository/image": [
-		{
-			"digest": "sha256:newer",
-			"tag": "v1",
-			"effective_on": "2022-04-11T00:00:00Z",
-		},
-		{
-			"digest": "sha256:digest",
-			"tag": "v1",
-			"effective_on": "1962-04-11T00:00:00Z",
-		},
-	]}
-	bundles._newer_in_effect_version_exists(ref) with data["task-bundles"] as acceptable
-}
-
 test_newer_version_exists_not_using_tags_newest if {
 	ref := image.parse("registry.io/repository/image:tag@sha256:digest")
 	acceptable := {"registry.io/repository/image": [{
@@ -320,4 +232,22 @@ test_is_acceptable if {
 
 	unacceptable_task := {"name": "my-task", "taskRef": {"bundle": "registry.io/other/image:tag@sha256:digest"}}
 	not bundles.is_acceptable_task(unacceptable_task) with data["task-bundles"] as acceptable
+}
+
+test_stale_entries_ignored if {
+	acceptable := {"registry.io/repository/image": [
+		{
+			"digest": "sha256:digest",
+			"effective_on": "2023-02-01T00:00:00Z",
+			"tag": "tag",
+		},
+		{
+			"digest": "sha256:digest",
+			"effective_on": "2023-01-01T00:00:00Z",
+			"tag": "tag",
+		},
+	]}
+
+	acceptable_task := {"name": "my-task", "taskRef": {"bundle": "registry.io/repository/image:tag@sha256:digest"}}
+	lib.assert_empty(bundles.unacceptable_task_bundle([acceptable_task])) with data["task-bundles"] as acceptable
 }

--- a/policy/pipeline/task_bundle_test.rego
+++ b/policy/pipeline/task_bundle_test.rego
@@ -74,10 +74,7 @@ test_acceptable_bundle_up_to_date_maintained_version if {
 
 # Warn about out of date bundles that are still acceptable.
 test_acceptable_bundle_out_of_date_past if {
-	tasks := [
-		{"name": "my-task-1", "taskRef": {"bundle": "reg.com/repo@sha256:bcd"}},
-		{"name": "my-task-2", "taskRef": {"bundle": "reg.com/repo@sha256:cde"}},
-	]
+	tasks := [{"name": "my-task-1", "taskRef": {"bundle": "reg.com/repo@sha256:bcd"}}]
 
 	lib.assert_equal_results(task_bundle.warn, {{
 		"code": "task_bundle.out_of_date_task_bundle",

--- a/policy/release/attestation_task_bundle_test.rego
+++ b/policy/release/attestation_task_bundle_test.rego
@@ -160,7 +160,7 @@ test_acceptable_bundle_up_to_date if {
 
 # Warn about out of date bundles that are still acceptable.
 test_acceptable_bundle_out_of_date_past if {
-	images := ["reg.com/repo@sha256:bcd", "reg.com/repo@sha256:cde"]
+	images := ["reg.com/repo@sha256:bcd"]
 	attestations := [
 		lib_test.mock_slsav02_attestation_bundles(images),
 		lib_test.mock_slsav1_attestation_bundles(images, "task-run-0"),


### PR DESCRIPTION
The list of acceptable bundles is time based. The presence of a record is not a sufficient indicator for it being valid. As time goes on and the effective_on date of records is reached, older entries fall off the list. Using those records is akin to using a record that is not on the list at all.

This commit introduces a helper function to prune old records from the list before the list is consumed. This consolidates the decision of which records should be ignored in a single place.

This fixes the related bug by ensuring stale records are used consistently across the code base.

It also removes/modifies certain tests which were asserting incorrect behavior.

Ref: RHTAPBUGS-1099