### PR TITLE
Tolerate git URL with a slash at the end

### DIFF
--- a/policy/release/slsa_source_correlated.rego
+++ b/policy/release/slsa_source_correlated.rego
@@ -132,6 +132,10 @@ _refs(expected_vcs_uri, expected_revision) := {
 		expected_vcs_uri,
 		crypto.sha1(sprintf("commit %d%s%s", [count(expected_revision), nul, expected_revision])),
 	]),
+	# tolerate slash at the end of the vcs URI
+	sprintf("%s@sha1:%s", [trim_suffix(expected_vcs_uri, "/"), expected_revision]),
+	# tolerate slash at the end of the vcs URI and append .git
+	sprintf("%s.git@sha1:%s", [trim_suffix(expected_vcs_uri, "/"), expected_revision]),
 	# tolerate missing .git suffix
 	sprintf("%s.git@gitCommit:%s", [
 		expected_vcs_uri,
@@ -140,6 +144,16 @@ _refs(expected_vcs_uri, expected_revision) := {
 	# tolerate extra or missing .git suffix
 	sprintf("%s@gitCommit:%s", [
 		trim_suffix(expected_vcs_uri, ".git"),
+		crypto.sha1(sprintf("commit %d%s%s", [count(expected_revision), nul, expected_revision])),
+	]),
+	# tolerate slash at the end of the vcs URI
+	sprintf("%s@gitCommit:%s", [
+		trim_suffix(expected_vcs_uri, "/"),
+		crypto.sha1(sprintf("commit %d%s%s", [count(expected_revision), nul, expected_revision])),
+	]),
+	# tolerate slash at the end of the vcs URI and append .git
+	sprintf("%s.git@gitCommit:%s", [
+		trim_suffix(expected_vcs_uri, "/"),
 		crypto.sha1(sprintf("commit %d%s%s", [count(expected_revision), nul, expected_revision])),
 	]),
 }

--- a/policy/release/slsa_source_correlated_test.rego
+++ b/policy/release/slsa_source_correlated_test.rego
@@ -417,6 +417,39 @@ test_rule_data_provided if {
 		with input.attestations as [_source_material_attestation("git+https://git.repository", "ref")]
 }
 
+test_refs if {
+	some provided, expected in {
+		{"https://git.repository": "rev"}: {
+			"https://git.repository@sha1:rev",
+			"https://git.repository.git@sha1:rev",
+			"https://git.repository@gitCommit:80fb0826a7207841d9c59ec544bf16b8c8a93c8b",
+			"https://git.repository.git@gitCommit:80fb0826a7207841d9c59ec544bf16b8c8a93c8b",
+		},
+		{"https://git.repository.git": "rev"}: {
+			"https://git.repository.git@sha1:rev",
+			"https://git.repository.git.git@sha1:rev",
+			"https://git.repository@sha1:rev",
+			"https://git.repository.git@gitCommit:80fb0826a7207841d9c59ec544bf16b8c8a93c8b",
+			"https://git.repository.git.git@gitCommit:80fb0826a7207841d9c59ec544bf16b8c8a93c8b",
+			"https://git.repository@gitCommit:80fb0826a7207841d9c59ec544bf16b8c8a93c8b",
+		},
+		{"https://git.repository/": "rev"}: {
+			"https://git.repository/@sha1:rev",
+			"https://git.repository/.git@sha1:rev",
+			"https://git.repository@sha1:rev",
+			"https://git.repository.git@sha1:rev",
+			"https://git.repository/@gitCommit:80fb0826a7207841d9c59ec544bf16b8c8a93c8b",
+			"https://git.repository/.git@gitCommit:80fb0826a7207841d9c59ec544bf16b8c8a93c8b",
+			"https://git.repository@gitCommit:80fb0826a7207841d9c59ec544bf16b8c8a93c8b",
+			"https://git.repository.git@gitCommit:80fb0826a7207841d9c59ec544bf16b8c8a93c8b",
+		},
+	}
+
+	some uri, revision in provided
+
+	lib.assert_equal(slsa_source_correlated._refs(uri, revision), expected)
+}
+
 expected := {"source": {"git": {"url": "https://git.repository", "revision": "ref"}}}
 
 # SLSA Provenance v0.2


### PR DESCRIPTION
This adds an additional case in the `_ref` function to handle the SCM URLs, e.g. `https://github.com/org/repository/`. This is needed as the attestation will contain something like
`git+https://github.com/org/repository.git`