### PR TITLE
Rename RHTAP to Konflux in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ For example to fetch a pipeline definition from your local cluster:
     make fetch-pipeline PIPELINE=<some-pipeline-name>
     more input/input.json # to look at it
 
-For a realistic Red Hat Trusted Application Pipeline pipeline definition that
+For a realistic Konflux pipeline definition that
 doesn't require cluster access, if you have the [build-definitions][builddefs]
 repo checked out nearby you can do something like this:
 

--- a/antora/docs/modules/ROOT/pages/index.adoc
+++ b/antora/docs/modules/ROOT/pages/index.adoc
@@ -2,8 +2,8 @@
 
 :numbered:
 
-The Enterprise Contract is a set of tools for verifing the provenance of container
-images built in Red Hat Trusted Application Pipeline and validating them against a
+The Enterprise Contract is a tool for verifing the provenance of container
+images built in Konflux CI, and validating them against a
 clearly defined Enterprise Contract policy.
 
 The Enterprise Contract policy is defined using the

--- a/antora/docs/modules/ROOT/pages/trusting_bundles.adoc
+++ b/antora/docs/modules/ROOT/pages/trusting_bundles.adoc
@@ -79,10 +79,10 @@ Be sure to include the `acceptable-bundles.yaml` file in a data source in your p
 
 == An Example
 
-Automation using the process described above manages the acceptable bundles used in Red Hat Trusted Application Pipeline, RHTAP. This section describes how.
+Automation using the process described above manages the acceptable bundles used in Konflux. This section describes how.
 
 The repository link:{build-definitions}[redhat-appstudio/build-definitions] contains all the Tekton
-definitions used by RHTAP. The CI/CD process on that repository performs the following actions:
+definitions used by Konflux. The CI/CD process on that repository performs the following actions:
 
 1. Determine which Tekton definitions have modifications.
 2. Build a new Tekton Bundle for each modified Tekton definition.
@@ -92,7 +92,7 @@ definitions used by RHTAP. The CI/CD process on that repository performs the fol
 
 The new Tekton Bundles become acceptable bundles as soon as the pull request merges.
 
-== Adding a new acceptable bundle to the Red Hat Trusted Application Pipeline
+== Adding a new acceptable bundle to Konflux
 
 The process to add a new task defintion to the existing Red Hat acceptable task list is relatively uncomplicated and is detailed below.
 

--- a/antora/docs/modules/ROOT/templates/acceptable_bundles.hbs
+++ b/antora/docs/modules/ROOT/templates/acceptable_bundles.hbs
@@ -4,7 +4,7 @@
 
 == Task Bundles
 
-The Enterprise Contract requires that all Red Hat Trusted Application Pipeline pipelines
+The Enterprise Contract requires that all Konflux pipelines
 use only tasks defined in these specific task bundles. See also the "Task bundle is not
 acceptable" xref:release_policy#unacceptable_task_bundle[release] and
 xref:pipeline_policy#unacceptable_task_bundle[policy] rules where this list is used.

--- a/antora/docs/modules/ROOT/templates/release_policy.hbs
+++ b/antora/docs/modules/ROOT/templates/release_policy.hbs
@@ -2,8 +2,8 @@
 
 :numbered:
 
-These rules are applied to pipeline run attestations associated with container images built by Red
-Hat Trusted Application Pipeline.
+These rules are applied to pipeline run attestations associated with container
+images built by Konflux.
 
 == Available rule collections
 

--- a/policy/pipeline/required_tasks.rego
+++ b/policy/pipeline/required_tasks.rego
@@ -2,7 +2,7 @@
 # METADATA
 # title: Required tasks
 # description: >-
-#   RHTAP expects that certain Tekton tasks are executed during image builds.
+#   Konflux expects that certain Tekton tasks are executed during image builds.
 #   This package includes policy rules to confirm that the pipeline definition
 #   includes those required tasks.
 #

--- a/policy/release/java.rego
+++ b/policy/release/java.rego
@@ -12,7 +12,7 @@
 #   dependencies that have been explicitly built from sources, or the name of the
 #   Maven repository names where the dependency artifact was retrieved from. The
 #   Maven repositories are configured using the 'JBSConfig' custom resources.
-#   Default configuration in RHTAP currently includes Maven repositories with
+#   Default configuration in Konflux currently includes Maven repositories with
 #   names : 'jboss', 'confluent', 'redhat', 'jitpack' and 'gradle'.
 #
 package policy.release.java


### PR DESCRIPTION
The CI system we used to call RHTAP is now called Konflux. Update the docs accordingly.

Ref: [EC-378](https://issues.redhat.com/browse/EC-378)