### PR TITLE
Use Task name in term for trusted_task.trusted

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -1659,7 +1659,7 @@ Confirm the `trusted_tasks` rule data was provided, since it's required by the p
 * FAILURE message: `Missing required trusted_tasks data`
 * Code: `trusted_task.data`
 * Effective from: `2024-05-07T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task.rego#L212[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task.rego#L213[Source, window="_blank"]
 
 [#trusted_task__pinned]
 === link:#trusted_task__pinned[Pinned]
@@ -1697,7 +1697,7 @@ All input trusted artifacts must be produced on the pipeline. If they are not th
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Code tampering detected, input %q for task %q was not produced by the pipeline as attested.`
 * Code: `trusted_task.valid_trusted_artifact_inputs`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task.rego#L130[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task.rego#L131[Source, window="_blank"]
 
 [#rpm_ostree_task_package]
 == link:#rpm_ostree_task_package[rpm-ostree Task]

--- a/policy/release/trusted_task.rego
+++ b/policy/release/trusted_task.rego
@@ -104,12 +104,13 @@ _trust_errors contains error if {
 	]
 
 	some untrusted_task in tkn.untrusted_task_refs(chain)
-	untrusted_task_name := tkn.pipeline_task_name(untrusted_task)
+	untrusted_pipeline_task_name := tkn.pipeline_task_name(untrusted_task)
+	untrusted_task_name := tkn.task_name(untrusted_task)
 
 	error := {
 		"msg": sprintf(
-			"Code tampering detected, untrusted task %q was included in build chain comprised of: %s",
-			[untrusted_task_name, concat(", ", dependency_chain)],
+			"Code tampering detected, untrusted PipelineTask %q (Task %q) was included in build chain comprised of: %s",
+			[untrusted_pipeline_task_name, untrusted_task_name, concat(", ", dependency_chain)],
 		),
 		"term": untrusted_task_name,
 	}

--- a/policy/release/trusted_task_test.rego
+++ b/policy/release/trusted_task_test.rego
@@ -137,8 +137,8 @@ test_trusted_artifact_tampering if {
 	lib.assert_equal_results(trusted_task.deny, {{
 		"code": "trusted_task.trusted",
 		# regal ignore:line-length
-		"msg": `Code tampering detected, untrusted task "task_b" was included in build chain comprised of: task_a, task_b, task_c`,
-		"term": "task_b",
+		"msg": `Code tampering detected, untrusted PipelineTask "task_b" (Task "TaskB") was included in build chain comprised of: task_a, task_b, task_c`,
+		"term": "TaskB",
 	}}) with data.trusted_tasks as trusted_tasks_data
 		with input.attestations as [evil_attestation]
 }


### PR DESCRIPTION
When a policy rule emits a violation/warning that contains a `term`, the `term` can be used in an exclude/include clause in a policy config. This is meant to provide fine-grained control over certain policy rules, e.g. ignore a violation but just for a particular Task.

Given how it's used, a `term` should be a piece of information that is not possible to be changed without detection. Otherwise, it becomes trivial to silently apply a certain exclusion to an unintended target.

A Task name is a good candidate for a `term` value. To change the Task name, a change to the Task definition is required. Given our concept of trusted Tasks, this can be easily detected.

A PipelineTask name, on the other hand, is completely within the control of the Pipeline author. Since we do not establish any trust on Pipeline definitions themselves, a Pipeline author can change the PipelineTask name without raising any issues in EC. (This is as designed because we take the approach of inspecting the contents of the Pipeline rather than trusting specific implementations of the Pipeline.)

For this reason, the PipelineTask name should naver be used as a `term` value.

This commit changes the `trusted_task.trusted` policy rule to use the Task name as the `term` instead of the PipelineTask name. To avoid confusion, the violation message is also updated to include both the Task and PipelineTask name.