### PR TITLE
Bump enforcing source image existence by a month

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -1275,7 +1275,7 @@ Verify the source container image exists.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `source_image.exists`
-* Effective from: `2024-05-04T00:00:00Z`
+* Effective from: `2024-06-05T00:00:00Z`
 * https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/source_image.rego#L15[Source, window="_blank"]
 
 [#source_image__signed]

--- a/policy/release/source_image.rego
+++ b/policy/release/source_image.rego
@@ -20,7 +20,7 @@ import data.lib.tkn
 #   failure_msg: "%s"
 #   collections:
 #   - redhat
-#   effective_on: 2024-05-04T00:00:00Z
+#   effective_on: 2024-06-05T00:00:00Z
 #
 deny contains result if {
 	some error in _source_image_errors


### PR DESCRIPTION
This has caught some folk by surprise, let's bump the effective on by ~1 month and figure out how to exclude folk that do not need to build the source image within that time.