### PR TITLE
Add rpm_ostree_task package

### DIFF
--- a/policy/lib/assertions.rego
+++ b/policy/lib/assertions.rego
@@ -77,6 +77,16 @@ assert_equal_results(left_result, right_result) if {
 	)
 }
 
+# assert_equal_results_no_collections is successful if both results match.
+# The values of "collections" are ignored.
+assert_equal_results_no_collections(left_result, right_result) if {
+	ignore_paths := ["/collections"]
+	assert_equal(
+		_ignore_attributes(left_result, ignore_paths),
+		_ignore_attributes(right_result, ignore_paths),
+	)
+}
+
 _ignore_attributes(values, ignore_paths) := new_values if {
 	new_values := {new_value |
 		some value in values

--- a/policy/lib/assertions_test.rego
+++ b/policy/lib/assertions_test.rego
@@ -102,3 +102,38 @@ test_assert_equal_results if {
 		{"spam": "maps", "collections": ["c", "d"], "effective_on": "1970-01-01T00:00:00Z"},
 	)
 }
+
+# regal ignore:rule-length
+test_assert_equal_results_no_collections if {
+	# Empty results
+	lib.assert_equal_results_no_collections(set(), set())
+	lib.assert_equal_results_no_collections({{}}, {{}})
+
+	# collections attribute is ignored
+	lib.assert_equal_results_no_collections({{"collections": ["a", "b"]}}, {{}})
+	lib.assert_equal_results_no_collections({{}}, {{"collections": ["a", "b"]}})
+	lib.assert_equal_results_no_collections({{"collections": ["a", "b"]}}, {{"collections": ["c", "d"]}})
+	lib.assert_equal_results_no_collections(
+		{{"spam": "maps", "collections": ["a", "b"]}},
+		{{"spam": "maps", "collections": ["c", "d"]}},
+	)
+
+	# missing attributes in one result is not ignored
+	not lib.assert_equal_results_no_collections(
+		{{"spam": "SPAM", "collections": ["a", "b"]}},
+		{{"collections": ["c", "d"]}},
+	)
+	not lib.assert_equal_results_no_collections(
+		{{"collections": ["c", "d"]}},
+		{{"spam": "SPAM", "collections": ["a", "b"]}},
+	)
+
+	# fallback for unexpected types
+	lib.assert_equal_results_no_collections({"spam", "maps"}, {"spam", "maps"})
+	not lib.assert_equal_results_no_collections({"spam", "maps"}, "spam")
+	not lib.assert_equal_results_no_collections(
+		# These are "objects" instead of the expected "set of objects"
+		{"spam": "maps", "collections": ["a", "b"]},
+		{"spam": "maps", "collections": ["c", "d"]},
+	)
+}

--- a/policy/release/rpm_ostree_task.rego
+++ b/policy/release/rpm_ostree_task.rego
@@ -1,0 +1,148 @@
+#
+# METADATA
+# title: rpm-ostree Task
+# description: >-
+#   This package is responsible for verifying the rpm-ostree Tekton Task was executed with the
+#   expected parameters.
+#
+package policy.release.rpm_ostree_task
+
+import rego.v1
+
+import data.lib
+import data.lib.tkn
+
+# METADATA
+# title: Builder image parameter
+# description: >-
+#   Verify the BUILDER_IMAGE parameter of the rpm-ostree Task uses an image reference that is both
+#   pinned to a digest and starts with a pre-defined list of prefixes. By default, the list of
+#   prefixes is empty allowing any pinned image reference to be used. This is customizable via the
+#   `allowed_rpm_ostree_builder_image_prefixes` rule data.
+# custom:
+#   short_name: builder_image_param
+#   failure_msg: "%s"
+#   solution: >-
+#     Make sure the rpm-ostree Task uses a pinned image reference from a pre-approved location.
+#   collections:
+#   - redhat
+#   effective_on: 2024-03-20T00:00:00Z
+#
+deny contains result if {
+	some error in builder_image_param_errors
+	result := _with_effective_on(lib.result_helper(rego.metadata.chain(), [error.msg]), error)
+}
+
+# METADATA
+# title: Rule data
+# description: >-
+#   Verify the rule data used by this package, `allowed_rpm_ostree_builder_image_prefixes`, is in
+#   the expected format.
+# custom:
+#   short_name: rule_data
+#   failure_msg: "%s"
+#   solution: >-
+#     Make sure the `allowed_rpm_ostree_builder_image_prefixes` rule data is in the expected format
+#     in the data source.
+#   collections:
+#   - redhat
+#
+deny contains result if {
+	some error in rule_data_errors
+	result := lib.result_helper(rego.metadata.chain(), [error])
+}
+
+# Detect when an image reference is not pinned to a digest.
+builder_image_param_errors contains error if {
+	some image in _builder_images
+	lib.image.parse(image).digest == ""
+	error := {"msg": sprintf("BUILDER_IMAGE %q is not pinned to a digest", [image])}
+}
+
+# Detect when an image reference does not start with with any of the pre-approved prefixes.
+builder_image_param_errors contains error if {
+	some image in _builder_images
+
+	# There are no matches
+	count([prefix |
+		some prefix in _allowed_prefixes
+		startswith(image, prefix.value)
+	]) == 0
+
+	pretty_prefixes := concat(", ", [prefix.value | some prefix in _allowed_prefixes])
+
+	error := {"msg": sprintf(
+		"BUILDER_IMAGE %q does not start with a pre-approved prefix: %s",
+		[image, pretty_prefixes],
+	)}
+}
+
+# Detect when an image starts with a pre-approved prefix, but that prefix has expiration date.
+builder_image_param_errors contains error if {
+	some image in _builder_images
+
+	# There is a match, but it has an expiration date.
+	some prefix in _allowed_prefixes
+	startswith(image, prefix.value)
+	prefix.expires_on != ""
+
+	error := {
+		"msg": sprintf(
+			"BUILDER_IMAGE %q starts with %q prefix that expires on %s",
+			[image, prefix.value, prefix.expires_on],
+		),
+		"effective_on": prefix.expires_on,
+	}
+}
+
+rule_data_errors contains msg if {
+	schema := {
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"type": "array",
+		"items": {"anyOf": [
+			{
+				"type": "object",
+				"properties": {"value": {"type": "string"}, "expires_on": {"type": "string"}},
+				"additionalProperties": false,
+				"required": ["value"],
+			},
+			{"type": "string"},
+		]},
+		"uniqueItems": true,
+	}
+
+	# match_schema expects either a marshaled JSON resource (String) or an Object. It doesn't
+	# handle an Array directly.
+	value := json.marshal(lib.rule_data(_rule_data_key))
+	some violation in json.match_schema(value, schema)[1]
+
+	msg := sprintf("Rule data %s has unexpected format: %s", [_rule_data_key, violation.error])
+}
+
+# _builder_images is a set of image references. Each corresponding to the BUILDER_IMAGE parameter
+# of an rpm-ostree Task.
+_builder_images contains image if {
+	some att in lib.pipelinerun_attestations
+	some task in tkn.tasks(att)
+	"rpm-ostree" in tkn.task_names(task)
+	image := tkn.task_param(task, "BUILDER_IMAGE")
+}
+
+# _allowed_prefixes is a set of objects. Each object is guaranteed to contains a `value` attribute.
+# If there are no items in the underlying rule data, this rules does not produce a result.
+_allowed_prefixes := prefixes if {
+	allowed_prefixes := lib.rule_data(_rule_data_key)
+	count(allowed_prefixes) > 0
+	prefixes := [_prefix_obj(prefix) | some prefix in allowed_prefixes]
+}
+
+# _prefix_obj ensures the given prefix value is wrapped in an object.
+_prefix_obj(prefix) := prefix if {
+	prefix.value
+} else := {"value": prefix}
+
+_with_effective_on(obj, record) := new_obj if {
+	new_obj := object.union(obj, {"effective_on": record.effective_on})
+} else := obj
+
+_rule_data_key := "allowed_rpm_ostree_builder_image_prefixes"

--- a/policy/release/rpm_ostree_task_test.rego
+++ b/policy/release/rpm_ostree_task_test.rego
@@ -1,0 +1,209 @@
+package policy.release.rpm_ostree_task_test
+
+import rego.v1
+
+import data.lib
+import data.policy.release.rpm_ostree_task
+
+test_success if {
+	slsa_v02_attestation := {"statement": {"predicate": {
+		"buildType": lib.tekton_pipeline_run,
+		"buildConfig": {"tasks": [{
+			"name": "rpm-ostree-p",
+			"ref": {"kind": "Task", "name": "rpm-ostree"},
+			"invocation": {"parameters": {"BUILDER_IMAGE": "registry.local/builder:v0.2@sha256:abc"}},
+		}]},
+	}}}
+
+	slsa_v1_attestation := {"statement": {
+		"predicateType": "https://slsa.dev/provenance/v1",
+		"predicate": {"buildDefinition": {
+			"buildType": "https://tekton.dev/chains/v2/slsa-tekton",
+			"externalParameters": {"runSpec": {"pipelineSpec": {}}},
+			"resolvedDependencies": [{
+				"name": "pipelineTask",
+				"content": base64.encode(json.marshal({"spec": {
+					"taskRef": {
+						"name": "rpm-ostree",
+						"kind": "Task",
+					},
+					"params": [{
+						"name": "BUILDER_IMAGE",
+						"value": "registry.local/builder:v1.0@sha256:bcd",
+					}],
+				}})),
+			}],
+		}},
+	}}
+
+	attestations := [slsa_v02_attestation, slsa_v1_attestation]
+
+	lib.assert_empty(rpm_ostree_task.deny) with input.attestations as attestations
+		with data.rule_data.allowed_rpm_ostree_builder_image_prefixes as ["registry.local/builder"]
+}
+
+test_builder_image_param_failures if {
+	slsa_v02_attestation := {"statement": {"predicate": {
+		"buildType": lib.tekton_pipeline_run,
+		"buildConfig": {"tasks": [
+			{
+				"name": "rpm-ostree-1",
+				"ref": {"kind": "Task", "name": "rpm-ostree"},
+				"invocation": {"parameters": {"BUILDER_IMAGE": "registry.local/spam:v0.2"}},
+			},
+			{
+				"name": "rpm-ostree-2",
+				"ref": {"kind": "Task", "name": "rpm-ostree"},
+				"invocation": {"parameters": {"BUILDER_IMAGE": "registry.local/deprecated:v0.2@sha256:abc"}},
+			},
+		]},
+	}}}
+
+	slsa_v1_attestation := {"statement": {
+		"predicateType": "https://slsa.dev/provenance/v1",
+		"predicate": {"buildDefinition": {
+			"buildType": "https://tekton.dev/chains/v2/slsa-tekton",
+			"externalParameters": {"runSpec": {"pipelineSpec": {}}},
+			"resolvedDependencies": [
+				{
+					"name": "pipelineTask",
+					"content": base64.encode(json.marshal({"spec": {
+						"taskRef": {
+							"name": "rpm-ostree",
+							"kind": "Task",
+						},
+						"params": [{
+							"name": "BUILDER_IMAGE",
+							"value": "registry.local/spam:v1.0",
+						}],
+					}})),
+				},
+				{
+					"name": "pipelineTask",
+					"content": base64.encode(json.marshal({"spec": {
+						"taskRef": {
+							"name": "rpm-ostree",
+							"kind": "Task",
+						},
+						"params": [{
+							"name": "BUILDER_IMAGE",
+							"value": "registry.local/deprecated:v1.0@sha256:bcd",
+						}],
+					}})),
+				},
+			],
+		}},
+	}}
+
+	attestations := [slsa_v02_attestation, slsa_v1_attestation]
+
+	expected := {
+		# Prefix with an expiration date
+		{
+			"code": "rpm_ostree_task.builder_image_param",
+			# regal ignore:line-length
+			"msg": "BUILDER_IMAGE \"registry.local/deprecated:v0.2@sha256:abc\" starts with \"registry.local/deprecated\" prefix that expires on 2099-01-01T00:00:00Z",
+			"effective_on": "2099-01-01T00:00:00Z",
+		},
+		{
+			"code": "rpm_ostree_task.builder_image_param",
+			# regal ignore:line-length
+			"msg": "BUILDER_IMAGE \"registry.local/deprecated:v1.0@sha256:bcd\" starts with \"registry.local/deprecated\" prefix that expires on 2099-01-01T00:00:00Z",
+			"effective_on": "2099-01-01T00:00:00Z",
+		},
+		# Prefix not allowed
+		{
+			"code": "rpm_ostree_task.builder_image_param",
+			# regal ignore:line-length
+			"msg": "BUILDER_IMAGE \"registry.local/spam:v0.2\" does not start with a pre-approved prefix: registry.local/builder, registry.local/deprecated",
+			"effective_on": "2024-03-20T00:00:00Z",
+		},
+		{
+			"code": "rpm_ostree_task.builder_image_param",
+			# regal ignore:line-length
+			"msg": "BUILDER_IMAGE \"registry.local/spam:v1.0\" does not start with a pre-approved prefix: registry.local/builder, registry.local/deprecated",
+			"effective_on": "2024-03-20T00:00:00Z",
+		},
+		# Not pinned
+		{
+			"code": "rpm_ostree_task.builder_image_param",
+			"msg": "BUILDER_IMAGE \"registry.local/spam:v0.2\" is not pinned to a digest",
+			"effective_on": "2024-03-20T00:00:00Z",
+		},
+		{
+			"code": "rpm_ostree_task.builder_image_param",
+			"msg": "BUILDER_IMAGE \"registry.local/spam:v1.0\" is not pinned to a digest",
+			"effective_on": "2024-03-20T00:00:00Z",
+		},
+	}
+
+	allowed_prefixes := [
+		"registry.local/builder",
+		{"value": "registry.local/deprecated", "expires_on": "2099-01-01T00:00:00Z"},
+	]
+
+	lib.assert_equal_results_no_collections(expected, rpm_ostree_task.deny) with input.attestations as attestations
+		with data.rule_data.allowed_rpm_ostree_builder_image_prefixes as allowed_prefixes
+}
+
+test_rule_data_failures if {
+	rd := {"allowed_rpm_ostree_builder_image_prefixes": [
+		# Unexpected type
+		["spam"],
+		# Missing required object attributes
+		{"expires_on": "2030-01-01T00:00:00Z"},
+		# Additional attributes not allowed
+		{"spam": "maps", "value": "registry.local/repo", "expires_on": "2030-01-01T00:00:00Z"},
+		# Incorrect type attributes
+		{"value": 0, "expires_on": 1},
+	]}
+
+	expected := {
+		{
+			"code": "rpm_ostree_task.rule_data",
+			# regal ignore:line-length
+			"msg": "Rule data allowed_rpm_ostree_builder_image_prefixes has unexpected format: 0: Invalid type. Expected: object, given: array",
+		},
+		{
+			"code": "rpm_ostree_task.rule_data",
+			# regal ignore:line-length
+			"msg": "Rule data allowed_rpm_ostree_builder_image_prefixes has unexpected format: 0: Must validate at least one schema (anyOf)",
+		},
+		{
+			"code": "rpm_ostree_task.rule_data",
+			"msg": "Rule data allowed_rpm_ostree_builder_image_prefixes has unexpected format: 1: value is required",
+		},
+		{
+			"code": "rpm_ostree_task.rule_data",
+			# regal ignore:line-length
+			"msg": "Rule data allowed_rpm_ostree_builder_image_prefixes has unexpected format: 1: Must validate at least one schema (anyOf)",
+		},
+		{
+			"code": "rpm_ostree_task.rule_data",
+			# regal ignore:line-length
+			"msg": "Rule data allowed_rpm_ostree_builder_image_prefixes has unexpected format: 2: Additional property spam is not allowed",
+		},
+		{
+			"code": "rpm_ostree_task.rule_data",
+			# regal ignore:line-length
+			"msg": "Rule data allowed_rpm_ostree_builder_image_prefixes has unexpected format: 2: Must validate at least one schema (anyOf)",
+		},
+		{
+			"code": "rpm_ostree_task.rule_data",
+			# regal ignore:line-length
+			"msg": "Rule data allowed_rpm_ostree_builder_image_prefixes has unexpected format: 3.expires_on: Invalid type. Expected: string, given: integer",
+		},
+		{
+			"code": "rpm_ostree_task.rule_data",
+			# regal ignore:line-length
+			"msg": "Rule data allowed_rpm_ostree_builder_image_prefixes has unexpected format: 3.value: Invalid type. Expected: string, given: integer",
+		},
+		{
+			"code": "rpm_ostree_task.rule_data",
+			# regal ignore:line-length
+			"msg": "Rule data allowed_rpm_ostree_builder_image_prefixes has unexpected format: 3: Must validate at least one schema (anyOf)",
+		},
+	}
+
+	lib.assert_equal_results(expected, rpm_ostree_task.deny) with data.rule_data as rd
+}


### PR DESCRIPTION
Add a new policy package, rpm_ostree_task under the release namespace. It is used to verify the rpm-ostree Tekton Task is executed with the expected parameters. All rules are added to the 'redhat' collection.