### PR TITLE
Two Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,10 +253,16 @@ fetch-pipeline: clean-input ## Fetches pipeline data for PIPELINE from your loca
 INPUT_DIR=./input
 INPUT_FILE=$(INPUT_DIR)/input.json
 
+ifndef NAMESPACE
+	NAMESPACE_FLAG=--all-namespaces
+else
+	NAMESPACE_FLAG=--namespace $(NAMESPACE)
+endif
+
 .PHONY: check-release
 check-release: ## Run policy evaluation for release
 	@$(CONFTEST) test $(INPUT_FILE) \
-	  --all-namespaces \
+	  $(NAMESPACE_FLAG) \
 	  --policy $(POLICY_DIR) \
 	  --data $(DATA_DIR) \
 	  --no-fail \


### PR DESCRIPTION
Was down a rabbit hole debugging [this](https://gitlab.cee.redhat.com/releng/rhtap-release-data/-/merge_requests/198), see also [this](https://github.com/securesign/rekor/pull/239).

Fixes `make check-release` which was failing due to the custom rego functions, and updates `make fetch-att` to produce an accurate `input/input.json` file.