### PR TITLE
Ensure schedule checks apply only to releases

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -1226,14 +1226,14 @@ Rules that verify the current date conform to a given schedule.
 [#schedule__date_restriction]
 === link:#schedule__date_restriction[Date Restriction]
 
-Check if the current date is not allowed based on the rule data value from the key `disallowed_dates`. By default, the list is empty in which case *any* day is allowed.
+Check if the current date is not allowed based on the rule data value from the key `disallowed_dates`. By default, the list is empty in which case *any* day is allowed. This check is enforced only for a "release" pipeline, as determined by the value of the `pipeline_intention` rule data.
 
 *Solution*: Try again on a different day.
 
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s is a disallowed date: %s`
 * Code: `schedule.date_restriction`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/schedule.rego#L33[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/schedule.rego#L36[Source, window="_blank"]
 
 [#schedule__rule_data_provided]
 === link:#schedule__rule_data_provided[Rule data provided]
@@ -1245,12 +1245,12 @@ Confirm the expected rule data keys have been provided in the expected format. T
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `schedule.rule_data_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/schedule.rego#L53[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/schedule.rego#L58[Source, window="_blank"]
 
 [#schedule__weekday_restriction]
 === link:#schedule__weekday_restriction[Weekday Restriction]
 
-Check if the current weekday is allowed based on the rule data value from the key `disallowed_weekdays`. By default, the list is empty in which case *any* weekday is allowed.
+Check if the current weekday is allowed based on the rule data value from the key `disallowed_weekdays`. By default, the list is empty in which case *any* weekday is allowed. This check is enforced only for a "release" pipeline, as determined by the value of the `pipeline_intention` rule data.
 
 *Solution*: Try again on a different weekday.
 

--- a/policy/lib/rule_data.rego
+++ b/policy/lib/rule_data.rego
@@ -80,6 +80,11 @@ rule_data_defaults := {
 		"features.operators.openshift.io/token-auth-azure",
 		"features.operators.openshift.io/token-auth-gcp",
 	],
+	# This will be set to "release" in Konflux release pipelines defined at
+	# https://github.com/konflux-ci/release-service-catalog/tree/development/pipelines
+	# Some checks are influenced by this value. Let's use null as a default instead
+	# of the usual empty list.
+	"pipeline_intention": null,
 }
 
 # Returns the "first found" of the following:


### PR DESCRIPTION
Make it so the "no Friday deploys" rule (for example) is used only for EC checks in release pipelines, and not for EC checks in regular pre-merge or post-merge CI pipelines.

Whether we're in a release pipeline is determined by checking the value of the new `pipeline_intention` rule data key.

See also:
* https://github.com/enterprise-contract/ec-cli/pull/1604
* https://github.com/konflux-ci/release-service-catalog/pull/409

Notes:
* Set a null default for the pipeline_intention rule data value since the standard default of an empty list seems less useful.
* This should allow the revert here to be unreverted: https://github.com/release-engineering/rhtap-ec-policy/pull/12

Ref: https://issues.redhat.com/browse/EC-293