### PR TITLE
Add trusted.trusted_parameters policy rule

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -174,6 +174,7 @@ Rules included:
 * xref:release_policy.adoc#trusted_task__trusted[Trusted Task checks: Tasks are trusted]
 * xref:release_policy.adoc#trusted_task__current[Trusted Task checks: Tasks using the latest versions]
 * xref:release_policy.adoc#trusted_task__valid_trusted_artifact_inputs[Trusted Task checks: Trusted Artifact produced in pipeline]
+* xref:release_policy.adoc#trusted_task__trusted_parameters[Trusted Task checks: Trusted parameters]
 * xref:release_policy.adoc#rpm_ostree_task__builder_image_param[rpm-ostree Task: Builder image parameter]
 * xref:release_policy.adoc#rpm_ostree_task__rule_data[rpm-ostree Task: Rule data]
 
@@ -1632,7 +1633,7 @@ Check if all Tekton Tasks use a Task definition by a pinned reference. When usin
 * WARNING message: `Pipeline task %q uses an unpinned task reference, %s`
 * Code: `trusted_task.pinned`
 * Effective from: `2024-05-07T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task.rego#L19[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task.rego#L21[Source, window="_blank"]
 
 [#trusted_task__data]
 === link:#trusted_task__data[Task tracking data was provided]
@@ -1645,7 +1646,7 @@ Confirm the `trusted_tasks` rule data was provided, since it's required by the p
 * FAILURE message: `Missing required trusted_tasks data`
 * Code: `trusted_task.data`
 * Effective from: `2024-05-07T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task.rego#L129[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task.rego#L131[Source, window="_blank"]
 
 [#trusted_task__trusted]
 === link:#trusted_task__trusted[Tasks are trusted]
@@ -1658,7 +1659,7 @@ Check the trust of the Tekton Tasks used in the build Pipeline. There are two mo
 * FAILURE message: `%s`
 * Code: `trusted_task.trusted`
 * Effective from: `2024-05-07T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task.rego#L66[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task.rego#L68[Source, window="_blank"]
 
 [#trusted_task__current]
 === link:#trusted_task__current[Tasks using the latest versions]
@@ -1671,7 +1672,7 @@ Check if all Tekton Tasks use the latest known Task reference.
 * WARNING message: `Pipeline task %q uses an out of date task reference, %s`
 * Code: `trusted_task.current`
 * Effective from: `2024-05-07T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task.rego#L44[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task.rego#L46[Source, window="_blank"]
 
 [#trusted_task__valid_trusted_artifact_inputs]
 === link:#trusted_task__valid_trusted_artifact_inputs[Trusted Artifact produced in pipeline]
@@ -1683,7 +1684,20 @@ All input trusted artifacts must be produced on the pipeline. If they are not th
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Code tampering detected, input %q for task %q was not produced by the pipeline as attested.`
 * Code: `trusted_task.valid_trusted_artifact_inputs`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task.rego#L92[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task.rego#L94[Source, window="_blank"]
+
+[#trusted_task__trusted_parameters]
+=== link:#trusted_task__trusted_parameters[Trusted parameters]
+
+Confirm certain parameters provided to each builder Task have come from trusted Tasks.
+
+*Solution*: Update your build Pipeline to ensure all the parameters provided to your builder Tasks come from trusted Tasks.
+
+* Rule type: [rule-type-indicator failure]#FAILURE#
+* FAILURE message: `The %q parameter of the %q PipelineTask includes an untrusted digest: %s`
+* Code: `trusted_task.trusted_parameters`
+* Effective from: `2021-07-04T00:00:00Z`
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task.rego#L150[Source, window="_blank"]
 
 [#rpm_ostree_task_package]
 == link:#rpm_ostree_task_package[rpm-ostree Task]

--- a/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
+++ b/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
@@ -140,6 +140,7 @@
 **** xref:release_policy.adoc#trusted_task__trusted[Tasks are trusted]
 **** xref:release_policy.adoc#trusted_task__current[Tasks using the latest versions]
 **** xref:release_policy.adoc#trusted_task__valid_trusted_artifact_inputs[Trusted Artifact produced in pipeline]
+**** xref:release_policy.adoc#trusted_task__trusted_parameters[Trusted parameters]
 *** xref:release_policy.adoc#rpm_ostree_task_package[rpm-ostree Task]
 **** xref:release_policy.adoc#rpm_ostree_task__builder_image_param[Builder image parameter]
 **** xref:release_policy.adoc#rpm_ostree_task__rule_data[Rule data]

--- a/policy/release/lib/attestations.rego
+++ b/policy/release/lib/attestations.rego
@@ -138,3 +138,28 @@ task_succeeded(name) if {
 	task := task_in_pipelinerun(name)
 	task.status == "Succeeded"
 }
+
+# param_values expands the value into a list of values as needed. This is useful when handling
+# parameters that could be of type string or an array of strings.
+param_values(value) := {value} if {
+	is_string(value)
+} else := values if {
+	is_array(value)
+	values := {v | some v in value}
+} else := values if {
+	is_object(value)
+	values := {v | some k, v in value}
+}
+
+# result_values expands the value of the given result into a list of values. This is useful when
+# handling results that could be of type string, array of strings, or an object.
+result_values(result) := value if {
+	result.type == "string"
+	value := {result.value}
+} else := value if {
+	result.type == "array"
+	value := {v | some v in result.value}
+} else := value if {
+	result.type == "object"
+	value := {v | some k, v in result.value}
+}

--- a/policy/release/lib/attestations.rego
+++ b/policy/release/lib/attestations.rego
@@ -148,7 +148,7 @@ param_values(value) := {value} if {
 	values := {v | some v in value}
 } else := values if {
 	is_object(value)
-	values := {v | some k, v in value}
+	values := {v | some v in value}
 }
 
 # result_values expands the value of the given result into a list of values. This is useful when
@@ -161,5 +161,5 @@ result_values(result) := value if {
 	value := {v | some v in result.value}
 } else := value if {
 	result.type == "object"
-	value := {v | some k, v in result.value}
+	value := {v | some v in result.value}
 }

--- a/policy/release/lib/attestations_test.rego
+++ b/policy/release/lib/attestations_test.rego
@@ -366,3 +366,19 @@ test_unmarshall_json if {
 	lib.assert_equal("not JSON", lib.unmarshal("not JSON"))
 	lib.assert_equal("", lib.unmarshal(""))
 }
+
+test_param_values if {
+	lib.assert_equal(lib.param_values("spam"), {"spam"})
+	lib.assert_equal(lib.param_values(["spam", "eggs"]), {"spam", "eggs"})
+	lib.assert_equal(lib.param_values({"maps": "spam", "sgge": "eggs"}), {"spam", "eggs"})
+
+	not lib.param_values(123)
+}
+
+test_result_values if {
+	lib.assert_equal(lib.result_values({"type": "string", "value": "spam"}), {"spam"})
+	lib.assert_equal(lib.result_values({"type": "array", "value": ["spam", "eggs"]}), {"spam", "eggs"})
+	lib.assert_equal(lib.result_values({"type": "object", "value": {"maps": "spam", "sgge": "eggs"}}), {"spam", "eggs"})
+
+	not lib.result_values(123)
+}

--- a/policy/release/trusted_task_test.rego
+++ b/policy/release/trusted_task_test.rego
@@ -160,13 +160,14 @@ test_tampered_trusted_artifact_inputs if {
 }
 
 test_artifact_chain if {
-	expected := {attestation_ta: {
+	expected := {
 		"task_a": {"task_b", "task_c"},
 		"task_b": {"task_c"},
 		"task_c": set(),
-	}}
+		"task_image_index": set(),
+	}
 
-	lib.assert_equal(trusted_task._artifact_chain, expected) with input.attestations as [attestation_ta]
+	lib.assert_equal(trusted_task._artifact_chain[attestation_ta], expected) with input.attestations as [attestation_ta]
 }
 
 test_trusted_artifact_inputs_from_parameters if {


### PR DESCRIPTION
This policy rule is responsible for identifying when a trusted builder Task uses the result from an untrusted Task.

The parameters inspected are scoped to values that look like a digest.This is because, at least with the SLSA Provenance 0.2 format, we cannot easily tell where a paramter came from (Pipeline parameter, default Task Parameter, hard-coded, from another Task, etc). The new policy rule makes an assumption that if a parameter includes a digest, that digest must be accounted for within the Pipeline.

This pull request also includes two other minor commits. One to add supporting helper functions, and the other to tidy up one of the existing test cases.

Fixes #1019
Ref: EC-658