### PR TITLE
Support all artifact result outputs

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -1000,7 +1000,7 @@ Verify the digest of the image being validated is reported by a trusted Task in 
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Image %q not built by a trusted task: %s`
 * Code: `slsa_build_scripted_build.image_built_by_trusted_task`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/slsa_build_scripted_build.rego#L113[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/slsa_build_scripted_build.rego#L103[Source, window="_blank"]
 
 [#slsa_build_scripted_build__subject_build_task_matches]
 === link:#slsa_build_scripted_build__subject_build_task_matches[Provenance subject matches build task image result]

--- a/policy/lib/tekton/task.rego
+++ b/policy/lib/tekton/task.rego
@@ -2,6 +2,7 @@ package lib.tkn
 
 import rego.v1
 
+import data.lib.arrays
 import data.lib.refs
 import data.lib.time as ectime
 
@@ -146,14 +147,14 @@ task_result(task, name) := value if {
 	value := _key_value(result, "value")
 }
 
-task_result_endswith(task, suffix) := value if {
-	value := [key_value |
+task_result_endswith(task, suffix) := values if {
+	results := arrays.sort_by("name", [result |
 		some result in task_results(task)
 		result_name := _key_value(result, "name")
 		endswith(result_name, suffix)
-		key_value := _key_value(result, "value")
-	]
-	count(value) > 0
+	])
+	values := [result.value | some result in results]
+	count(values) > 0
 }
 
 # slsa v0.2 step image

--- a/policy/lib/tekton/task.rego
+++ b/policy/lib/tekton/task.rego
@@ -147,10 +147,13 @@ task_result(task, name) := value if {
 }
 
 task_result_endswith(task, suffix) := value if {
-	some result in task_results(task)
-	result_name := _key_value(result, "name")
-	endswith(result_name, suffix)
-	value := _key_value(result, "value")
+	value := [key_value |
+		some result in task_results(task)
+		result_name := _key_value(result, "name")
+		endswith(result_name, suffix)
+		key_value := _key_value(result, "value")
+	]
+	count(value) > 0
 }
 
 # slsa v0.2 step image
@@ -163,11 +166,11 @@ task_step_image_ref(step) := step.imageID
 build_tasks(attestation) := [task |
 	some task in tasks(attestation)
 
-	image_url := task_result_endswith(task, "IMAGE_URL")
-	count(trim_space(image_url)) > 0
+	image_url := task_result_artifact_url(task)
+	count(image_url) > 0
 
-	image_digest := task_result_endswith(task, "IMAGE_DIGEST")
-	count(trim_space(image_digest)) > 0
+	image_digest := task_result_artifact_digest(task)
+	count(image_digest) > 0
 ]
 
 git_clone_tasks(attestation) := [task |

--- a/policy/lib/tekton/task_results.rego
+++ b/policy/lib/tekton/task_results.rego
@@ -9,6 +9,8 @@ import rego.v1
 task_result_artifact_url(task) := value if {
 	value := [url |
 		some url in task_result_endswith(task, "IMAGE_URL")
+
+		# don't allow empty results
 		count(url) > 0
 	]
 	count(value) > 0
@@ -18,6 +20,8 @@ task_result_artifact_url(task) := value if {
 task_result_artifact_url(task) := value if {
 	value := [url |
 		some url in task_result_endswith(task, "ARTIFACT_URI")
+
+		# don't allow empty results
 		count(url) > 0
 	]
 	count(value) > 0
@@ -25,9 +29,8 @@ task_result_artifact_url(task) := value if {
 
 # returns the image url from the task result IMAGES
 task_result_artifact_url(task) := value if {
-	results := task_result_endswith(task, "IMAGES")
 	value := [v |
-		some result in results
+		some result in task_result_endswith(task, "IMAGES")
 		some image in split(result, ",")
 		split_item := split(image, "@")
 		v := trim_space(split_item[0])
@@ -38,9 +41,8 @@ task_result_artifact_url(task) := value if {
 # returns the image url from the task result ARTIFACT_OUTPUTS
 task_result_artifact_url(task) := value if {
 	value := [url |
-		outputs := task_result_endswith(task, "ARTIFACT_OUTPUTS")
-		some output in outputs
-		url := trim_space(output.uri)
+		some result in task_result_endswith(task, "ARTIFACT_OUTPUTS")
+		url := trim_space(result.uri)
 	]
 	count(value) > 0
 }
@@ -49,19 +51,28 @@ task_result_artifact_url(task) := value if {
 task_result_artifact_digest(task) := value if {
 	value := [digest |
 		some digest in task_result_endswith(task, "IMAGE_DIGEST")
+
+		# don't allow empty results
 		count(digest) > 0
 	]
 	count(value) > 0
 }
 
 # returns the value of a task result with name ARTIFACT_DIGEST
-task_result_artifact_digest(task) := task_result_endswith(task, "ARTIFACT_DIGEST")
+task_result_artifact_digest(task) := value if {
+	value := [digest |
+		some digest in task_result_endswith(task, "ARTIFACT_DIGEST")
+
+		# don't allow empty results
+		count(digest) > 0
+	]
+	count(value) > 0
+}
 
 # returns the image digest from the task result IMAGES
 task_result_artifact_digest(task) := value if {
-	results := task_result_endswith(task, "IMAGES")
 	value := [v |
-		some result in results
+		some result in task_result_endswith(task, "IMAGES")
 		some image in split(result, ",")
 		split_item := split(image, "@")
 		v := trim_space(split_item[1])
@@ -71,10 +82,9 @@ task_result_artifact_digest(task) := value if {
 
 # returns the image digest from the task result ARTIFACT_OUTPUTS
 task_result_artifact_digest(task) := value if {
-	value := [digest |
-		outputs := task_result_endswith(task, "ARTIFACT_OUTPUTS")
-		some output in outputs
-		digest := trim_space(output.digest)
+	value := [url |
+		some result in task_result_endswith(task, "ARTIFACT_OUTPUTS")
+		url := trim_space(result.digest)
 	]
 	count(value) > 0
 }

--- a/policy/lib/tekton/task_results.rego
+++ b/policy/lib/tekton/task_results.rego
@@ -1,0 +1,89 @@
+package lib.tkn
+
+import rego.v1
+
+# handle the output artifacts from Tekton Chains
+# https://tekton.dev/docs/chains/slsa-provenance/#output-artifacts
+
+# returns the value of a task result with name IMAGE_URL
+task_result_artifact_url(task) := value if {
+	value := [url |
+		some url in task_result_endswith(task, "IMAGE_URL")
+		count(url) > 0
+	]
+	count(value) > 0
+}
+
+# returns the value of a task result with name ARTIFACT_URI
+task_result_artifact_url(task) := value if {
+	value := [url |
+		some url in task_result_endswith(task, "ARTIFACT_URI")
+		count(url) > 0
+	]
+	count(value) > 0
+}
+
+# returns the image url from the task result IMAGES
+task_result_artifact_url(task) := value if {
+	results := task_result_endswith(task, "IMAGES")
+	value := [v |
+		some result in results
+		some image in split(result, ",")
+		split_item := split(image, "@")
+		v := trim_space(split_item[0])
+	]
+	count(value) > 0
+}
+
+# returns the image url from the task result ARTIFACT_OUTPUTS
+task_result_artifact_url(task) := value if {
+	value := [url |
+		outputs := task_result_endswith(task, "ARTIFACT_OUTPUTS")
+		some output in outputs
+		url := trim_space(output.uri)
+	]
+	count(value) > 0
+}
+
+# returns the value of a task result with name IMAGE_DIGEST
+task_result_artifact_digest(task) := value if {
+	value := [digest |
+		some digest in task_result_endswith(task, "IMAGE_DIGEST")
+		count(digest) > 0
+	]
+	count(value) > 0
+}
+
+# returns the value of a task result with name ARTIFACT_DIGEST
+task_result_artifact_digest(task) := task_result_endswith(task, "ARTIFACT_DIGEST")
+
+# returns the image digest from the task result IMAGES
+task_result_artifact_digest(task) := value if {
+	results := task_result_endswith(task, "IMAGES")
+	value := [v |
+		some result in results
+		some image in split(result, ",")
+		split_item := split(image, "@")
+		v := trim_space(split_item[1])
+	]
+	count(value) > 0
+}
+
+# returns the image digest from the task result ARTIFACT_OUTPUTS
+task_result_artifact_digest(task) := value if {
+	value := [digest |
+		outputs := task_result_endswith(task, "ARTIFACT_OUTPUTS")
+		some output in outputs
+		digest := trim_space(output.digest)
+	]
+	count(value) > 0
+}
+
+images_with_digests(tasks) := [sprintf("%v@%v", [i, d]) |
+	some y
+	some task in tasks
+	images := task_result_artifact_url(task)
+	digests := task_result_artifact_digest(task)
+	i := images[y]
+	d := digests[y]
+]

--- a/policy/lib/tekton/task_results_test.rego
+++ b/policy/lib/tekton/task_results_test.rego
@@ -66,10 +66,47 @@ test_invalid_result_name if {
 }
 
 test_images_with_digests if {
-	results := [{
+	results_artifact_outputs := [{
 		"name": "ARTIFACT_OUTPUTS",
 		"value": {"uri": "img1", "digest": "1234"},
 	}]
-	tasks := [slsav1_task_result("task1", results), slsav1_task_result("task2", results)]
-	lib.assert_equal(["img1@1234", "img1@1234"], tkn.images_with_digests(tasks))
+	results_images := [
+		{
+			"name": "image1_IMAGE_URL",
+			"value": "img1",
+		},
+		{
+			"name": "image1_IMAGE_DIGEST",
+			"value": "1234",
+		},
+	]
+	results_images_unordered := [
+		{
+			"name": "image1_IMAGE_URL",
+			"value": "img1",
+		},
+		{
+			"name": "image2_IMAGE_DIGEST",
+			"value": "5678",
+		},
+		{
+			"name": "image2_IMAGE_URL",
+			"value": "img2",
+		},
+		{
+			"name": "image1_IMAGE_DIGEST",
+			"value": "1234",
+		},
+	]
+	tasks_artifacts := [
+		slsav1_task_result("task1", results_artifact_outputs),
+		slsav1_task_result("task2", results_artifact_outputs),
+	]
+	lib.assert_equal(["img1@1234", "img1@1234"], tkn.images_with_digests(tasks_artifacts))
+
+	tasks_images := [slsav1_task_result("task1", results_images), slsav1_task_result("task2", results_images)]
+	lib.assert_equal(["img1@1234", "img1@1234"], tkn.images_with_digests(tasks_images))
+
+	tasks_ordered := [slsav1_task_result("task1", results_images_unordered)]
+	lib.assert_equal(["img1@1234", "img2@5678"], tkn.images_with_digests(tasks_ordered))
 }

--- a/policy/lib/tekton/task_results_test.rego
+++ b/policy/lib/tekton/task_results_test.rego
@@ -1,0 +1,75 @@
+package lib.tkn_test
+
+import rego.v1
+
+import data.lib
+import data.lib.tkn
+
+test_image_result if {
+	results := [
+		{
+			"name": "IMAGE_URL",
+			"value": "image1",
+		},
+		{
+			"name": "IMAGE_DIGEST",
+			"value": "1234",
+		},
+	]
+	lib.assert_equal(["image1"], tkn.task_result_artifact_url(slsav1_task_result("task1", results)))
+	lib.assert_equal(["1234"], tkn.task_result_artifact_digest(slsav1_task_result("task1", results)))
+}
+
+test_artifact_result if {
+	results := [
+		{
+			"name": "ARTIFACT_URI",
+			"value": "image1",
+		},
+		{
+			"name": "ARTIFACT_DIGEST",
+			"value": "1234",
+		},
+	]
+	lib.assert_equal(["image1"], tkn.task_result_artifact_url(slsav1_task_result("task1", results)))
+	lib.assert_equal(["1234"], tkn.task_result_artifact_digest(slsav1_task_result("task1", results)))
+}
+
+test_images_result if {
+	results := [{
+		"name": "IMAGES",
+		"value": "img1@sha256:digest1, img2@sha256:digest2",
+	}]
+	lib.assert_equal(["img1", "img2"], tkn.task_result_artifact_url(slsav1_task_result("task1", results)))
+	lib.assert_equal(
+		["sha256:digest1", "sha256:digest2"],
+		tkn.task_result_artifact_digest(slsav1_task_result("task1", results)),
+	)
+}
+
+test_artifact_outputs_result if {
+	results := [{
+		"name": "ARTIFACT_OUTPUTS",
+		"value": {"uri": "img1", "digest": "1234"},
+	}]
+	lib.assert_equal(["img1"], tkn.task_result_artifact_url(slsav1_task_result("task1", results)))
+	lib.assert_equal(["1234"], tkn.task_result_artifact_digest(slsav1_task_result("task1", results)))
+}
+
+test_invalid_result_name if {
+	results := [{
+		"name": "INVALID_OUTPUTS",
+		"value": {"uri": "img1", "digest": "1234"},
+	}]
+	not tkn.task_result_artifact_url(slsav1_task_result("task1", results))
+	not tkn.task_result_artifact_digest(slsav1_task_result("task1", results))
+}
+
+test_images_with_digests if {
+	results := [{
+		"name": "ARTIFACT_OUTPUTS",
+		"value": {"uri": "img1", "digest": "1234"},
+	}]
+	tasks := [slsav1_task_result("task1", results), slsav1_task_result("task2", results)]
+	lib.assert_equal(["img1@1234", "img1@1234"], tkn.images_with_digests(tasks))
+}

--- a/policy/lib/tekton/task_test.rego
+++ b/policy/lib/tekton/task_test.rego
@@ -675,7 +675,7 @@ test_task_result_endswith if {
 		},
 	]
 	task1 := slsav1_task_result("task1", results)
-	lib.assert_equal(["image1", "1234-image1"], tkn.task_result_endswith(task1, "ARTIFACT_URI"))
+	lib.assert_equal(["1234-image1", "image1"], tkn.task_result_endswith(task1, "ARTIFACT_URI"))
 }
 
 _expected_latest := {

--- a/policy/release/slsa_build_scripted_build_test.rego
+++ b/policy/release/slsa_build_scripted_build_test.rego
@@ -469,13 +469,18 @@ _mock_attestation(original_tasks) := d if {
 	]
 
 	d := {"statement": {
-		"subject": [{
-			"name": _image_url,
-			"digest": {_image_digest_algorithm: _image_digest_value},
-		}],
+		"subject": generate_subjects(original_tasks),
 		"predicate": {
 			"buildType": lib.tekton_pipeline_run,
 			"buildConfig": {"tasks": tasks},
 		},
 	}}
 }
+
+generate_subjects(tasks) := [subject |
+	some task in tasks
+	subject := {
+		"name": _image_url,
+		"digest": {_image_digest_algorithm: _image_digest_value},
+	}
+]


### PR DESCRIPTION
This change supports all chains artifacts outputs. It uses all outputs to identify the build task.

https://issues.redhat.com/browse/EC-590