### PR TITLE
Remove sbom_cyclonedx.contains_components rule

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -54,7 +54,6 @@ Rules included:
 * xref:release_policy.adoc#cve__rule_data_provided[CVE checks: Rule data provided]
 * xref:release_policy.adoc#provenance_materials__git_clone_source_matches_provenance[Provenance Materials: Git clone source matches materials provenance]
 * xref:release_policy.adoc#provenance_materials__git_clone_task_found[Provenance Materials: Git clone task found]
-* xref:release_policy.adoc#sbom_cyclonedx__contains_components[SBOM CycloneDX: Contains components]
 * xref:release_policy.adoc#sbom_cyclonedx__found[SBOM CycloneDX: Found]
 * xref:release_policy.adoc#sbom_cyclonedx__valid[SBOM CycloneDX: Valid]
 * xref:release_policy.adoc#slsa_provenance_available__allowed_predicate_types_provided[SLSA - Provenance - Available: Allowed predicate types provided]
@@ -130,7 +129,6 @@ Rules included:
 * xref:release_policy.adoc#provenance_materials__git_clone_task_found[Provenance Materials: Git clone task found]
 * xref:release_policy.adoc#redhat_manifests__redhat_manifests_missing[Red Hat manifests: Missing Red Hat manifests]
 * xref:release_policy.adoc#sbom_cyclonedx__allowed[SBOM CycloneDX: Allowed]
-* xref:release_policy.adoc#sbom_cyclonedx__contains_components[SBOM CycloneDX: Contains components]
 * xref:release_policy.adoc#sbom_cyclonedx__disallowed_packages_provided[SBOM CycloneDX: Disallowed packages list is provided]
 * xref:release_policy.adoc#sbom_cyclonedx__found[SBOM CycloneDX: Found]
 * xref:release_policy.adoc#sbom_cyclonedx__valid[SBOM CycloneDX: Valid]
@@ -862,18 +860,6 @@ Confirm the CycloneDX SBOM contains only allowed packages. By default all packag
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Package is not allowed: %s`
 * Code: `sbom_cyclonedx.allowed`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx.rego#L71[Source, window="_blank"]
-
-[#sbom_cyclonedx__contains_components]
-=== link:#sbom_cyclonedx__contains_components[Contains components]
-
-Check the list of components in the CycloneDX SBOM is not empty.
-
-*Solution*: Verify the SBOM is correctly identifying the components in the image.
-
-* Rule type: [rule-type-indicator failure]#FAILURE#
-* FAILURE message: `The list of components is empty`
-* Code: `sbom_cyclonedx.contains_components`
 * https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx.rego#L53[Source, window="_blank"]
 
 [#sbom_cyclonedx__disallowed_packages_provided]
@@ -886,7 +872,7 @@ Confirm the `disallowed_packages` rule data was provided, since it is required b
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `sbom_cyclonedx.disallowed_packages_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx.rego#L91[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx.rego#L73[Source, window="_blank"]
 
 [#sbom_cyclonedx__found]
 === link:#sbom_cyclonedx__found[Found]

--- a/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
+++ b/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
@@ -68,7 +68,6 @@
 **** xref:release_policy.adoc#redhat_manifests__redhat_manifests_missing[Missing Red Hat manifests]
 *** xref:release_policy.adoc#sbom_cyclonedx_package[SBOM CycloneDX]
 **** xref:release_policy.adoc#sbom_cyclonedx__allowed[Allowed]
-**** xref:release_policy.adoc#sbom_cyclonedx__contains_components[Contains components]
 **** xref:release_policy.adoc#sbom_cyclonedx__disallowed_packages_provided[Disallowed packages list is provided]
 **** xref:release_policy.adoc#sbom_cyclonedx__found[Found]
 **** xref:release_policy.adoc#sbom_cyclonedx__valid[Valid]

--- a/policy/release/sbom_cyclonedx.rego
+++ b/policy/release/sbom_cyclonedx.rego
@@ -51,24 +51,6 @@ deny contains result if {
 }
 
 # METADATA
-# title: Contains components
-# description: Check the list of components in the CycloneDX SBOM is not empty.
-# custom:
-#   short_name: contains_components
-#   failure_msg: The list of components is empty
-#   solution: >-
-#     Verify the SBOM is correctly identifying the components in the image.
-#   collections:
-#   - minimal
-#   - redhat
-#
-deny contains result if {
-	some s in sbom.cyclonedx_sboms
-	count(object.get(s, "components", [])) == 0
-	result := lib.result_helper(rego.metadata.chain(), [])
-}
-
-# METADATA
 # title: Allowed
 # description: >-
 #   Confirm the CycloneDX SBOM contains only allowed packages. By default all packages are allowed.

--- a/policy/release/sbom_cyclonedx_test.rego
+++ b/policy/release/sbom_cyclonedx_test.rego
@@ -36,30 +36,6 @@ test_not_valid if {
 		with input.image.ref as "registry.local/spam@sha256:123"
 }
 
-test_empty_components if {
-	expected := {{
-		"code": "sbom_cyclonedx.contains_components",
-		"msg": "The list of components is empty",
-	}}
-	att := json.patch(_sbom_attestation, [{
-		"op": "add",
-		"path": "/statement/predicate/components",
-		"value": [],
-	}])
-	lib.assert_equal_results(expected, sbom_cyclonedx.deny) with input.attestations as [att]
-		with input.image.ref as "registry.local/spam@sha256:123"
-}
-
-test_missing_components if {
-	expected := {{
-		"code": "sbom_cyclonedx.contains_components",
-		"msg": "The list of components is empty",
-	}}
-	att := json.remove(_sbom_attestation, ["/statement/predicate/components"])
-	lib.assert_equal_results(expected, sbom_cyclonedx.deny) with input.attestations as [att]
-		with input.image.ref as "registry.local/spam@sha256:123"
-}
-
 test_allowed_by_default if {
 	assert_allowed("pkg:golang/k8s.io/client-go@v0.28.3", [])
 }


### PR DESCRIPTION
We cannot demand that there are components within the SBOM, an example of a valid SBOM without components is an operator bundle which does not contain any executables within it, only descriptors, and it is usually built from `scratch` image.