### PR TITLE
live-test: interrupt execution on new events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ quiet-test: ## Run all tests in quiet mode and check coverage
 live-test: ## Continuously run tests on changes to any `*.rego` files, `entr` needs to be installed
 	@trap exit SIGINT; \
 	while true; do \
-	  git ls-files -c -o '*.rego' | entr -d -c $(MAKE) --no-print-directory quiet-test; \
+	  git ls-files -c -o '*.rego' | entr -r -d -c $(MAKE) --no-print-directory quiet-test; \
 	done
 
 ##


### PR DESCRIPTION
This change makes it so `make live-test` does not miss file updates. Prior to this change, if a file was modified while the test command was still running, the tests would not get triggered for those changes. Now, the current test is interrupted and restarted.