### PR TITLE
Fetch SBOM from OCI blob

### DIFF
--- a/policy/lib/sbom.rego
+++ b/policy/lib/sbom.rego
@@ -1,8 +1,13 @@
 package lib.sbom
 
+import data.lib
+import data.lib.tkn
 import rego.v1
 
-cyclonedx_sboms := array.concat(_cyclonedx_sboms_from_image, _cyclonedx_sboms_from_attestations)
+cyclonedx_sboms := array.concat(
+	array.concat(_cyclonedx_sboms_from_image, _cyclonedx_sboms_from_attestations),
+	_cyclonedx_sboms_from_oci,
+)
 
 _cyclonedx_sboms_from_image := [sbom |
 	some path in ["root/buildinfo/content_manifests/sbom-cyclonedx.json"]
@@ -16,4 +21,14 @@ _cyclonedx_sboms_from_attestations := [sbom |
 	# https://cyclonedx.org/specification/overview/#recognized-predicate-type
 	statement.predicateType == "https://cyclonedx.org/bom"
 	sbom := statement.predicate
+]
+
+_cyclonedx_sboms_from_oci := [sbom |
+	some attestation in lib.pipelinerun_attestations
+	some task in tkn.build_tasks(attestation)
+
+	blob_ref := tkn.task_result(task, "SBOM_BLOB_URL")
+	blob := ec.oci.blob(blob_ref)
+
+	sbom := json.unmarshal(blob)
 ]

--- a/policy/lib/sbom_test.rego
+++ b/policy/lib/sbom_test.rego
@@ -15,12 +15,35 @@ test_cyclonedx_sboms if {
 			"predicateType": "https://example.org/boom",
 			"predicate": "not an sbom",
 		}},
+		{"statement": {"predicate": {
+			"buildType": lib.tekton_pipeline_run,
+			"buildConfig": {"tasks": [{"results": [
+				{
+					"name": "IMAGE_DIGEST",
+					"type": "string",
+					"value": "sha256:f0cacc1a",
+				},
+				{
+					"name": "IMAGE_URL",
+					"type": "string",
+					"value": "registry.io/repository/image@sha256:baadf00d",
+				},
+				{
+					"name": "SBOM_BLOB_URL",
+					"type": "string",
+					"value": "registry.io/repository/image@sha256:f0cacc1a",
+				},
+			]}]},
+		}}},
 	]
 	image := {"files": {
 		"root/buildinfo/content_manifests/sbom-cyclonedx.json": "sbom from image",
 		"root/foo": "not an sbom",
 	}}
-	expected := ["sbom from image", "sbom from attestation"]
+	expected := ["sbom from image", "sbom from attestation", {"sbom": "from oci blob"}]
 	lib.assert_equal(sbom.cyclonedx_sboms, expected) with input.attestations as attestations
 		with input.image as image
+		with ec.oci.blob as mock_ec_oci_blob
 }
+
+mock_ec_oci_blob("registry.io/repository/image@sha256:f0cacc1a") := `{"sbom": "from oci blob"}`


### PR DESCRIPTION
This is using `ec.oci.blob` function to fetch the SBOM from an OCI blob, expecting a JSON string to be present, which will be unmarshaled and stored in the `data.lib.sbom.cyclonedx_sboms` array.

This all will happen only if the `beta` source directory is included in the policy sources.

Reference: EC-499