### PR TITLE
Add policy check to verify if the digest was scanned

### DIFF
--- a/policy/release/lib/attestations.rego
+++ b/policy/release/lib/attestations.rego
@@ -31,6 +31,8 @@ taskrun_att_build_types := {
 # with test_ is treated as though it was a test.)
 task_test_result_name := "TEST_OUTPUT"
 
+task_test_image_result_name := "IMAGES_PROCESSED"
+
 java_sbom_component_count_result_name := "SBOM_JAVA_COMPONENTS_COUNT"
 
 build_base_images_digests_result_name := "BASE_IMAGES_DIGESTS"
@@ -114,6 +116,8 @@ unmarshal(raw) := value if {
 # (Don't call it test_results since test_ means a unit test)
 # First find results using the new task result name
 results_from_tests := results_named(task_test_result_name)
+
+images_processed_results_from_tests := results_named(task_test_image_result_name)
 
 # Check for a task by name. Return the task if found
 task_in_pipelinerun(name) := task if {

--- a/policy/release/test.rego
+++ b/policy/release/test.rego
@@ -10,6 +10,7 @@ package policy.release.test
 import rego.v1
 
 import data.lib
+import data.lib.image
 
 # METADATA
 # title: Test data found in task results
@@ -220,6 +221,34 @@ warn contains result if {
 deny contains result if {
 	some error in _rule_data_errors
 	result := lib.result_helper(rego.metadata.chain(), [error])
+}
+
+# METADATA
+# title: Image digest is present in IMAGES_PROCESSED result
+# description: >-
+#   Ensure that task producing the IMAGES_PROCESSED result contains the
+#   digests of the built image.
+# custom:
+#   short_name: test_all_images
+#   failure_msg: Test '%s' did not process image with digest '%s'.
+#   solution: >-
+#     Found an image not processed by a task. Make sure that the task
+#     processes and includes the image digest of all images in the
+#     `IMAGES_PROCESSED` result.
+#   collections:
+#   - redhat
+#
+deny contains result if {
+	img := image.parse(input.image.ref)
+	img_digest := img.digest
+
+	some task in lib.images_processed_results_from_tests
+	not img_digest in object.get(task.value, ["image", "digests"], [])
+	result := lib.result_helper_with_term(
+		rego.metadata.chain(),
+		[task.name, img_digest],
+		task.name,
+	)
 }
 
 # Collect all tests that have resulted with one of the given

--- a/policy/release/test_test.rego
+++ b/policy/release/test_test.rego
@@ -435,6 +435,37 @@ test_wrong_attestation_type if {
 	lib.assert_empty(test.deny) with input.attestations as [tr, tr_slsav1]
 }
 
+test_all_image_processed if {
+	# regal ignore:line-length
+	digests_processed := {"image": {"digests": ["sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb"]}}
+	pipeline_run := lib_test.att_mock_helper_ref(lib.task_test_image_result_name, digests_processed, "success_23", _bundle)
+	attestations := [
+		pipeline_run,
+		lib_test.att_mock_helper_ref(lib.task_test_result_name, {"result": "SUCCESS"}, "errored_1", _bundle),
+	]
+
+	lib.assert_empty(test.deny) with input.attestations as attestations
+		with input.image.ref as _bundle
+}
+
+test_all_images_not_processed if {
+	digests_processed := {"image": {"digests": ["sha256:wrongDigest"]}}
+	pipeline_run := lib_test.att_mock_helper_ref(lib.task_test_image_result_name, digests_processed, "success_23", _bundle)
+
+	attestations := [
+		pipeline_run,
+		lib_test.att_mock_helper_ref(lib.task_test_result_name, {"result": "SUCCESS"}, "errored_1", _bundle),
+	]
+
+	lib.assert_equal_results(test.deny, {{
+		"code": "test.test_all_images",
+		# regal ignore:line-length
+		"msg": "Test 'success_23' did not process image with digest 'sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb'.",
+		"term": "success_23",
+	}}) with input.attestations as attestations
+		with input.image.ref as _bundle
+}
+
 test_rule_data_provided if {
 	d := {
 		"supported_tests_results": [


### PR DESCRIPTION
For tests emitting IMAGES_PROCESSED result, verify the input image digest has been processed.

Resolves: CVP-4067