### PR TITLE
Add labels.optional_disallowed_inherited_labels

### DIFF
--- a/policy/release/labels.rego
+++ b/policy/release/labels.rego
@@ -115,6 +115,31 @@ deny contains result if {
 }
 
 # METADATA
+# title: Optional disallowed inherited labels
+# description: >-
+#   Check that certain labels on the image have different values than the labels
+#   from the parent image. If the label is inherited from the parent image but not
+#   redefined for the image, it will contain an incorrect value for the image.
+#   Use the rule data `optional_disallowed_inherited_labels` key to set the list of
+#   labels to check.
+# custom:
+#   short_name: optional_disallowed_inherited_labels
+#   failure_msg: >-
+#     The %q label should not be inherited from the parent image. This will be a
+#     violation in the future.
+#   solution: >-
+#     Update the image build process to overwrite the inherited labels.
+#   collections:
+#   - redhat
+#
+warn contains result if {
+	some inherited_label in lib.rule_data("optional_disallowed_inherited_labels")
+	name := inherited_label.name
+	_value(labels, name) == _value(parent_labels, name)
+	result := lib.result_helper_with_term(rego.metadata.chain(), [name], name)
+}
+
+# METADATA
 # title: Rule data provided
 # description: >-
 #   Confirm the expected rule data keys have been provided in the expected format. The keys are
@@ -223,6 +248,7 @@ _rule_data_errors contains msg if {
 		["optional_labels", name_and_description],
 		["fbc_optional_labels", name_and_description],
 		["disallowed_inherited_labels", name_only],
+		["optional_disallowed_inherited_labels", name_only],
 		["fbc_disallowed_inherited_labels", name_only],
 		["deprecated_labels", deprecated],
 	]

--- a/policy/release/labels_test.rego
+++ b/policy/release/labels_test.rego
@@ -131,6 +131,35 @@ test_fbc_disallowed_inherited_image_labels if {
 		with data.rule_data as _rule_data
 }
 
+test_optional_disallowed_inherited_image_labels if {
+	expected := {{
+		"code": "labels.optional_disallowed_inherited_labels",
+		# regal ignore:line-length
+		"msg": "The \"optional.unique\" label should not be inherited from the parent image. This will be a violation in the future.",
+		"term": "optional.unique",
+	}}
+
+	image := json.patch(_image, [
+		{"op": "add", "path": "/config/Labels/optional.unique", "value": "spam"},
+		{"op": "add", "path": "/parent/config/Labels/optional.unique", "value": "spam"},
+	])
+	lib.assert_equal_results(labels.warn, expected) with input.image as image with data.rule_data as _rule_data
+
+	# A missing label on either image does not trigger a warning.
+	lib.assert_empty(labels.warn) with input.image as json.patch(_image, [{
+		"op": "add",
+		"path": "/config/Labels/optional.unique",
+		"value": "spam",
+	}])
+		with data.rule_data as _rule_data
+	lib.assert_empty(labels.warn) with input.image as json.patch(_image, [{
+		"op": "add",
+		"path": "/parent/config/Labels/optional.unique",
+		"value": "spam",
+	}])
+		with data.rule_data as _rule_data
+}
+
 test_rule_data_provided if {
 	d := {
 		"required_labels": [
@@ -268,4 +297,5 @@ _rule_data := {
 	"fbc_optional_labels": [{"name": "fbc.summary", "description": "A short description of the FBC image."}],
 	"disallowed_inherited_labels": [{"name": "unique"}],
 	"fbc_disallowed_inherited_labels": [{"name": "fbc.unique"}],
+	"optional_disallowed_inherited_labels": [{"name": "optional.unique"}],
 }


### PR DESCRIPTION
Add a new rule to warn users about, currently, optional labels that must not be inherited from the parent image.

Ref: EC-144