### PR TITLE
Add trusted_task package

### DIFF
--- a/example/data/trusted_tekton_tasks_git.yml
+++ b/example/data/trusted_tekton_tasks_git.yml
@@ -1,0 +1,21 @@
+---
+trusted_tasks:
+  git+https://github.com/redhat-appstudio/build-definitions.git//task/buildah/0.1/buildah.yaml:
+    - ref: 3672a457e3e89c0591369f609eba727b8e84108f
+      effective_on: 2024-02-16T00:00:00Z
+    - ref: 81185d669f543f5cd9114377f7ee0480e15a7ac1
+      effective_on: 2024-02-10T00:00:00Z
+
+  git+https://github.com/redhat-appstudio/build-definitions.git//task/clair-scan/0.1/clair-scan.yaml:
+    - ref: 28b86c8b94c42995d98f843b0fc854c1cf2ae500
+      effective_on: 2024-02-15T00:00:00Z
+    - ref: 4efdfc8c8da9f78602b5a21bcd2b3cf5667503fc
+      effective_on: 2024-01-31T00:00:00Z
+
+  oci://quay.io/redhat-appstudio-tekton-catalog/task-clamav-scan:0.1:
+    - ref: sha256:d72cb58db88289559676676c3db43906718028e07279f70ddb12ed8bdc8e2860
+      effective_on: "2023-11-01T00:00:00Z"
+
+  oci://quay.io/redhat-appstudio-tekton-catalog/task-git-clone:0.1:
+    - ref: sha256:b8fddc2d36313a5cde93aba2491205f4a84e6853af6c34ede681f8339b147478
+      effective_on: "2023-11-01T00:00:00Z"

--- a/policy/lib/refs.rego
+++ b/policy/lib/refs.rego
@@ -2,6 +2,8 @@ package lib.refs
 
 import rego.v1
 
+import data.lib.image
+
 # Return an object that represents the task "name", "kind", and "bundle". "bundle" is
 # omitted if a bundle is not used.
 #
@@ -17,62 +19,79 @@ task_ref(task) := i if {
 	# Handle old-style bundle reference
 	r := _ref(task)
 	bundle := r.bundle
-	i := {
-		"bundle": bundle,
-		"name": _ref_name(task),
-		"kind": lower(object.get(r, "kind", "task")),
-		"pinned": _has_digest(bundle),
-	}
+	pinned_ref := _pinned_ref_for_bundle(bundle)
+	i := _with_pinned_ref(
+		{
+			"bundle": bundle,
+			"name": _ref_name(task),
+			"kind": lower(object.get(r, "kind", "task")),
+			"key": _key_for_bundle(bundle),
+		},
+		pinned_ref,
+	)
 } else := i if {
 	# Handle bundle-resolver reference
 	r := _ref(task)
 	r.resolver == "bundles"
 	bundle := _param(r, "bundle", "")
-	i := {
-		"bundle": bundle,
-		"name": _ref_name(task),
-		"kind": lower(_param(r, "kind", "task")),
-		"pinned": _has_digest(bundle),
-	}
+	pinned_ref := _pinned_ref_for_bundle(bundle)
+	i := _with_pinned_ref(
+		{
+			"bundle": bundle,
+			"name": _ref_name(task),
+			"kind": lower(_param(r, "kind", "task")),
+			"key": _key_for_bundle(bundle),
+		},
+		pinned_ref,
+	)
 } else := i if {
 	r := _ref(task)
 	r.resolver == "git"
 	revision := _param(r, "revision", "")
-	i := {
-		"url": _param(r, "url", ""),
-		"revision": revision,
-		"pathInRepo": _param(r, "pathInRepo", ""),
-		"name": _ref_name(task),
-		"kind": lower(object.get(r, "kind", "task")),
-		"pinned": _is_sha1(revision),
-	}
+	url := _param(r, "url", "")
+	canonical_url := _with_git_suffix(_with_git_prefix(url))
+	path_in_repo := _param(r, "pathInRepo", "")
+	pinned_ref := _pinned_ref_for_git(revision)
+	i := _with_pinned_ref(
+		{
+			"url": url,
+			"revision": revision,
+			"pathInRepo": path_in_repo,
+			"name": _ref_name(task),
+			"kind": lower(object.get(r, "kind", "task")),
+			"key": _key_for_git(canonical_url, path_in_repo),
+		},
+		pinned_ref,
+	)
 } else := i if {
 	# Handle inlined Task definitions
 	_ref(task) == {}
-	i := {
-		# The Task definition itself is inlined without a name. Use a special value here to
-		# distinguish from other reference types.
-		"name": _no_task_name,
-		"kind": "task",
-		"pinned": true,
-	}
+	i := _with_pinned_ref(
+		{
+			# The Task definition itself is inlined without a name. Use a special value here to
+			# distinguish from other reference types.
+			"name": _no_task_name,
+			"kind": "task",
+			"key": _unkonwn_task_key,
+		},
+		_inlined_pinned_ref,
+	)
 } else := i if {
 	# Handle local reference
 	r := _ref(task)
-	i := {
-		"name": _ref_name(task),
-		"kind": lower(object.get(r, "kind", "task")),
-		"pinned": false,
-	}
+	i := _with_pinned_ref(
+		{
+			"name": _ref_name(task),
+			"kind": lower(object.get(r, "kind", "task")),
+			"key": _unkonwn_task_key,
+		},
+		"",
+	)
 }
 
 default _is_sha1(_) := false
 
 _is_sha1(value) if regex.match(`^[0-9a-f]{40}$`, value)
-
-default _has_digest(_) := false
-
-_has_digest(value) if contains(value, "@sha256:")
 
 _param(taskRef, name, fallback) := value if {
 	some param in taskRef.params
@@ -116,4 +135,49 @@ _ref_name(task) := name if {
 	name := _ref(task).name
 } else := _no_task_name
 
+_key_for_bundle(bundle) := key if {
+	parts := image.parse(bundle)
+	parts.tag != ""
+	key := sprintf("oci://%s:%s", [parts.repo, parts.tag])
+} else := key if {
+	parts := image.parse(bundle)
+	key := sprintf("oci://%s", [parts.repo])
+} else := sprintf("oci://%s", [bundle])
+
+_key_for_git(url, path_in_repo) := sprintf("%s//%s", [url, path_in_repo])
+
+_with_git_prefix(url) := with_prefix if {
+	not startswith(url, "git+")
+	with_prefix := sprintf("git+%s", [url])
+} else := url
+
+_with_git_suffix(url) := with_suffix if {
+	not endswith(url, ".git")
+	with_suffix := sprintf("%s.git", [url])
+} else := url
+
+_pinned_ref_for_bundle(bundle) := digest if {
+	parts := image.parse(bundle)
+	digest := parts.digest
+} else := ""
+
+_pinned_ref_for_git(revision) := commit if {
+	_is_sha1(revision)
+	commit := revision
+} else := ""
+
+_with_pinned_ref(obj, pinned_ref) := new_obj if {
+	pinned_ref != ""
+	new_obj := object.union(obj, {
+		"pinned": true,
+		"pinned_ref": pinned_ref,
+	})
+} else := new_obj if {
+	new_obj := object.union(obj, {"pinned": false})
+}
+
 _no_task_name := "<NAMELESS>"
+
+_inlined_pinned_ref := "<INLINED>"
+
+_unkonwn_task_key := "<UNKNOWN>"

--- a/policy/lib/refs_test.rego
+++ b/policy/lib/refs_test.rego
@@ -7,7 +7,13 @@ import data.lib.refs
 
 _image := "registry.img/test@sha256:digest"
 
+_image_key := "oci://registry.img/test"
+
+_image_digest := "sha256:digest"
+
 _unpinned_image := "registry.img/test:latest"
+
+_unpinned_image_key := "oci://registry.img/test:latest"
 
 _git_path := "tasks/test.yaml"
 
@@ -15,41 +21,43 @@ _git_commit := "48df630394794f28142224295851a45eea5c63ae"
 
 _git_branch := "main"
 
-_git_url := "git.local/repo.git"
+_git_url := "https://git.local/repo"
+
+_git_key := "git+https://git.local/repo.git//tasks/test.yaml"
 
 test_bundle_in_definition if {
 	lib.assert_equal(
 		refs.task_ref({"taskRef": {"bundle": _image, "name": "test", "kind": "Task"}}),
-		{"bundle": _image, "kind": "task", "name": "test", "pinned": true},
+		{"bundle": _image, "kind": "task", "name": "test", "pinned": true, "pinned_ref": _image_digest, "key": _image_key},
 	)
 
 	lib.assert_equal(
 		refs.task_ref({"taskRef": {"bundle": _unpinned_image, "name": "test", "kind": "Task"}}),
-		{"bundle": _unpinned_image, "kind": "task", "name": "test", "pinned": false},
+		{"bundle": _unpinned_image, "kind": "task", "name": "test", "pinned": false, "key": _unpinned_image_key},
 	)
 }
 
 test_bundle_in_slsa_v1_0 if {
 	lib.assert_equal(
 		refs.task_ref({"spec": {"taskRef": {"name": "test", "kind": "Task", "bundle": _image}}}),
-		{"bundle": _image, "kind": "task", "name": "test", "pinned": true},
+		{"bundle": _image, "kind": "task", "name": "test", "pinned": true, "pinned_ref": _image_digest, "key": _image_key},
 	)
 
 	lib.assert_equal(
 		refs.task_ref({"spec": {"taskRef": {"name": "test", "kind": "Task", "bundle": _unpinned_image}}}),
-		{"bundle": _unpinned_image, "kind": "task", "name": "test", "pinned": false},
+		{"bundle": _unpinned_image, "kind": "task", "name": "test", "pinned": false, "key": _unpinned_image_key},
 	)
 }
 
 test_bundle_in_slsa_v0_2 if {
 	lib.assert_equal(
 		refs.task_ref({"ref": {"name": "test", "kind": "Task", "bundle": _image}}),
-		{"bundle": _image, "kind": "task", "name": "test", "pinned": true},
+		{"bundle": _image, "kind": "task", "name": "test", "pinned": true, "pinned_ref": _image_digest, "key": _image_key},
 	)
 
 	lib.assert_equal(
 		refs.task_ref({"ref": {"name": "test", "kind": "Task", "bundle": _unpinned_image}}),
-		{"bundle": _unpinned_image, "kind": "task", "name": "test", "pinned": false},
+		{"bundle": _unpinned_image, "kind": "task", "name": "test", "pinned": false, "key": _unpinned_image_key},
 	)
 }
 
@@ -60,7 +68,7 @@ test_bundles_resolver_in_definition if {
 			{"name": "name", "value": "test"},
 			{"name": "kind", "value": "task"},
 		]}}),
-		{"bundle": _image, "kind": "task", "name": "test", "pinned": true},
+		{"bundle": _image, "kind": "task", "name": "test", "pinned": true, "pinned_ref": _image_digest, "key": _image_key},
 	)
 
 	lib.assert_equal(
@@ -69,7 +77,7 @@ test_bundles_resolver_in_definition if {
 			{"name": "name", "value": "test"},
 			{"name": "kind", "value": "task"},
 		]}}),
-		{"bundle": _unpinned_image, "kind": "task", "name": "test", "pinned": false},
+		{"bundle": _unpinned_image, "kind": "task", "name": "test", "pinned": false, "key": _unpinned_image_key},
 	)
 }
 
@@ -80,7 +88,7 @@ test_bundles_resolver_in_slsa_v1_0 if {
 			{"name": "name", "value": "test"},
 			{"name": "kind", "value": "task"},
 		]}}}),
-		{"bundle": _image, "kind": "task", "name": "test", "pinned": true},
+		{"bundle": _image, "kind": "task", "name": "test", "pinned": true, "pinned_ref": _image_digest, "key": _image_key},
 	)
 
 	lib.assert_equal(
@@ -89,7 +97,7 @@ test_bundles_resolver_in_slsa_v1_0 if {
 			{"name": "name", "value": "test"},
 			{"name": "kind", "value": "task"},
 		]}}}),
-		{"bundle": _unpinned_image, "kind": "task", "name": "test", "pinned": false},
+		{"bundle": _unpinned_image, "kind": "task", "name": "test", "pinned": false, "key": _unpinned_image_key},
 	)
 }
 
@@ -100,7 +108,7 @@ test_bundles_resolver_in_slsa_v0_2 if {
 			{"name": "name", "value": "test"},
 			{"name": "kind", "value": "task"},
 		]}}),
-		{"bundle": _image, "kind": "task", "name": "test", "pinned": true},
+		{"bundle": _image, "kind": "task", "name": "test", "pinned": true, "pinned_ref": _image_digest, "key": _image_key},
 	)
 
 	lib.assert_equal(
@@ -109,7 +117,7 @@ test_bundles_resolver_in_slsa_v0_2 if {
 			{"name": "name", "value": "test"},
 			{"name": "kind", "value": "task"},
 		]}}),
-		{"bundle": _unpinned_image, "kind": "task", "name": "test", "pinned": false},
+		{"bundle": _unpinned_image, "kind": "task", "name": "test", "pinned": false, "key": _unpinned_image_key},
 	)
 }
 
@@ -131,6 +139,8 @@ test_git_resolver_in_definition if {
 			"revision": _git_commit,
 			"url": _git_url,
 			"pinned": true,
+			"pinned_ref": _git_commit,
+			"key": _git_key,
 		},
 	)
 
@@ -147,6 +157,7 @@ test_git_resolver_in_definition if {
 			"revision": _git_branch,
 			"url": _git_url,
 			"pinned": false,
+			"key": _git_key,
 		},
 	)
 }
@@ -168,6 +179,8 @@ test_git_resolver_in_slsa_v1_0 if {
 			"revision": _git_commit,
 			"url": _git_url,
 			"pinned": true,
+			"pinned_ref": _git_commit,
+			"key": _git_key,
 		},
 	)
 
@@ -187,6 +200,7 @@ test_git_resolver_in_slsa_v1_0 if {
 			"revision": _git_branch,
 			"url": _git_url,
 			"pinned": false,
+			"key": _git_key,
 		},
 	)
 }
@@ -208,6 +222,8 @@ test_git_resolver_in_slsa_v0_2 if {
 			"revision": _git_commit,
 			"url": _git_url,
 			"pinned": true,
+			"pinned_ref": _git_commit,
+			"key": _git_key,
 		},
 	)
 
@@ -227,62 +243,95 @@ test_git_resolver_in_slsa_v0_2 if {
 			"revision": _git_branch,
 			"url": _git_url,
 			"pinned": false,
+			"key": _git_key,
 		},
+	)
+}
+
+test_git_resolver_canonical_key if {
+	task := {"ref": {"resolver": "git", "params": [
+		{"name": "url", "value": null},
+		{"name": "pathInRepo", "value": "pa/th"},
+	]}}
+
+	expected := "git+git.local/repo.git//pa/th"
+
+	lib.assert_equal(
+		refs.task_ref(json.patch(task, [{"op": "add", "path": "/ref/params/0/value", "value": "git.local/repo"}])).key,
+		expected,
+	)
+
+	lib.assert_equal(
+		refs.task_ref(json.patch(task, [{"op": "add", "path": "/ref/params/0/value", "value": "git.local/repo.git"}])).key,
+		expected,
+	)
+
+	lib.assert_equal(
+		refs.task_ref(json.patch(task, [{"op": "add", "path": "/ref/params/0/value", "value": "git+git.local/repo"}])).key,
+		expected,
+	)
+
+	lib.assert_equal(
+		# regal ignore:line-length
+		refs.task_ref(json.patch(task, [{"op": "add", "path": "/ref/params/0/value", "value": "git+git.local/repo.git"}])).key,
+		expected,
 	)
 }
 
 test_inlined_task_in_definition if {
 	lib.assert_equal(
 		refs.task_ref({"taskSpec": {"params": [], "steps": []}}),
-		{"kind": "task", "name": refs._no_task_name, "pinned": true},
+		{"kind": "task", "name": refs._no_task_name, "pinned": true, "pinned_ref": "<INLINED>", "key": "<UNKNOWN>"},
 	)
 }
 
 test_inlined_task_in_slsa_v1_0 if {
 	lib.assert_equal(
 		refs.task_ref({"spec": {"taskSpec": {"steps": [], "params": []}}}),
-		{"kind": "task", "name": refs._no_task_name, "pinned": true},
+		{"kind": "task", "name": refs._no_task_name, "pinned": true, "pinned_ref": "<INLINED>", "key": "<UNKNOWN>"},
 	)
 }
 
 test_inlined_task_in_slsa_v0_2 if {
 	lib.assert_equal(
 		refs.task_ref({"ref": {}}),
-		{"kind": "task", "name": refs._no_task_name, "pinned": true},
+		{"kind": "task", "name": refs._no_task_name, "pinned": true, "pinned_ref": "<INLINED>", "key": "<UNKNOWN>"},
 	)
 }
 
 test_local_task_in_definition if {
 	lib.assert_equal(
 		refs.task_ref({"taskRef": {"name": "test", "kind": "Task"}}),
-		{"kind": "task", "name": "test", "pinned": false},
+		{"kind": "task", "name": "test", "pinned": false, "key": "<UNKNOWN>"},
 	)
 }
 
 test_local_task_in_slsa_v1_0 if {
 	lib.assert_equal(
 		refs.task_ref({"spec": {"taskRef": {"name": "test", "kind": "Task"}}}),
-		{"kind": "task", "name": "test", "pinned": false},
+		{"kind": "task", "name": "test", "pinned": false, "key": "<UNKNOWN>"},
 	)
 }
 
 test_local_task_in_slsa_v0_2 if {
 	lib.assert_equal(
 		refs.task_ref({"ref": {"name": "test", "kind": "Task"}}),
-		{"kind": "task", "name": "test", "pinned": false},
+		{"kind": "task", "name": "test", "pinned": false, "key": "<UNKNOWN>"},
 	)
 }
 
 test_bundle_with_defaults if {
 	lib.assert_equal(
 		refs.task_ref({"ref": {"bundle": _image}}),
-		{"bundle": _image, "kind": "task", "name": refs._no_task_name, "pinned": true},
+		# regal ignore:line-length
+		{"bundle": _image, "kind": "task", "name": refs._no_task_name, "pinned": true, "pinned_ref": _image_digest, "key": _image_key},
 	)
 }
 
 test_bundle_resolver_with_defaults if {
 	lib.assert_equal(
 		refs.task_ref({"ref": {"resolver": "bundles", "params": [{"name": "bundle", "value": _image}]}}),
-		{"bundle": _image, "kind": "task", "name": refs._no_task_name, "pinned": true},
+		# regal ignore:line-length
+		{"bundle": _image, "kind": "task", "name": refs._no_task_name, "pinned": true, "pinned_ref": _image_digest, "key": _image_key},
 	)
 }

--- a/policy/lib/tekton/trusted.rego
+++ b/policy/lib/tekton/trusted.rego
@@ -1,0 +1,61 @@
+package lib.tkn
+
+import rego.v1
+
+import data.lib.refs
+import data.lib.time as time_lib
+
+# Returns a subset of tasks that use unpinned Task references.
+unpinned_task_references(tasks) := {task |
+	some task in tasks
+	not refs.task_ref(task).pinned
+}
+
+# Returns if the list of trusted Tasks are missing
+default missing_trusted_tasks_data := false
+
+missing_trusted_tasks_data if {
+	count(_trusted_tasks) == 0
+}
+
+# Returns a subset of tasks that use a trusted Task reference, but an updated Task reference exists.
+out_of_date_task_refs(tasks) := {task |
+	some task in tasks
+	is_trusted_task(task)
+	_newer_record_exists(task)
+}
+
+# Returns a subset of tasks that do not use a trusted Task reference.
+untrusted_task_refs(tasks) := {task |
+	some task in tasks
+	not is_trusted_task(task)
+}
+
+# Returns true if the task uses a trusted Task reference.
+is_trusted_task(task) if {
+	ref := refs.task_ref(task)
+	records := _trusted_tasks[ref.key]
+
+	some record in records
+
+	# A trusted task reference is one that is recorded in the trusted tasks data, this is done by
+	# matching its pinned reference; note no care is given to the expiry or freshness since expired
+	# records have already been filtered out.
+	record.ref == ref.pinned_ref
+}
+
+# Returns true if a newer record exists with a different digest.
+_newer_record_exists(task) if {
+	ref := refs.task_ref(task)
+	records := _trusted_tasks[ref.key]
+
+	newest_record := time_lib.newest(records)
+	newest_record.ref != ref.pinned_ref
+}
+
+# _trusted_tasks provides a safe way to access the list of trusted tasks. It prevents a policy rule
+# from incorrectly not evaluating due to missing data. It also removes stale records.
+_trusted_tasks[key] := pruned_records if {
+	some key, records in data.trusted_tasks
+	pruned_records := time_lib.acceptable_items(records)
+}

--- a/policy/lib/tekton/trusted_test.rego
+++ b/policy/lib/tekton/trusted_test.rego
@@ -1,0 +1,186 @@
+package lib.tkn_test
+
+import rego.v1
+
+import data.lib
+import data.lib.tkn
+
+test_unpinned_task_references if {
+	tasks := [
+		trusted_bundle_task,
+		unpinned_bundle_task,
+		trusted_git_task,
+		unpinned_git_task,
+	]
+
+	expected := {unpinned_bundle_task, unpinned_git_task}
+
+	lib.assert_equal(expected, tkn.unpinned_task_references(tasks)) with data.trusted_tasks as trusted_tasks
+}
+
+test_missing_trusted_tasks_data if {
+	lib.assert_equal(true, tkn.missing_trusted_tasks_data)
+
+	lib.assert_equal(false, tkn.missing_trusted_tasks_data) with data.trusted_tasks as trusted_tasks
+}
+
+test_out_of_date_task_refs if {
+	tasks := [
+		newest_trusted_bundle_task,
+		outdated_trusted_bundle_task,
+		newest_trusted_git_task,
+		outdated_trusted_git_task,
+	]
+
+	expected := {outdated_trusted_bundle_task, outdated_trusted_git_task}
+
+	lib.assert_equal(expected, tkn.out_of_date_task_refs(tasks)) with data.trusted_tasks as trusted_tasks
+}
+
+test_untrusted_task_refs if {
+	tasks := [
+		trusted_bundle_task,
+		untrusted_bundle_task,
+		expired_trusted_bundle_task,
+		trusted_git_task,
+		untrusted_git_task,
+		expired_trusted_git_task,
+	]
+
+	expected := {untrusted_bundle_task, expired_trusted_bundle_task, untrusted_git_task, expired_trusted_git_task}
+
+	lib.assert_equal(expected, tkn.untrusted_task_refs(tasks)) with data.trusted_tasks as trusted_tasks
+}
+
+test_is_trusted_task if {
+	tkn.is_trusted_task(trusted_bundle_task) with data.trusted_tasks as trusted_tasks
+	tkn.is_trusted_task(trusted_git_task) with data.trusted_tasks as trusted_tasks
+
+	not tkn.is_trusted_task(untrusted_bundle_task) with data.trusted_tasks as trusted_tasks
+	not tkn.is_trusted_task(untrusted_git_task) with data.trusted_tasks as trusted_tasks
+
+	tkn.is_trusted_task(newest_trusted_bundle_task) with data.trusted_tasks as future_trusted_tasks
+	tkn.is_trusted_task(newest_trusted_git_task) with data.trusted_tasks as future_trusted_tasks
+}
+
+trusted_bundle_task := {"spec": {"taskRef": {"resolver": "bundles", "params": [
+	{"name": "bundle", "value": "registry.local/trusty:1.0@sha256:digest"},
+	{"name": "name", "value": "trusty"},
+	{"name": "kind", "value": "task"},
+]}}}
+
+newest_trusted_bundle_task := trusted_bundle_task
+
+outdated_trusted_bundle_task := {"spec": {"taskRef": {"resolver": "bundles", "params": [
+	{"name": "bundle", "value": "registry.local/trusty:1.0@sha256:outdated-digest"},
+	{"name": "name", "value": "trusty"},
+	{"name": "kind", "value": "task"},
+]}}}
+
+expired_trusted_bundle_task := {"spec": {"taskRef": {"resolver": "bundles", "params": [
+	{"name": "bundle", "value": "registry.local/trusty:1.0@sha256:expired-digest"},
+	{"name": "name", "value": "trusty"},
+	{"name": "kind", "value": "task"},
+]}}}
+
+unpinned_bundle_task := {"spec": {"taskRef": {"resolver": "bundles", "params": [
+	{"name": "bundle", "value": "registry.local/trusty:1.0"},
+	{"name": "name", "value": "crook"},
+	{"name": "kind", "value": "task"},
+]}}}
+
+untrusted_bundle_task := {"spec": {"taskRef": {"resolver": "bundles", "params": [
+	{"name": "bundle", "value": "registry.local/crook:1.0@sha256:digest"},
+	{"name": "name", "value": "crook"},
+	{"name": "kind", "value": "task"},
+]}}}
+
+trusted_git_task := {
+	"metadata": {"labels": {"tekton.dev/task": "honest-abe"}},
+	"spec": {"taskRef": {"resolver": "git", "params": [
+		{"name": "revision", "value": "48df630394794f28142224295851a45eea5c63ae"},
+		{"name": "pathInRepo", "value": "tasks/honest-abe.yaml"},
+		{"name": "url", "value": "git.local/repo.git"},
+	]}},
+}
+
+newest_trusted_git_task := trusted_git_task
+
+outdated_trusted_git_task := {
+	"metadata": {"labels": {"tekton.dev/task": "honest-abe"}},
+	"spec": {"taskRef": {"resolver": "git", "params": [
+		{"name": "revision", "value": "37ef630394794f28142224295851a45eea5c63ae"},
+		{"name": "pathInRepo", "value": "tasks/honest-abe.yaml"},
+		{"name": "url", "value": "git.local/repo.git"},
+	]}},
+}
+
+expired_trusted_git_task := {
+	"metadata": {"labels": {"tekton.dev/task": "honest-abe"}},
+	"spec": {"taskRef": {"resolver": "git", "params": [
+		{"name": "revision", "value": "26ef630394794f28142224295851a45eea5c63ae"},
+		{"name": "pathInRepo", "value": "tasks/honest-abe.yaml"},
+		{"name": "url", "value": "git.local/repo.git"},
+	]}},
+}
+
+unpinned_git_task := {
+	"metadata": {"labels": {"tekton.dev/task": "honest-abe"}},
+	"spec": {"taskRef": {"resolver": "git", "params": [
+		{"name": "revision", "value": "main"},
+		{"name": "pathInRepo", "value": "tasks/honest-abe.yaml"},
+		{"name": "url", "value": "git.local/repo.git"},
+	]}},
+}
+
+untrusted_git_task := {
+	"metadata": {"labels": {"tekton.dev/task": "lawless"}},
+	"spec": {"taskRef": {"resolver": "git", "params": [
+		{"name": "revision", "value": "37ef630394794f28142224295851a45eea5c63ae"},
+		{"name": "pathInRepo", "value": "tasks/lawless.yaml"},
+		{"name": "url", "value": "git.local/repo.git"},
+	]}},
+}
+
+trusted_tasks := {
+	"oci://registry.local/trusty:1.0": [
+		{
+			"ref": "sha256:digest",
+			"effective_on": "2099-01-01T00:00:00Z",
+		},
+		{
+			"ref": "sha256:outdated-digest",
+			"effective_on": "2024-01-01T00:00:00Z",
+		},
+		{
+			"ref": "sha256:expired-digest",
+			"effective_on": "2023-01-01T00:00:00Z",
+		},
+	],
+	"git+git.local/repo.git//tasks/honest-abe.yaml": [
+		{
+			"ref": "48df630394794f28142224295851a45eea5c63ae",
+			"effective_on": "2099-01-01T00:00:00Z",
+		},
+		{
+			"ref": "37ef630394794f28142224295851a45eea5c63ae",
+			"effective_on": "2024-01-01T00:00:00Z",
+		},
+		{
+			"ref": "26ef630394794f28142224295851a45eea5c63ae",
+			"effective_on": "2023-01-01T00:00:00Z",
+		},
+	],
+}
+
+# Corner case where all entries are in the future.
+future_trusted_tasks := {
+	"oci://registry.local/trusty:1.0": [{
+		"ref": "sha256:digest",
+		"effective_on": "2099-01-01T00:00:00Z",
+	}],
+	"git+git.local/repo.git//tasks/honest-abe.yaml": [{
+		"ref": "48df630394794f28142224295851a45eea5c63ae",
+		"effective_on": "2099-01-01T00:00:00Z",
+	}],
+}

--- a/policy/release/trusted_task.rego
+++ b/policy/release/trusted_task.rego
@@ -1,0 +1,99 @@
+#
+# METADATA
+# title: Trusted Task checks
+# description: >-
+#   This package is used to verify all the Tekton Tasks involved in building the image are trusted.
+#   Trust is established by comparing the Task references found in the SLSA Provenance with the
+#   pre-defined list of trusted Tasks. The list is customized via the `trusted_tasks` rule data key.
+#
+package policy.release.trusted_task
+
+import rego.v1
+
+import data.lib
+import data.lib.refs
+import data.lib.tkn
+
+# TODO: Add these rules to the redhat collection when all the pieces are in place.
+
+# METADATA
+# title: Pinned
+# description: >-
+#   Check if all Tekton Tasks use a Task definition by a pinned reference. When using the git
+#   resolver, a commit ID is expected for the revision parameter. When using the bundles resolver,
+#   the bundle parameter is expected to include an image reference with a digest.
+# custom:
+#   short_name: pinned
+#   failure_msg: Pipeline task %q uses an unpinned task reference, %s
+#   solution: >-
+#     Update the Pipeline definition so that all Task references have a pinned value as mentioned
+#     in the description.
+#
+warn contains result if {
+	some task in tkn.unpinned_task_references(lib.tasks_from_pipelinerun)
+	result := lib.result_helper_with_term(
+		rego.metadata.chain(),
+		[tkn.pipeline_task_name(task), _task_info(task)],
+		tkn.task_name(task),
+	)
+}
+
+# METADATA
+# title: Current
+# description: >-
+#   Check if all Tekton Tasks use the latest known Task reference.
+# custom:
+#   short_name: current
+#   failure_msg: Pipeline task %q uses an out of date task reference, %s
+#   solution: >-
+#     Update the Task reference to a newer version.
+#
+warn contains result if {
+	some task in tkn.out_of_date_task_refs(lib.tasks_from_pipelinerun)
+	result := lib.result_helper_with_term(
+		rego.metadata.chain(),
+		[tkn.pipeline_task_name(task), _task_info(task)],
+		tkn.task_name(task),
+	)
+}
+
+# METADATA
+# title: Trusted
+# description: >-
+#   Check if all Tekton Tasks use a trusted Task reference.
+# custom:
+#   short_name: trusted
+#   failure_msg: Pipeline task %q uses an untrusted task reference, %s
+#   solution: >-
+#     For each Task in the SLSA Provenance attestation, check if the Tekton Bundle used is
+#     an xref:acceptable_bundles.adoc#_task_bundles[acceptable bundle].
+#
+deny contains result if {
+	some task in tkn.untrusted_task_refs(lib.tasks_from_pipelinerun)
+	result := lib.result_helper_with_term(
+		rego.metadata.chain(),
+		[tkn.pipeline_task_name(task), _task_info(task)],
+		tkn.task_name(task),
+	)
+}
+
+# METADATA
+# title: Data
+# description: >-
+#   Confirm the `trusted_tasks` rule data was provided, since it's required by the policy rules in
+#   this package.
+# custom:
+#   short_name: data
+#   failure_msg: Missing required trusted_tasks data
+#   solution: >-
+#     Create a, or use an existing, trusted tasks list as a data source.
+#
+deny contains result if {
+	tkn.missing_trusted_tasks_data
+	result := lib.result_helper(rego.metadata.chain(), [])
+}
+
+_task_info(task) := info if {
+	ref := refs.task_ref(task)
+	info := sprintf("%s@%s", [object.get(ref, "key", ""), object.get(ref, "pinned_ref", "")])
+}

--- a/policy/release/trusted_task_test.rego
+++ b/policy/release/trusted_task_test.rego
@@ -1,0 +1,284 @@
+package policy.release.trusted_task_test
+
+import rego.v1
+
+import data.lib
+import data.policy.release.trusted_task
+
+test_success if {
+	att := {"statement": {"predicate": {
+		"buildType": lib.tekton_pipeline_run,
+		"buildConfig": {"tasks": [
+			newest_bundle_pipeline_task,
+			newest_git_pipeline_task,
+		]},
+	}}}
+
+	lib.assert_empty(trusted_task.warn | trusted_task.deny, expected) with input.attestations as [att]
+		with data.trusted_tasks as trusted_tasks_data
+}
+
+test_pinned_warning if {
+	att := {"statement": {"predicate": {
+		"buildType": lib.tekton_pipeline_run,
+		"buildConfig": {"tasks": [
+			trusted_bundle_pipeline_task,
+			unpinned_bundle_pipeline_task,
+			trusted_git_pipeline_task,
+			unpinned_git_pipeline_task,
+		]},
+	}}}
+
+	expected := {
+		{
+			"code": "trusted_task.pinned",
+			# regal ignore:line-length
+			"msg": "Pipeline task \"unpinned-honest-abe-p\" uses an unpinned task reference, git+git.local/repo.git//tasks/honest-abe.yaml@", "term": "honest-abe",
+		},
+		{
+			"code": "trusted_task.pinned",
+			# regal ignore:line-length
+			"msg": "Pipeline task \"unpinned-trusty-p\" uses an unpinned task reference, oci://registry.local/trusty:1.0@", "term": "trusty",
+		},
+	}
+
+	lib.assert_equal_results(trusted_task.warn, expected) with input.attestations as [att]
+		with data.trusted_tasks as trusted_tasks_data
+}
+
+test_outdated_warning if {
+	att := {"statement": {"predicate": {
+		"buildType": lib.tekton_pipeline_run,
+		"buildConfig": {"tasks": [
+			trusted_bundle_pipeline_task,
+			outdated_bundle_pipeline_task,
+			trusted_git_pipeline_task,
+			outdated_git_pipeline_task,
+		]},
+	}}}
+
+	expected := {
+		{
+			"code": "trusted_task.current",
+			# regal ignore:line-length
+			"msg": "Pipeline task \"outadated-honest-abe-p\" uses an out of date task reference, git+git.local/repo.git//tasks/honest-abe.yaml@37ef630394794f28142224295851a45eea5c63ae",
+			"term": "honest-abe",
+		},
+		{
+			"code": "trusted_task.current",
+			# regal ignore:line-length
+			"msg": "Pipeline task \"outdated-trusty-p\" uses an out of date task reference, oci://registry.local/trusty:1.0@sha256:outdated-digest",
+			"term": "trusty",
+		},
+	}
+
+	lib.assert_equal_results(trusted_task.warn, expected) with input.attestations as [att]
+		with data.trusted_tasks as trusted_tasks_data
+}
+
+test_trusted_violation if {
+	att := {"statement": {"predicate": {
+		"buildType": lib.tekton_pipeline_run,
+		"buildConfig": {"tasks": [
+			trusted_bundle_pipeline_task,
+			outdated_bundle_pipeline_task,
+			unknown_bundle_pipeline_task,
+			expired_bundle_pipeline_task,
+			trusted_git_pipeline_task,
+			outdated_git_pipeline_task,
+			unknown_git_pipeline_task,
+			expired_git_pipeline_task,
+			inlined_pipeline_task,
+		]},
+	}}}
+
+	expected := {
+		{
+			"code": "trusted_task.trusted",
+			"msg": "Pipeline task \"crook-p\" uses an untrusted task reference, oci://registry.local/crook:1.0@sha256:digest",
+			"term": "crook",
+		},
+		{
+			"code": "trusted_task.trusted",
+			# regal ignore:line-length
+			"msg": "Pipeline task \"expired-honest-abe-p\" uses an untrusted task reference, git+git.local/repo.git//tasks/honest-abe.yaml@26ef630394794f28142224295851a45eea5c63ae",
+			"term": "honest-abe",
+		},
+		{
+			"code": "trusted_task.trusted",
+			# regal ignore:line-length
+			"msg": "Pipeline task \"expired-trusty-p\" uses an untrusted task reference, oci://registry.local/trusty:1.0@sha256:expired-digest",
+			"term": "trusty",
+		},
+		{
+			# regal ignore:line-length
+			"code": "trusted_task.trusted", "msg": "Pipeline task \"inlined-p\" uses an untrusted task reference, <UNKNOWN>@<INLINED>",
+			"term": "<NAMELESS>",
+		},
+		{
+			"code": "trusted_task.trusted",
+			# regal ignore:line-length
+			"msg": "Pipeline task \"untrusted-lawless-p\" uses an untrusted task reference, git+git.local/repo.git//tasks/lawless.yaml@37ef630394794f28142224295851a45eea5c63ae",
+			"term": "lawless",
+		},
+	}
+
+	lib.assert_equal_results(trusted_task.deny, expected) with input.attestations as [att]
+		with data.trusted_tasks as trusted_tasks_data
+}
+
+test_data_missing if {
+	expected := {{"code": "trusted_task.data", "msg": "Missing required trusted_tasks data"}}
+	lib.assert_equal_results(trusted_task.deny, expected) with data.trusted_tasks as []
+}
+
+#########################################
+# Pipeline Tasks using bundles resolver #
+#########################################
+
+trusted_bundle_pipeline_task := {
+	"name": "trusty-p",
+	"ref": {"resolver": "bundles", "params": [
+		{"name": "bundle", "value": "registry.local/trusty:1.0@sha256:digest"},
+		{"name": "name", "value": "trusty"},
+		{"name": "kind", "value": "task"},
+	]},
+}
+
+newest_bundle_pipeline_task := trusted_bundle_pipeline_task
+
+outdated_bundle_pipeline_task := {
+	"name": "outdated-trusty-p",
+	"ref": {"resolver": "bundles", "params": [
+		{"name": "bundle", "value": "registry.local/trusty:1.0@sha256:outdated-digest"},
+		{"name": "name", "value": "trusty"},
+		{"name": "kind", "value": "task"},
+	]},
+}
+
+expired_bundle_pipeline_task := {
+	"name": "expired-trusty-p",
+	"ref": {"resolver": "bundles", "params": [
+		{"name": "bundle", "value": "registry.local/trusty:1.0@sha256:expired-digest"},
+		{"name": "name", "value": "trusty"},
+		{"name": "kind", "value": "task"},
+	]},
+}
+
+unpinned_bundle_pipeline_task := {
+	"name": "unpinned-trusty-p",
+	"ref": {"resolver": "bundles", "params": [
+		{"name": "bundle", "value": "registry.local/trusty:1.0"},
+		{"name": "name", "value": "trusty"},
+		{"name": "kind", "value": "task"},
+	]},
+}
+
+unknown_bundle_pipeline_task := {
+	"name": "crook-p",
+	"ref": {"resolver": "bundles", "params": [
+		{"name": "bundle", "value": "registry.local/crook:1.0@sha256:digest"},
+		{"name": "name", "value": "crook"},
+		{"name": "kind", "value": "task"},
+	]},
+}
+
+#####################################
+# Pipeline Tasks using git resolver #
+#####################################
+
+trusted_git_pipeline_task := {
+	"name": "honest-abe-p",
+	"ref": {"resolver": "git", "params": [
+		{"name": "revision", "value": "48df630394794f28142224295851a45eea5c63ae"},
+		{"name": "pathInRepo", "value": "tasks/honest-abe.yaml"},
+		{"name": "url", "value": "git.local/repo.git"},
+	]},
+	"invocation": {"environment": {"labels": {"tekton.dev/task": "honest-abe"}}},
+}
+
+newest_git_pipeline_task := trusted_git_pipeline_task
+
+outdated_git_pipeline_task := {
+	"name": "outadated-honest-abe-p",
+	"ref": {"resolver": "git", "params": [
+		{"name": "revision", "value": "37ef630394794f28142224295851a45eea5c63ae"},
+		{"name": "pathInRepo", "value": "tasks/honest-abe.yaml"},
+		{"name": "url", "value": "git.local/repo.git"},
+	]},
+	"invocation": {"environment": {"labels": {"tekton.dev/task": "honest-abe"}}},
+}
+
+expired_git_pipeline_task := {
+	"name": "expired-honest-abe-p",
+	"ref": {"resolver": "git", "params": [
+		{"name": "revision", "value": "26ef630394794f28142224295851a45eea5c63ae"},
+		{"name": "pathInRepo", "value": "tasks/honest-abe.yaml"},
+		{"name": "url", "value": "git.local/repo.git"},
+	]},
+	"invocation": {"environment": {"labels": {"tekton.dev/task": "honest-abe"}}},
+}
+
+unpinned_git_pipeline_task := {
+	"name": "unpinned-honest-abe-p",
+	"ref": {"resolver": "git", "params": [
+		{"name": "revision", "value": "main"},
+		{"name": "pathInRepo", "value": "tasks/honest-abe.yaml"},
+		{"name": "url", "value": "git.local/repo.git"},
+	]},
+	"invocation": {"environment": {"labels": {"tekton.dev/task": "honest-abe"}}},
+}
+
+unknown_git_pipeline_task := {
+	"name": "untrusted-lawless-p",
+	"ref": {"resolver": "git", "params": [
+		{"name": "revision", "value": "37ef630394794f28142224295851a45eea5c63ae"},
+		{"name": "pathInRepo", "value": "tasks/lawless.yaml"},
+		{"name": "url", "value": "git.local/repo.git"},
+	]},
+	"invocation": {"environment": {"labels": {"tekton.dev/task": "lawless"}}},
+}
+
+##########################
+# Inlined Pipeline Tasks #
+##########################
+
+inlined_pipeline_task := {
+	"name": "inlined-p",
+	"ref": {},
+}
+
+######################
+# Trusted Tasks data #
+######################
+
+trusted_tasks_data := {
+	"oci://registry.local/trusty:1.0": [
+		{
+			"ref": "sha256:digest",
+			"effective_on": "2099-01-01T00:00:00Z",
+		},
+		{
+			"ref": "sha256:outdated-digest",
+			"effective_on": "2024-01-01T00:00:00Z",
+		},
+		{
+			"ref": "sha256:expired-digest",
+			"effective_on": "2023-01-01T00:00:00Z",
+		},
+	],
+	"git+git.local/repo.git//tasks/honest-abe.yaml": [
+		{
+			"ref": "48df630394794f28142224295851a45eea5c63ae",
+			"effective_on": "2099-01-01T00:00:00Z",
+		},
+		{
+			"ref": "37ef630394794f28142224295851a45eea5c63ae",
+			"effective_on": "2024-01-01T00:00:00Z",
+		},
+		{
+			"ref": "26ef630394794f28142224295851a45eea5c63ae",
+			"effective_on": "2023-01-01T00:00:00Z",
+		},
+	],
+}


### PR DESCRIPTION
This new package allows verifying that a certain Task is trusted. It supports both the bundles and the git resolvers.

Eventually, this will supersede the attestation_task_bundle package.

Ref: EC-186