### PR TITLE
Deprecated CVE result name is ok if new is present

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -48,7 +48,6 @@ Rules included:
 * xref:release_policy.adoc#cve__unpatched_cve_blockers[CVE checks: Blocking unpatched CVE check]
 * xref:release_policy.adoc#cve__cve_results_found[CVE checks: CVE scan results found]
 * xref:release_policy.adoc#cve__deprecated_cve_result_name[CVE checks: Deprecated CVE result name]
-* xref:release_policy.adoc#cve__deprecated_unpatched_cve_result_name[CVE checks: Deprecated CVE result name for unpatched vulnerabilities]
 * xref:release_policy.adoc#cve__cve_warnings[CVE checks: Non-blocking CVE check]
 * xref:release_policy.adoc#cve__unpatched_cve_warnings[CVE checks: Non-blocking unpatched CVE check]
 * xref:release_policy.adoc#cve__rule_data_provided[CVE checks: Rule data provided]
@@ -106,7 +105,6 @@ Rules included:
 * xref:release_policy.adoc#cve__unpatched_cve_blockers[CVE checks: Blocking unpatched CVE check]
 * xref:release_policy.adoc#cve__cve_results_found[CVE checks: CVE scan results found]
 * xref:release_policy.adoc#cve__deprecated_cve_result_name[CVE checks: Deprecated CVE result name]
-* xref:release_policy.adoc#cve__deprecated_unpatched_cve_result_name[CVE checks: Deprecated CVE result name for unpatched vulnerabilities]
 * xref:release_policy.adoc#cve__cve_warnings[CVE checks: Non-blocking CVE check]
 * xref:release_policy.adoc#cve__unpatched_cve_warnings[CVE checks: Non-blocking unpatched CVE check]
 * xref:release_policy.adoc#cve__rule_data_provided[CVE checks: Rule data provided]
@@ -403,7 +401,7 @@ The SLSA Provenance attestation for the image is inspected to ensure CVEs that h
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Found %d CVE vulnerabilities of %s security level`
 * Code: `cve.cve_blockers`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/cve.rego#L110[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/cve.rego#L89[Source, window="_blank"]
 
 [#cve__unpatched_cve_blockers]
 === link:#cve__unpatched_cve_blockers[Blocking unpatched CVE check]
@@ -415,7 +413,7 @@ The SLSA Provenance attestation for the image is inspected to ensure CVEs that d
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Found %d unpatched CVE vulnerabilities of %s security level`
 * Code: `cve.unpatched_cve_blockers`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/cve.rego#L135[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/cve.rego#L114[Source, window="_blank"]
 
 [#cve__cve_results_found]
 === link:#cve__cve_results_found[CVE scan results found]
@@ -427,7 +425,7 @@ Confirm that clair-scan task results are present in the SLSA Provenance attestat
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Clair CVE scan results were not found`
 * Code: `cve.cve_results_found`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/cve.rego#L161[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/cve.rego#L140[Source, window="_blank"]
 
 [#cve__deprecated_cve_result_name]
 === link:#cve__deprecated_cve_result_name[Deprecated CVE result name]
@@ -440,18 +438,6 @@ The `CLAIR_SCAN_RESULT` result name has been deprecated, and has been replaced w
 * WARNING message: `CVE scan uses deprecated result name`
 * Code: `cve.deprecated_cve_result_name`
 * https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/cve.rego#L66[Source, window="_blank"]
-
-[#cve__deprecated_unpatched_cve_result_name]
-=== link:#cve__deprecated_unpatched_cve_result_name[Deprecated CVE result name for unpatched vulnerabilities]
-
-The `CLAIR_SCAN_RESULT` result name has been deprecated, and has been replaced with `SCAN_OUTPUT`. If any task results with the old name are found, this rule will raise a warning.
-
-*Solution*: Use the newer `SCAN_OUTPUT` result name, including for unpached vulnerabilities.
-
-* Rule type: [rule-type-indicator warning]#WARNING#
-* WARNING message: `CVE scan uses deprecated result name`
-* Code: `cve.deprecated_unpatched_cve_result_name`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/cve.rego#L88[Source, window="_blank"]
 
 [#cve__cve_warnings]
 === link:#cve__cve_warnings[Non-blocking CVE check]
@@ -487,7 +473,7 @@ Confirm the expected rule data keys have been provided in the expected format. T
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `cve.rule_data_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/cve.rego#L186[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/cve.rego#L165[Source, window="_blank"]
 
 [#external_parameters_package]
 == link:#external_parameters_package[External parameters]

--- a/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
+++ b/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
@@ -29,7 +29,6 @@
 **** xref:release_policy.adoc#cve__unpatched_cve_blockers[Blocking unpatched CVE check]
 **** xref:release_policy.adoc#cve__cve_results_found[CVE scan results found]
 **** xref:release_policy.adoc#cve__deprecated_cve_result_name[Deprecated CVE result name]
-**** xref:release_policy.adoc#cve__deprecated_unpatched_cve_result_name[Deprecated CVE result name for unpatched vulnerabilities]
 **** xref:release_policy.adoc#cve__cve_warnings[Non-blocking CVE check]
 **** xref:release_policy.adoc#cve__unpatched_cve_warnings[Non-blocking unpatched CVE check]
 **** xref:release_policy.adoc#cve__rule_data_provided[Rule data provided]

--- a/policy/release/cve.rego
+++ b/policy/release/cve.rego
@@ -81,29 +81,8 @@ warn contains result if {
 #   - attestation_type.known_attestation_type
 #
 warn contains result if {
-	_vulnerabilities_deprecated
-	result := lib.result_helper(rego.metadata.chain(), [])
-}
-
-# METADATA
-# title: Deprecated CVE result name for unpatched vulnerabilities
-# description: >-
-#   The `CLAIR_SCAN_RESULT` result name has been deprecated, and has been
-#   replaced with `SCAN_OUTPUT`. If any task results with the old name are
-#   found, this rule will raise a warning.
-# custom:
-#   short_name: deprecated_unpatched_cve_result_name
-#   failure_msg: CVE scan uses deprecated result name
-#   solution: >-
-#     Use the newer `SCAN_OUTPUT` result name, including for unpached vulnerabilities.
-#   collections:
-#   - minimal
-#   - redhat
-#   depends_on:
-#   - attestation_type.known_attestation_type
-#
-warn contains result if {
-	_unpatched_vulnerabilities_deprecated
+	count(lib.results_named(_result_name)) == 0
+	count(lib.results_named(_deprecated_result_name)) > 0
 	result := lib.result_helper(rego.metadata.chain(), [])
 }
 

--- a/policy/release/cve_test.rego
+++ b/policy/release/cve_test.rego
@@ -106,6 +106,7 @@ test_success_with_rule_data_deprecated_name if {
 	]
 	lib.assert_empty(cve.deny) with input.attestations as attestations
 		with data.rule_data.restrict_cve_security_levels as ["unknown"]
+	lib.assert_empty(cve.warn) with input.attestations as attestations
 }
 
 test_failure if {
@@ -184,6 +185,25 @@ test_failure_deprecated_name if {
 		},
 	}
 	lib.assert_equal_results(cve.deny, expected_deny) with input.attestations as attestations
+
+	expected_warn := {
+		{
+			"code": "cve.unpatched_cve_warnings",
+			"msg": "Found 1 non-blocking unpatched CVE vulnerabilities of critical security level",
+			"term": "critical",
+		},
+		{
+			"code": "cve.unpatched_cve_warnings",
+			"msg": "Found 10 non-blocking unpatched CVE vulnerabilities of high security level",
+			"term": "high",
+		},
+		{
+			"code": "cve.deprecated_cve_result_name",
+			"effective_on": "2022-01-01T00:00:00Z",
+			"msg": "CVE scan uses deprecated result name",
+		},
+	}
+	lib.assert_equal_results(cve.warn, expected_warn) with input.attestations as attestations
 }
 
 test_failure_with_rule_data if {
@@ -277,7 +297,7 @@ test_warn if {
 	lib.assert_equal_results(cve.warn, expected) with input.attestations as attestations
 }
 
-test_warn_deprecated_name if {
+test_no_warn_deprecated_name_with_new_name_present if {
 	slsav1_task_with_result := tkn_test.slsav1_task_result_ref(
 		"clair-scan",
 		[{
@@ -302,16 +322,6 @@ test_warn_deprecated_name if {
 		lib_test.mock_slsav1_attestation_with_tasks([tkn_test.slsav1_task_bundle(slsav1_task_with_result, _bundle)]),
 	]
 	expected := {
-		{
-			"code": "cve.deprecated_cve_result_name",
-			"collections": ["minimal", "redhat"],
-			"effective_on": "2022-01-01T00:00:00Z",
-			"msg": "CVE scan uses deprecated result name",
-		},
-		{
-			"code": "cve.deprecated_unpatched_cve_result_name",
-			"msg": "CVE scan uses deprecated result name",
-		},
 		{
 			"code": "cve.unpatched_cve_warnings",
 			"msg": "Found 1 non-blocking unpatched CVE vulnerabilities of critical security level",


### PR DESCRIPTION
If the scanning task emits both the new result name (`SCAN_OUTPUT`) and the deprecated one `CLAIR_SCAN_RESULT` the `deprecated_cve_result_name` warning should not be emitted.

Also the second warning about the same issue with the code `deprecated_unpatched_cve_result_name` is removed to reduce the noise.