### PR TITLE
Edge case with Tasks that have same effective_on

### DIFF
--- a/policy/lib/tekton/trusted.rego
+++ b/policy/lib/tekton/trusted.rego
@@ -51,6 +51,12 @@ _newer_record_exists(task) if {
 
 	newest_record := time_lib.newest(records)
 	newest_record.ref != ref.pinned_ref
+
+	# newest record could have the same effective_on as the record for the given
+	# task, in that case we can't claim that the newer record exists
+	some record in records
+	record.ref == ref.pinned_ref
+	newest_record.effective_on != record.effective_on
 }
 
 # _trusted_tasks provides a safe way to access the list of trusted tasks. It prevents a policy rule

--- a/policy/lib/tekton/trusted_test.rego
+++ b/policy/lib/tekton/trusted_test.rego
@@ -26,6 +26,7 @@ test_missing_trusted_tasks_data if {
 
 test_out_of_date_task_refs if {
 	tasks := [
+		same_date_trusted_bundle_task,
 		newest_trusted_bundle_task,
 		outdated_trusted_bundle_task,
 		newest_trusted_git_task,
@@ -70,6 +71,12 @@ trusted_bundle_task := {"spec": {"taskRef": {"resolver": "bundles", "params": [
 ]}}}
 
 newest_trusted_bundle_task := trusted_bundle_task
+
+same_date_trusted_bundle_task := {"spec": {"taskRef": {"resolver": "bundles", "params": [
+	{"name": "bundle", "value": "registry.local/trusty:1.0@sha256:same_date"},
+	{"name": "name", "value": "trusty"},
+	{"name": "kind", "value": "task"},
+]}}}
 
 outdated_trusted_bundle_task := {"spec": {"taskRef": {"resolver": "bundles", "params": [
 	{"name": "bundle", "value": "registry.local/trusty:1.0@sha256:outdated-digest"},
@@ -146,6 +153,10 @@ trusted_tasks := {
 	"oci://registry.local/trusty:1.0": [
 		{
 			"ref": "sha256:digest",
+			"effective_on": "2099-01-01T00:00:00Z",
+		},
+		{
+			"ref": "sha256:same_date",
 			"effective_on": "2099-01-01T00:00:00Z",
 		},
 		{


### PR DESCRIPTION
If two versions of the Task have the same effective_on one of them will be considered out of date, this is a bit confusing as the latest version could be the one that is deemed out of date.

This changes so that if the proposed out of date task record and the examined task record have the same exact effective_on the task is not considered out of date.

We have this situation now, as the two top records for the buildah task have the same effective on:

```yaml
  oci://quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.1:
    - effective_on: "2024-06-29T00:00:00Z"
      ref: sha256:b8d50716c01160be5deb27dd30f79ae33cc89c72952285cd850323fa0a88b8db
    - effective_on: "2024-06-29T00:00:00Z"
      expires_on: "2024-06-29T00:00:00Z"
      ref: sha256:9f698f0903234093711ab2310891239fdcd6cfda5407f881822e6fa2cb05f771
```

and the latest digest `b8d5071` is ruled to be out of date.