### PR TITLE
Add trusted_artifacts task policy package

### DIFF
--- a/antora/docs/modules/ROOT/pages/task_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/task_policy.adoc
@@ -22,7 +22,7 @@ Confirm the `allowed_step_image_registry_prefixes` rule data was provided, since
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `step_image_registries.step_image_registry_prefix_list_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/task/step_image_registries.rego#L42[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/task/step_image_registries.rego#L43[Source, window="_blank"]
 
 [#step_image_registries__step_images_permitted]
 === link:#step_image_registries__step_images_permitted[Step images come from permitted registry]
@@ -34,7 +34,7 @@ Confirm that each step in the Task uses a container image with a URL that matche
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Step %d uses disallowed image ref '%s'`
 * Code: `step_image_registries.step_images_permitted`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/task/step_image_registries.rego#L14[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/task/step_image_registries.rego#L15[Source, window="_blank"]
 
 [#annotation_package]
 == link:#annotation_package[Tekton Task annotations]
@@ -81,3 +81,31 @@ Confirm the task definition has the kind "Task".
 * FAILURE message: `Unexpected kind '%s' for task definition`
 * Code: `kind.expected_kind`
 * https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/task/kind.rego#L16[Source, window="_blank"]
+
+[#trusted_artifacts_package]
+== link:#trusted_artifacts_package[Trusted Artifacts Conventions]
+
+Policies to verify that a Tekton task definition conforms to the expected conventions required for using Trusted Artifacts.
+
+* Package name: `trusted_artifacts`
+* Package full path: `policy.task.trusted_artifacts`
+
+[#trusted_artifacts__parameter]
+=== link:#trusted_artifacts__parameter[Parameter]
+
+Trusted Artifact parameters follow the expected naming convention.
+
+* Rule type: [rule-type-indicator failure]#FAILURE#
+* FAILURE message: `The parameter %q of the Task %q does not use the _ARTIFACT suffix`
+* Code: `trusted_artifacts.parameter`
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/task/trusted_artifacts.rego#L15[Source, window="_blank"]
+
+[#trusted_artifacts__result]
+=== link:#trusted_artifacts__result[Result]
+
+Trusted Artifact results follow the expected naming convention.
+
+* Rule type: [rule-type-indicator failure]#FAILURE#
+* FAILURE message: `The result %q of the Task %q does not use the _ARTIFACT suffix`
+* Code: `trusted_artifacts.result`
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/task/trusted_artifacts.rego#L28[Source, window="_blank"]

--- a/antora/docs/modules/ROOT/partials/task_policy_nav.adoc
+++ b/antora/docs/modules/ROOT/partials/task_policy_nav.adoc
@@ -7,3 +7,6 @@
 ** xref:task_policy.adoc#kind_package[Tekton task kind checks]
 *** xref:task_policy.adoc#kind__kind_present[Kind field is present in task definition]
 *** xref:task_policy.adoc#kind__expected_kind[Task definition has expected kind]
+** xref:task_policy.adoc#trusted_artifacts_package[Trusted Artifacts Conventions]
+*** xref:task_policy.adoc#trusted_artifacts__parameter[Parameter]
+*** xref:task_policy.adoc#trusted_artifacts__result[Result]

--- a/policy/lib/k8s.rego
+++ b/policy/lib/k8s.rego
@@ -1,0 +1,21 @@
+package lib.k8s
+
+import rego.v1
+
+# name returns the name of the resource. If a name is not defined, "noname" is returned. This
+# function always returns a value.
+name(resource) := name if {
+	name := resource.metadata.name
+} else := "noname"
+
+# version returns the version of the resource as defined via the "app.kubernetes.io/version" label.
+# This is NOT the API Version of the resource. More info about this label in
+# https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels
+# If a version is not defined, "noversion" is returned. This function always returns a value.
+version(resource) := version if {
+	version := resource.metadata.labels["app.kubernetes.io/version"]
+} else := "noversion"
+
+# name_version is a convenience function that returns the resource's name and version. This
+# function always returns a value.
+name_version(resource) := sprintf("%s/%s", [name(resource), version(resource)])

--- a/policy/lib/k8s_test.rego
+++ b/policy/lib/k8s_test.rego
@@ -1,0 +1,43 @@
+package policy.task.k8s_test
+
+import rego.v1
+
+import data.lib
+import data.lib.k8s
+
+test_name if {
+	lib.assert_equal(k8s.name({}), "noname")
+	lib.assert_equal(k8s.name(""), "noname")
+	lib.assert_equal(k8s.name(123), "noname")
+
+	lib.assert_equal(k8s.name({"metadata": {"name": "spam"}}), "spam")
+}
+
+test_version if {
+	lib.assert_equal(k8s.version({}), "noversion")
+	lib.assert_equal(k8s.version(""), "noversion")
+	lib.assert_equal(k8s.version(123), "noversion")
+
+	lib.assert_equal(
+		k8s.version({"metadata": {"labels": {"app.kubernetes.io/version": "1.0"}}}),
+		"1.0",
+	)
+}
+
+test_name_version if {
+	lib.assert_equal(k8s.name_version({}), "noname/noversion")
+	lib.assert_equal(k8s.name_version(""), "noname/noversion")
+	lib.assert_equal(k8s.name_version(123), "noname/noversion")
+
+	lib.assert_equal(k8s.name_version({"metadata": {"name": "spam"}}), "spam/noversion")
+
+	lib.assert_equal(
+		k8s.name_version({"metadata": {"labels": {"app.kubernetes.io/version": "1.0"}}}),
+		"noname/1.0",
+	)
+
+	lib.assert_equal(
+		k8s.name_version({"metadata": {"name": "spam", "labels": {"app.kubernetes.io/version": "1.0"}}}),
+		"spam/1.0",
+	)
+}

--- a/policy/task/step_image_registries.rego
+++ b/policy/task/step_image_registries.rego
@@ -10,6 +10,7 @@ package policy.task.step_image_registries
 import rego.v1
 
 import data.lib
+import data.lib.k8s
 
 # METADATA
 # title: Step images come from permitted registry
@@ -35,7 +36,7 @@ deny contains result if {
 	result := lib.result_helper_with_term(
 		rego.metadata.chain(),
 		[step_index, image_ref],
-		_task_name_version(input),
+		k8s.name_version(input),
 	)
 }
 
@@ -80,13 +81,3 @@ _rule_data_errors contains msg if {
 }
 
 _rule_data_key := "allowed_step_image_registry_prefixes"
-
-_task_name_version(task) := sprintf("%s/%s", [_name(task), _version(task)])
-
-_name(task) := name if {
-	name := task.metadata.name
-} else := "noname"
-
-_version(task) := version if {
-	version := task.metadata.labels["app.kubernetes.io/version"]
-} else := "noversion"

--- a/policy/task/trusted_artifacts.rego
+++ b/policy/task/trusted_artifacts.rego
@@ -1,0 +1,61 @@
+#
+# METADATA
+# title: Trusted Artifacts Conventions
+# description: >-
+#   Policies to verify that a Tekton task definition conforms to the expected conventions required
+#   for using Trusted Artifacts.
+#
+package policy.task.trusted_artifacts
+
+import rego.v1
+
+import data.lib
+import data.lib.k8s
+
+# METADATA
+# title: Parameter
+# description: Trusted Artifact parameters follow the expected naming convention.
+# custom:
+#   short_name: parameter
+#   failure_msg: The parameter %q of the Task %q does not use the _ARTIFACT suffix
+#
+deny contains result if {
+	some param_name in _ta_parameters
+	not _has_ta_suffix(param_name)
+	result := lib.result_helper(rego.metadata.chain(), [param_name, k8s.name_version(input)])
+}
+
+# METADATA
+# title: Result
+# description: Trusted Artifact results follow the expected naming convention.
+# custom:
+#   short_name: result
+#   failure_msg: The result %q of the Task %q does not use the _ARTIFACT suffix
+#
+deny contains result if {
+	some result_name in _ta_results
+	not _has_ta_suffix(result_name)
+	result := lib.result_helper(rego.metadata.chain(), [result_name, k8s.name_version(input)])
+}
+
+_ta_parameters contains param_name if {
+	some step in input.spec.steps
+	_is_ta_step(step)
+	"use" in step.args
+	some arg in step.args
+	some arg_param in regex.find_n(`\$\(params\..*\)`, arg, -1)
+	param_name := trim_prefix(trim_suffix(arg_param, ")"), "$(params.")
+}
+
+_ta_results contains result_name if {
+	some step in input.spec.steps
+	_is_ta_step(step)
+	"create" in step.args
+	some arg in step.args
+	some arg_result in regex.find_n(`\$\(results\..*\.path\)`, arg, -1)
+	result_name := trim_prefix(trim_suffix(arg_result, ".path)"), "$(results.")
+}
+
+_has_ta_suffix(name) if endswith(name, "_ARTIFACT")
+
+_is_ta_step(step) if contains(step.image, "trusted-artifacts")

--- a/policy/task/trusted_artifacts_test.rego
+++ b/policy/task/trusted_artifacts_test.rego
@@ -1,0 +1,99 @@
+package policy.task.trusted_artifacts_test
+
+import rego.v1
+
+import data.lib
+import data.policy.task.trusted_artifacts
+
+test_all_good if {
+	lib.assert_empty(trusted_artifacts.deny) with input as _task
+}
+
+test_bad_ta_param if {
+	expected := {{
+		"code": "trusted_artifacts.parameter",
+		"msg": "The parameter \"I3_ARTIFACTO\" of the Task \"spam-oci-ta/0.1\" does not use the _ARTIFACT suffix",
+	}}
+	lib.assert_equal_results(trusted_artifacts.deny, expected) with input as _task_bad_ta_param
+}
+
+test_bad_ta_result if {
+	expected := {{
+		"code": "trusted_artifacts.result",
+		"msg": "The result \"O3_ARTIFACTO\" of the Task \"spam-oci-ta/0.1\" does not use the _ARTIFACT suffix",
+	}}
+	lib.assert_equal_results(trusted_artifacts.deny, expected) with input as _task_bad_ta_result
+}
+
+test_ignore_non_ta_tasks if {
+	task_not_ta_param := json.patch(
+		_task_bad_ta_param,
+		[{"op": "add", "path": "/spec/steps/0/image", "value": "registry.local/spam:1.0"}],
+	)
+	lib.assert_empty(trusted_artifacts.deny) with input as task_not_ta_param
+
+	task_not_ta_result := json.patch(
+		_task_bad_ta_result,
+		[{"op": "add", "path": "/spec/steps/2/image", "value": "registry.local/spam:1.0"}],
+	)
+	lib.assert_empty(trusted_artifacts.deny) with input as task_not_ta_result
+}
+
+_task := {
+	"apiVersion": "tekton.dev/v1",
+	"kind": "Task",
+	"metadata": {
+		"labels": {"app.kubernetes.io/version": "0.1"},
+		"name": "spam-oci-ta",
+	},
+	"spec": {
+		"params": [
+			{"name": "input"},
+			{"name": "ociStorage"},
+			{"name": "I1_ARTIFACT"},
+			{"name": "I2_ARTIFACT"},
+		],
+		"results": [
+			{"name": "TEST_OUTPUT"},
+			{"name": "O1_ARTIFACT"},
+			{"name": "O2_ARTIFACT"},
+		],
+		"steps": [
+			{
+				"image": "quay.io/redhat-appstudio/build-trusted-artifacts:latest",
+				"name": "use-trusted-artifact",
+				"args": [
+					"use",
+					"$(params.I1_ARTIFACT)=/var/workdir/input1",
+					"$(params.I2_ARTIFACT)=/var/workdir/input2",
+				],
+			},
+			{
+				"image": "registry.local/sleeper:latest",
+				"name": "sleep",
+				"script": "sleep 5",
+			},
+			{
+				"image": "quay.io/redhat-appstudio/build-trusted-artifacts:latest",
+				"name": "create-trusted-artifact",
+				"args": [
+					"create",
+					"--store",
+					"$(params.ociStorage)",
+					"$(results.O1_ARTIFACT.path)=/var/workdir/output1",
+					"$(results.O2_ARTIFACT.path)=/var/workdir/output2",
+				],
+			},
+		],
+	},
+}
+
+_task_bad_ta_param := json.patch(_task, [
+	{"op": "add", "path": "/spec/params/-", "value": {"name": "I3_ARTIFACTO"}},
+	{"op": "add", "path": "/spec/steps/0/args/-", "value": "$(params.I3_ARTIFACTO)=/var/workdir/input3"},
+])
+
+_task_bad_ta_result := json.patch(_task, [
+	{"op": "add", "path": "/spec/results/-", "value": {"name": "O3_ARTIFACTO"}},
+	{"op": "add", "path": "/spec/steps/2/args/-", "value": "$(results.O3_ARTIFACTO.path)=/var/workdir/output3"},
+])


### PR DESCRIPTION
These policy rules are meant to assist Task authors in conforming to the conventions expected by Trusted Artifacts. Mainly, it is important to follow the pattern of using the `_ARTIFACT` suffix for any Trusted Artifact parameter and result.

This PR also includes a small refactoring so we can re-use the helper functions previously defined in the `step_image_registries` package.

NOTE: These are not added to the `redhat` collection because, currently, collections are only supported on the policy rules in the `release` namespace.

Ref: EC-371