### PR TITLE
WIP: Add a function to wrap values from `rule_data.yml` with `effective_on` metadata

### DIFF
--- a/policy/lib/rule_data.rego
+++ b/policy/lib/rule_data.rego
@@ -1,5 +1,7 @@
 package lib
 
+import data.lib.time as lib_time
+
 import rego.v1
 
 # Values in data.rule_data_custom or data.rule_data
@@ -108,4 +110,23 @@ rule_data(key_name) := value if {
 } else := value if {
 	# If the key is not found, default to an empty list
 	value := []
+}
+
+
+# Wraps a value from rule_data in an object that contains an effective_on time, if not already present.
+#
+rule_data_append_effective_on(key_name) := value if {
+	# Retrieve original rule_data value
+	value := rule_data(key_name)
+
+	# Check whether the value is already formatted correctly with "value" and "effective_on" fields. If so, we're done
+	is_object(value)
+	value.effective_on
+	value.value
+} else := value if {
+	# If any of the above conditions fail, then wrap the original value with effective_on data.
+	value := {
+		"value": rule_data(key_name),
+		"effective_on": lib_time.default_effective_on,
+	}
 }

--- a/policy/lib/rule_data_test.rego
+++ b/policy/lib/rule_data_test.rego
@@ -26,6 +26,40 @@ test_rule_data if {
 		with lib.rule_data_defaults as {"key3": 10}
 }
 
+test_rule_data_append_effective_on if {
+	lib.assert_equal(
+		[
+			{
+				"value": 10,
+				"effective_on": lib.time.default_effective_on,
+			},
+			{
+				"value": 20,
+				"effective_on": "2024-01-01T00:00:00Z",
+			},
+			{
+				"value": 30,
+				"effective_on": "9999-01-01T00:00:00Z",
+			},
+		],
+		[
+			lib.rule_data_append_effective_on("key0"),
+			lib.rule_data_append_effective_on("key1"),
+			lib.rule_data_append_effective_on("key2"),
+		],
+	) with data.rule_data as {
+			"key0": 10,
+			"key1": {
+				"value": 20,
+				"effective_on": "2024-01-01T00:00:00Z",
+			},
+			"key2": {
+				"value": 30,
+				"effective_on": "9999-01-01T00:00:00Z",
+			},
+		}
+}
+
 # Need this for 100% coverage
 test_rule_data_defaults if {
 	lib.assert_not_empty(lib.rule_data_defaults)


### PR DESCRIPTION
This came out of a discussion in this week's Community Meeting about time based data: https://github.com/enterprise-contract/community/issues/26#issuecomment-1932242124

It was suggested there that an inverse of the function I was working on [here](https://github.com/enterprise-contract/ec-policies/pull/860), where we provide default effective_on dates to all data that doesn't have it, would allow additional policy rules to be written that can assume all data has an effective date.