### PR TITLE
Allow image URLs and digests to contain \n

### DIFF
--- a/acceptance/features/release.feature
+++ b/acceptance/features/release.feature
@@ -19,10 +19,8 @@ Feature: Golden Container Image
                                 "@redhat"
                             ],
                             "exclude": [
-                                "sbom_cyclonedx.found",
-                                "redhat_manifests.redhat_manifests_missing",
                                 "cve.deprecated_cve_result_name",
-                                "source_image.exists"
+                                "source_image"
                             ]
                         }
                     }

--- a/acceptance/samples/policy-input-golden-container.json
+++ b/acceptance/samples/policy-input-golden-container.json
@@ -8,7 +8,25 @@
           {
             "name": "quay.io/redhat-appstudio/ec-golden-image",
             "digest": {
-              "sha256": "6fa252a7df2735b84674e64b78ac66279af0f2cbbb7ed1dd6a534daf0a4b8738"
+              "sha256": "b4cfd7c1fc510d6b934c195cf5bf1d647ff332215104a0d05942fc0aa1fe09e7"
+            }
+          },
+          {
+            "name": "quay.io/redhat-appstudio/ec-golden-image",
+            "digest": {
+              "sha256": "ade052c249de1420c0f860fef47b620f00135aade4a55bc385de1dd634e8cc7a"
+            }
+          },
+          {
+            "name": "quay.io/redhat-appstudio/ec-golden-image",
+            "digest": {
+              "sha256": "e5f4f3669712c98fd37a960479f56d96c7c2743f3c424275d00623f7661d8272"
+            }
+          },
+          {
+            "name": "quay.io/redhat-appstudio/ec-golden-image",
+            "digest": {
+              "sha256": "d8f4506d1de07b7c28e84503b395a16ebbd25ed668291997b2abedb1629180c7"
             }
           }
         ],
@@ -20,63 +38,62 @@
           "invocation": {
             "configSource": {},
             "parameters": {
-              "build-source-image": "false",
+              "build-source-image": "true",
               "dockerfile": "Containerfile",
               "git-url": "https://github.com/enterprise-contract/golden-container",
               "hermetic": "true",
               "image-expires-after": "",
               "java": "false",
-              "output-image": "quay.io/redhat-appstudio/ec-golden-image:68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+              "output-image": "quay.io/redhat-appstudio/ec-golden-image:b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
               "path-context": ".",
               "prefetch-input": "",
               "rebuild": "false",
-              "revision": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+              "revision": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
               "skip-checks": "false",
               "skip-optional": "true"
             },
             "environment": {
               "annotations": {
-                "build.appstudio.openshift.io/repo": "https://github.com/enterprise-contract/golden-container?rev=68b69547cad3c4ba856fe6b06154012f33dd8b5a",
-                "build.appstudio.redhat.com/commit_sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                "build.appstudio.openshift.io/repo": "https://github.com/enterprise-contract/golden-container?rev=b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                "build.appstudio.redhat.com/commit_sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                 "build.appstudio.redhat.com/target_branch": "main",
                 "pipelinesascode.tekton.dev/branch": "main",
-                "pipelinesascode.tekton.dev/check-run-id": "20539638032",
+                "pipelinesascode.tekton.dev/check-run-id": "25796873737",
+                "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
                 "pipelinesascode.tekton.dev/event-type": "push",
-                "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-iiug",
+                "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-yoreai",
                 "pipelinesascode.tekton.dev/git-provider": "github",
                 "pipelinesascode.tekton.dev/installation-id": "34493006",
-                "pipelinesascode.tekton.dev/log-url": "https://console.redhat.com/preview/application-pipeline",
+                "pipelinesascode.tekton.dev/log-url": "https://console.redhat.com/preview/application-pipeline/ns/rhtap-contract-tenant/pipelinerun/golden-container-on-push-xd69b",
                 "pipelinesascode.tekton.dev/max-keep-runs": "3",
                 "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"main\"",
                 "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
                 "pipelinesascode.tekton.dev/repo-url": "https://github.com/enterprise-contract/golden-container",
                 "pipelinesascode.tekton.dev/repository": "golden-container",
                 "pipelinesascode.tekton.dev/sender": "renovate[bot]",
-                "pipelinesascode.tekton.dev/sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
-                "pipelinesascode.tekton.dev/sha-title": "Update quay.io/redhat-appstudio-tekton-catalog/task-clair-scan:0.1 Docker digest to 63b42c0",
-                "pipelinesascode.tekton.dev/sha-url": "https://github.com/enterprise-contract/golden-container/commit/68b69547cad3c4ba856fe6b06154012f33dd8b5a",
-                "pipelinesascode.tekton.dev/state": "started",
-                "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
-                "pipelinesascode.tekton.dev/url-repository": "golden-container"
-              },
-              "labels": {
-                "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
-                "app.kubernetes.io/version": "v0.22.4",
-                "appstudio.openshift.io/application": "golden-container",
-                "appstudio.openshift.io/component": "golden-container",
-                "pipelines.appstudio.openshift.io/type": "build",
-                "pipelinesascode.tekton.dev/branch": "main",
-                "pipelinesascode.tekton.dev/check-run-id": "20539638032",
-                "pipelinesascode.tekton.dev/event-type": "push",
-                "pipelinesascode.tekton.dev/git-provider": "github",
-                "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
-                "pipelinesascode.tekton.dev/repository": "golden-container",
-                "pipelinesascode.tekton.dev/sender": "renovate__bot",
-                "pipelinesascode.tekton.dev/sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                "pipelinesascode.tekton.dev/sha-title": "Update github/codeql-action action to v3.25.8",
+                "pipelinesascode.tekton.dev/sha-url": "https://github.com/enterprise-contract/golden-container/commit/b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                 "pipelinesascode.tekton.dev/state": "started",
                 "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
                 "pipelinesascode.tekton.dev/url-repository": "golden-container",
-                "tekton.dev/pipeline": "golden-container-on-push-fdv54"
+                "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"golden-container\",\"commit\":\"b0d7c600114b39f0f14e4e85a7c8aed7c4de316e\",\"eventType\":\"push\"}"
+              },
+              "labels": {
+                "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
+                "app.kubernetes.io/version": "v0.27.0",
+                "appstudio.openshift.io/application": "golden-container",
+                "appstudio.openshift.io/component": "golden-container",
+                "pipelines.appstudio.openshift.io/type": "build",
+                "pipelinesascode.tekton.dev/check-run-id": "25796873737",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
+                "pipelinesascode.tekton.dev/repository": "golden-container",
+                "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                "pipelinesascode.tekton.dev/state": "started",
+                "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
+                "pipelinesascode.tekton.dev/url-repository": "golden-container",
+                "tekton.dev/pipeline": "golden-container-on-push-xd69b"
               }
             }
           },
@@ -85,7 +102,6 @@
               {
                 "name": "init",
                 "ref": {
-                  "kind": "Task",
                   "resolver": "bundles",
                   "params": [
                     {
@@ -94,7 +110,7 @@
                     },
                     {
                       "name": "bundle",
-                      "value": "quay.io/redhat-appstudio-tekton-catalog/task-init:0.2@sha256:3d8f01fa59596a998d30dc700fcf7377f09d60008337290eebaeaf604512ce2b"
+                      "value": "quay.io/redhat-appstudio-tekton-catalog/task-init:0.2@sha256:b23c7a924f303a67b3a00b32a6713ae1a4fccbc5327daa76a6edd250501ea7a3"
                     },
                     {
                       "name": "kind",
@@ -102,16 +118,16 @@
                     }
                   ]
                 },
-                "startedOn": "2024-01-16T17:03:22Z",
-                "finishedOn": "2024-01-16T17:03:29Z",
+                "startedOn": "2024-06-04T15:53:32Z",
+                "finishedOn": "2024-06-04T15:53:43Z",
                 "status": "Succeeded",
                 "steps": [
                   {
-                    "entryPoint": "#!/bin/bash\necho \"Build Initialize: $IMAGE_URL\"\necho\n\necho \"Determine if Image Already Exists\"\n# Build the image when image does not exists or rebuild is set to true\nif ! oc image info $IMAGE_URL &>/dev/null || [ \"$REBUILD\" == \"true\" ] || [ \"$SKIP_CHECKS\" == \"false\" ]; then\n  echo -n \"true\" > /tekton/results/build\nelse\n  echo -n \"false\" > /tekton/results/build\nfi\n",
+                    "entryPoint": "#!/bin/bash\necho \"Build Initialize: $IMAGE_URL\"\necho\n\necho \"Determine if Image Already Exists\"\n# Build the image when rebuild is set to true or image does not exist\n# The image check comes last to avoid unnecessary, slow API calls\nif [ \"$REBUILD\" == \"true\" ] || [ \"$SKIP_CHECKS\" == \"false\" ] || ! skopeo inspect --raw docker://$IMAGE_URL &>/dev/null; then\n  echo -n \"true\" > /tekton/results/build\nelse\n  echo -n \"false\" > /tekton/results/build\nfi\n",
                     "arguments": null,
                     "environment": {
                       "container": "init",
-                      "image": "oci://registry.redhat.io/openshift4/ose-cli@sha256:73df37794ffff7de1101016c23dc623e4990810390ebdabcbbfa065214352c7c"
+                      "image": "oci://registry.access.redhat.com/ubi9/skopeo@sha256:23557ecf3de07618968affb59adfb3db80336b976501032b5da9e4e92b943776"
                     },
                     "annotations": null
                   }
@@ -119,61 +135,61 @@
                 "invocation": {
                   "configSource": {},
                   "parameters": {
-                    "image-url": "quay.io/redhat-appstudio/ec-golden-image:68b69547cad3c4ba856fe6b06154012f33dd8b5a",
-                    "pipelinerun-name": "golden-container-on-push-fdv54",
-                    "pipelinerun-uid": "45d81570-f6e7-4144-94d3-1aeff14fa750",
+                    "image-url": "quay.io/redhat-appstudio/ec-golden-image:b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                    "pipelinerun-name": "golden-container-on-push-xd69b",
+                    "pipelinerun-uid": "939a9213-de78-428b-90c9-6d2c0d6822c1",
                     "rebuild": "false",
                     "skip-checks": "false",
                     "skip-optional": "true"
                   },
                   "environment": {
                     "annotations": {
-                      "build.appstudio.openshift.io/repo": "https://github.com/enterprise-contract/golden-container?rev=68b69547cad3c4ba856fe6b06154012f33dd8b5a",
-                      "build.appstudio.redhat.com/commit_sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "build.appstudio.openshift.io/repo": "https://github.com/enterprise-contract/golden-container?rev=b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "build.appstudio.redhat.com/commit_sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "build.appstudio.redhat.com/target_branch": "main",
-                      "pipeline.tekton.dev/release": "876b81e",
+                      "pipeline.tekton.dev/release": "34d8c0f",
                       "pipelinesascode.tekton.dev/branch": "main",
-                      "pipelinesascode.tekton.dev/check-run-id": "20539638032",
+                      "pipelinesascode.tekton.dev/check-run-id": "25796873737",
+                      "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
                       "pipelinesascode.tekton.dev/event-type": "push",
-                      "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-iiug",
+                      "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-yoreai",
                       "pipelinesascode.tekton.dev/git-provider": "github",
                       "pipelinesascode.tekton.dev/installation-id": "34493006",
-                      "pipelinesascode.tekton.dev/log-url": "https://console.redhat.com/preview/application-pipeline",
+                      "pipelinesascode.tekton.dev/log-url": "https://console.redhat.com/preview/application-pipeline/ns/rhtap-contract-tenant/pipelinerun/golden-container-on-push-xd69b",
                       "pipelinesascode.tekton.dev/max-keep-runs": "3",
                       "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"main\"",
                       "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
                       "pipelinesascode.tekton.dev/repo-url": "https://github.com/enterprise-contract/golden-container",
                       "pipelinesascode.tekton.dev/repository": "golden-container",
                       "pipelinesascode.tekton.dev/sender": "renovate[bot]",
-                      "pipelinesascode.tekton.dev/sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
-                      "pipelinesascode.tekton.dev/sha-title": "Update quay.io/redhat-appstudio-tekton-catalog/task-clair-scan:0.1 Docker digest to 63b42c0",
-                      "pipelinesascode.tekton.dev/sha-url": "https://github.com/enterprise-contract/golden-container/commit/68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "pipelinesascode.tekton.dev/sha-title": "Update github/codeql-action action to v3.25.8",
+                      "pipelinesascode.tekton.dev/sha-url": "https://github.com/enterprise-contract/golden-container/commit/b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "pipelinesascode.tekton.dev/state": "started",
                       "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
                       "pipelinesascode.tekton.dev/url-repository": "golden-container",
+                      "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"golden-container\",\"commit\":\"b0d7c600114b39f0f14e4e85a7c8aed7c4de316e\",\"eventType\":\"push\"}",
                       "tekton.dev/pipelines.minVersion": "0.12.1",
-                      "tekton.dev/tags": "appstudio, hacbs"
+                      "tekton.dev/tags": "appstudio, hacbs",
+                      "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-d93a888b435563acf59b69d48e089821-27768dd301e54f1b-01\"}"
                     },
                     "labels": {
                       "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
-                      "app.kubernetes.io/version": "v0.22.4",
+                      "app.kubernetes.io/version": "v0.27.0",
                       "appstudio.openshift.io/application": "golden-container",
                       "appstudio.openshift.io/component": "golden-container",
                       "pipelines.appstudio.openshift.io/type": "build",
-                      "pipelinesascode.tekton.dev/branch": "main",
-                      "pipelinesascode.tekton.dev/check-run-id": "20539638032",
+                      "pipelinesascode.tekton.dev/check-run-id": "25796873737",
                       "pipelinesascode.tekton.dev/event-type": "push",
-                      "pipelinesascode.tekton.dev/git-provider": "github",
                       "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
                       "pipelinesascode.tekton.dev/repository": "golden-container",
-                      "pipelinesascode.tekton.dev/sender": "renovate__bot",
-                      "pipelinesascode.tekton.dev/sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "pipelinesascode.tekton.dev/state": "started",
                       "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
                       "pipelinesascode.tekton.dev/url-repository": "golden-container",
                       "tekton.dev/memberOf": "tasks",
-                      "tekton.dev/pipeline": "golden-container-on-push-fdv54",
-                      "tekton.dev/pipelineRun": "golden-container-on-push-fdv54",
+                      "tekton.dev/pipeline": "golden-container-on-push-xd69b",
+                      "tekton.dev/pipelineRun": "golden-container-on-push-xd69b",
                       "tekton.dev/pipelineTask": "init",
                       "tekton.dev/task": "init"
                     }
@@ -189,9 +205,10 @@
               },
               {
                 "name": "clone-repository",
-                "after": ["init"],
+                "after": [
+                  "init"
+                ],
                 "ref": {
-                  "kind": "Task",
                   "resolver": "bundles",
                   "params": [
                     {
@@ -200,7 +217,7 @@
                     },
                     {
                       "name": "bundle",
-                      "value": "quay.io/redhat-appstudio-tekton-catalog/task-git-clone:0.1@sha256:b8fddc2d36313a5cde93aba2491205f4a84e6853af6c34ede681f8339b147478"
+                      "value": "quay.io/redhat-appstudio-tekton-catalog/task-git-clone:0.1@sha256:ae1249aa49e82da5f99cc23b256172dce8f7c7951ece68ca0419240c4ecb52e2"
                     },
                     {
                       "name": "kind",
@@ -208,16 +225,16 @@
                     }
                   ]
                 },
-                "startedOn": "2024-01-16T17:03:29Z",
-                "finishedOn": "2024-01-16T17:03:44Z",
+                "startedOn": "2024-06-04T15:53:44Z",
+                "finishedOn": "2024-06-04T15:53:59Z",
                 "status": "Succeeded",
                 "steps": [
                   {
-                    "entryPoint": "#!/usr/bin/env sh\nset -eu\n\nif [ \"${PARAM_VERBOSE}\" = \"true\" ] ; then\n  set -x\nfi\n\nif [ \"${WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND}\" = \"true\" ] ; then\n  if [ -f \"${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials\" ] && [ -f \"${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig\" ]; then\n    cp \"${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials\" \"${PARAM_USER_HOME}/.git-credentials\"\n    cp \"${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig\" \"${PARAM_USER_HOME}/.gitconfig\"\n  # Compatibility with kubernetes.io/basic-auth secrets\n  elif [ -f \"${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/username\" ] && [ -f \"${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/password\" ]; then\n    HOSTNAME=$(echo $PARAM_URL | awk -F/ '{print $3}')\n    echo \"https://$(cat ${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/username):$(cat ${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/password)@$HOSTNAME\" > \"${PARAM_USER_HOME}/.git-credentials\"\n    echo -e \"[credential \\\"https://$HOSTNAME\\\"]\\n  helper = store\" > \"${PARAM_USER_HOME}/.gitconfig\"\n  else\n    echo \"Unknown basic-auth workspace format\"\n    exit 1\n  fi\n  chmod 400 \"${PARAM_USER_HOME}/.git-credentials\"\n  chmod 400 \"${PARAM_USER_HOME}/.gitconfig\"\nfi\n\nif [ \"${WORKSPACE_SSH_DIRECTORY_BOUND}\" = \"true\" ] ; then\n  cp -R \"${WORKSPACE_SSH_DIRECTORY_PATH}\" \"${PARAM_USER_HOME}\"/.ssh\n  chmod 700 \"${PARAM_USER_HOME}\"/.ssh\n  chmod -R 400 \"${PARAM_USER_HOME}\"/.ssh/*\nfi\n\nCHECKOUT_DIR=\"${WORKSPACE_OUTPUT_PATH}/${PARAM_SUBDIRECTORY}\"\n\ncleandir() {\n  # Delete any existing contents of the repo directory if it exists.\n  #\n  # We don't just \"rm -rf ${CHECKOUT_DIR}\" because ${CHECKOUT_DIR} might be \"/\"\n  # or the root of a mounted volume.\n  if [ -d \"${CHECKOUT_DIR}\" ] ; then\n    # Delete non-hidden files and directories\n    rm -rf \"${CHECKOUT_DIR:?}\"/*\n    # Delete files and directories starting with . but excluding ..\n    rm -rf \"${CHECKOUT_DIR}\"/.[!.]*\n    # Delete files and directories starting with .. plus any other character\n    rm -rf \"${CHECKOUT_DIR}\"/..?*\n  fi\n}\n\nif [ \"${PARAM_DELETE_EXISTING}\" = \"true\" ] ; then\n  cleandir\nfi\n\ntest -z \"${PARAM_HTTP_PROXY}\" || export HTTP_PROXY=\"${PARAM_HTTP_PROXY}\"\ntest -z \"${PARAM_HTTPS_PROXY}\" || export HTTPS_PROXY=\"${PARAM_HTTPS_PROXY}\"\ntest -z \"${PARAM_NO_PROXY}\" || export NO_PROXY=\"${PARAM_NO_PROXY}\"\n\n/ko-app/git-init \\\n  -url=\"${PARAM_URL}\" \\\n  -revision=\"${PARAM_REVISION}\" \\\n  -refspec=\"${PARAM_REFSPEC}\" \\\n  -path=\"${CHECKOUT_DIR}\" \\\n  -sslVerify=\"${PARAM_SSL_VERIFY}\" \\\n  -submodules=\"${PARAM_SUBMODULES}\" \\\n  -depth=\"${PARAM_DEPTH}\" \\\n  -sparseCheckoutDirectories=\"${PARAM_SPARSE_CHECKOUT_DIRECTORIES}\"\ncd \"${CHECKOUT_DIR}\"\nRESULT_SHA=\"$(git rev-parse HEAD)\"\nEXIT_CODE=\"$?\"\nif [ \"${EXIT_CODE}\" != 0 ] ; then\n  exit \"${EXIT_CODE}\"\nfi\nprintf \"%s\" \"${RESULT_SHA}\" > \"/tekton/results/commit\"\nprintf \"%s\" \"${PARAM_URL}\" > \"/tekton/results/url\"\n\nif [ \"${PARAM_FETCH_TAGS}\" = \"true\" ] ; then\n  echo \"Fetching tags\"\n  git fetch --tags\nfi\n",
+                    "entryPoint": "#!/usr/bin/env sh\nset -eu\n\nif [ \"${PARAM_VERBOSE}\" = \"true\" ] ; then\n  set -x\nfi\n\nif [ -n \"${PARAM_GIT_INIT_IMAGE}\" ]; then\n  echo \"WARNING: provided deprecated gitInitImage parameter has no effect.\"\nfi\n\nif [ \"${WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND}\" = \"true\" ] ; then\n  if [ -f \"${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials\" ] && [ -f \"${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig\" ]; then\n    cp \"${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials\" \"${PARAM_USER_HOME}/.git-credentials\"\n    cp \"${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig\" \"${PARAM_USER_HOME}/.gitconfig\"\n  # Compatibility with kubernetes.io/basic-auth secrets\n  elif [ -f \"${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/username\" ] && [ -f \"${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/password\" ]; then\n    HOSTNAME=$(echo $PARAM_URL | awk -F/ '{print $3}')\n    echo \"https://$(cat ${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/username):$(cat ${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/password)@$HOSTNAME\" > \"${PARAM_USER_HOME}/.git-credentials\"\n    echo -e \"[credential \\\"https://$HOSTNAME\\\"]\\n  helper = store\" > \"${PARAM_USER_HOME}/.gitconfig\"\n  else\n    echo \"Unknown basic-auth workspace format\"\n    exit 1\n  fi\n  chmod 400 \"${PARAM_USER_HOME}/.git-credentials\"\n  chmod 400 \"${PARAM_USER_HOME}/.gitconfig\"\nfi\n\n# Should be called after the gitconfig is copied from the repository secret\nca_bundle=/mnt/trusted-ca/ca-bundle.crt\nif [ -f \"$ca_bundle\" ]; then\n  echo \"INFO: Using mounted CA bundle: $ca_bundle\"\n  git config --global http.sslCAInfo \"$ca_bundle\"\nfi\n\nif [ \"${WORKSPACE_SSH_DIRECTORY_BOUND}\" = \"true\" ] ; then\n  cp -R \"${WORKSPACE_SSH_DIRECTORY_PATH}\" \"${PARAM_USER_HOME}\"/.ssh\n  chmod 700 \"${PARAM_USER_HOME}\"/.ssh\n  chmod -R 400 \"${PARAM_USER_HOME}\"/.ssh/*\nfi\n\nCHECKOUT_DIR=\"${WORKSPACE_OUTPUT_PATH}/${PARAM_SUBDIRECTORY}\"\n\ncleandir() {\n  # Delete any existing contents of the repo directory if it exists.\n  #\n  # We don't just \"rm -rf ${CHECKOUT_DIR}\" because ${CHECKOUT_DIR} might be \"/\"\n  # or the root of a mounted volume.\n  if [ -d \"${CHECKOUT_DIR}\" ] ; then\n    # Delete non-hidden files and directories\n    rm -rf \"${CHECKOUT_DIR:?}\"/*\n    # Delete files and directories starting with . but excluding ..\n    rm -rf \"${CHECKOUT_DIR}\"/.[!.]*\n    # Delete files and directories starting with .. plus any other character\n    rm -rf \"${CHECKOUT_DIR}\"/..?*\n  fi\n}\n\nif [ \"${PARAM_DELETE_EXISTING}\" = \"true\" ] ; then\n  cleandir\nfi\n\ntest -z \"${PARAM_HTTP_PROXY}\" || export HTTP_PROXY=\"${PARAM_HTTP_PROXY}\"\ntest -z \"${PARAM_HTTPS_PROXY}\" || export HTTPS_PROXY=\"${PARAM_HTTPS_PROXY}\"\ntest -z \"${PARAM_NO_PROXY}\" || export NO_PROXY=\"${PARAM_NO_PROXY}\"\n\n/ko-app/git-init \\\n  -url=\"${PARAM_URL}\" \\\n  -revision=\"${PARAM_REVISION}\" \\\n  -refspec=\"${PARAM_REFSPEC}\" \\\n  -path=\"${CHECKOUT_DIR}\" \\\n  -sslVerify=\"${PARAM_SSL_VERIFY}\" \\\n  -submodules=\"${PARAM_SUBMODULES}\" \\\n  -depth=\"${PARAM_DEPTH}\" \\\n  -sparseCheckoutDirectories=\"${PARAM_SPARSE_CHECKOUT_DIRECTORIES}\"\ncd \"${CHECKOUT_DIR}\"\nRESULT_SHA=\"$(git rev-parse HEAD)\"\nEXIT_CODE=\"$?\"\nif [ \"${EXIT_CODE}\" != 0 ] ; then\n  exit \"${EXIT_CODE}\"\nfi\nprintf \"%s\" \"${RESULT_SHA}\" > \"/tekton/results/commit\"\nprintf \"%s\" \"${PARAM_URL}\" > \"/tekton/results/url\"\n\nif [ \"${PARAM_FETCH_TAGS}\" = \"true\" ] ; then\n  echo \"Fetching tags\"\n  git fetch --tags\nfi\n",
                     "arguments": null,
                     "environment": {
                       "container": "clone",
-                      "image": "oci://registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:2fa0b06d52b04f377c696412e19307a9eff27383f81d87aae0b4f71672a1cd0b"
+                      "image": "oci://quay.io/konflux-ci/git-clone@sha256:005487d3967e7a90490f96b2ff3b0c6d0463b647d212cd809683b494e20146a8"
                     },
                     "annotations": null
                   },
@@ -226,7 +243,7 @@
                     "arguments": null,
                     "environment": {
                       "container": "symlink-check",
-                      "image": "oci://registry.redhat.io/ubi9@sha256:089bd3b82a78ac45c0eed231bb58bfb43bfcd0560d9bba240fc6355502c92976"
+                      "image": "oci://quay.io/konflux-ci/git-clone@sha256:005487d3967e7a90490f96b2ff3b0c6d0463b647d212cd809683b494e20146a8"
                     },
                     "annotations": null
                   }
@@ -234,75 +251,77 @@
                 "invocation": {
                   "configSource": {},
                   "parameters": {
+                    "caTrustConfigMapKey": "ca-bundle.crt",
+                    "caTrustConfigMapName": "trusted-ca",
                     "deleteExisting": "true",
                     "depth": "1",
                     "enableSymlinkCheck": "true",
                     "fetchTags": "false",
-                    "gitInitImage": "registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8:v1.8.2-8@sha256:a538c423e7a11aae6ae582a411fdb090936458075f99af4ce5add038bb6983e8",
+                    "gitInitImage": "",
                     "httpProxy": "",
                     "httpsProxy": "",
                     "noProxy": "",
                     "refspec": "",
-                    "revision": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                    "revision": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                     "sparseCheckoutDirectories": "",
                     "sslVerify": "true",
                     "subdirectory": "source",
                     "submodules": "true",
                     "url": "https://github.com/enterprise-contract/golden-container",
                     "userHome": "/tekton/home",
-                    "verbose": "true"
+                    "verbose": "false"
                   },
                   "environment": {
                     "annotations": {
-                      "build.appstudio.openshift.io/repo": "https://github.com/enterprise-contract/golden-container?rev=68b69547cad3c4ba856fe6b06154012f33dd8b5a",
-                      "build.appstudio.redhat.com/commit_sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "build.appstudio.openshift.io/repo": "https://github.com/enterprise-contract/golden-container?rev=b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "build.appstudio.redhat.com/commit_sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "build.appstudio.redhat.com/target_branch": "main",
-                      "pipeline.tekton.dev/release": "876b81e",
+                      "pipeline.tekton.dev/release": "34d8c0f",
                       "pipelinesascode.tekton.dev/branch": "main",
-                      "pipelinesascode.tekton.dev/check-run-id": "20539638032",
+                      "pipelinesascode.tekton.dev/check-run-id": "25796873737",
+                      "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
                       "pipelinesascode.tekton.dev/event-type": "push",
-                      "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-iiug",
+                      "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-yoreai",
                       "pipelinesascode.tekton.dev/git-provider": "github",
                       "pipelinesascode.tekton.dev/installation-id": "34493006",
-                      "pipelinesascode.tekton.dev/log-url": "https://console.redhat.com/preview/application-pipeline",
+                      "pipelinesascode.tekton.dev/log-url": "https://console.redhat.com/preview/application-pipeline/ns/rhtap-contract-tenant/pipelinerun/golden-container-on-push-xd69b",
                       "pipelinesascode.tekton.dev/max-keep-runs": "3",
                       "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"main\"",
                       "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
                       "pipelinesascode.tekton.dev/repo-url": "https://github.com/enterprise-contract/golden-container",
                       "pipelinesascode.tekton.dev/repository": "golden-container",
                       "pipelinesascode.tekton.dev/sender": "renovate[bot]",
-                      "pipelinesascode.tekton.dev/sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
-                      "pipelinesascode.tekton.dev/sha-title": "Update quay.io/redhat-appstudio-tekton-catalog/task-clair-scan:0.1 Docker digest to 63b42c0",
-                      "pipelinesascode.tekton.dev/sha-url": "https://github.com/enterprise-contract/golden-container/commit/68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "pipelinesascode.tekton.dev/sha-title": "Update github/codeql-action action to v3.25.8",
+                      "pipelinesascode.tekton.dev/sha-url": "https://github.com/enterprise-contract/golden-container/commit/b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "pipelinesascode.tekton.dev/state": "started",
                       "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
                       "pipelinesascode.tekton.dev/url-repository": "golden-container",
+                      "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"golden-container\",\"commit\":\"b0d7c600114b39f0f14e4e85a7c8aed7c4de316e\",\"eventType\":\"push\"}",
                       "tekton.dev/categories": "Git",
                       "tekton.dev/displayName": "git clone",
                       "tekton.dev/pipelines.minVersion": "0.21.0",
                       "tekton.dev/platforms": "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64",
-                      "tekton.dev/tags": "git"
+                      "tekton.dev/tags": "git",
+                      "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-d93a888b435563acf59b69d48e089821-690f07be1502a14f-01\"}"
                     },
                     "labels": {
                       "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
-                      "app.kubernetes.io/version": "v0.22.4",
+                      "app.kubernetes.io/version": "v0.27.0",
                       "appstudio.openshift.io/application": "golden-container",
                       "appstudio.openshift.io/component": "golden-container",
                       "pipelines.appstudio.openshift.io/type": "build",
-                      "pipelinesascode.tekton.dev/branch": "main",
-                      "pipelinesascode.tekton.dev/check-run-id": "20539638032",
+                      "pipelinesascode.tekton.dev/check-run-id": "25796873737",
                       "pipelinesascode.tekton.dev/event-type": "push",
-                      "pipelinesascode.tekton.dev/git-provider": "github",
                       "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
                       "pipelinesascode.tekton.dev/repository": "golden-container",
-                      "pipelinesascode.tekton.dev/sender": "renovate__bot",
-                      "pipelinesascode.tekton.dev/sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "pipelinesascode.tekton.dev/state": "started",
                       "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
                       "pipelinesascode.tekton.dev/url-repository": "golden-container",
                       "tekton.dev/memberOf": "tasks",
-                      "tekton.dev/pipeline": "golden-container-on-push-fdv54",
-                      "tekton.dev/pipelineRun": "golden-container-on-push-fdv54",
+                      "tekton.dev/pipeline": "golden-container-on-push-xd69b",
+                      "tekton.dev/pipelineRun": "golden-container-on-push-xd69b",
                       "tekton.dev/pipelineTask": "clone-repository",
                       "tekton.dev/task": "git-clone"
                     }
@@ -312,7 +331,7 @@
                   {
                     "name": "commit",
                     "type": "string",
-                    "value": "68b69547cad3c4ba856fe6b06154012f33dd8b5a"
+                    "value": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e"
                   },
                   {
                     "name": "url",
@@ -323,9 +342,10 @@
               },
               {
                 "name": "prefetch-dependencies",
-                "after": ["clone-repository"],
+                "after": [
+                  "clone-repository"
+                ],
                 "ref": {
-                  "kind": "Task",
                   "resolver": "bundles",
                   "params": [
                     {
@@ -334,7 +354,7 @@
                     },
                     {
                       "name": "bundle",
-                      "value": "quay.io/redhat-appstudio-tekton-catalog/task-prefetch-dependencies:0.1@sha256:9630dd7d50002fdffb4a406fb0c538703ef98bf2f4318249ac3a2c229938dbea"
+                      "value": "quay.io/redhat-appstudio-tekton-catalog/task-prefetch-dependencies:0.1@sha256:9aec3ae9f0f50a05abdc739faf4cbc82832cff16c77ac74e1d54072a882c0503"
                     },
                     {
                       "name": "kind",
@@ -342,16 +362,16 @@
                     }
                   ]
                 },
-                "startedOn": "2024-01-16T17:03:45Z",
-                "finishedOn": "2024-01-16T17:03:51Z",
+                "startedOn": "2024-06-04T15:53:59Z",
+                "finishedOn": "2024-06-04T15:54:28Z",
                 "status": "Succeeded",
                 "steps": [
                   {
-                    "entryPoint": "if [ -z \"${INPUT}\" ]\nthen\n  echo \"Build will be executed with network isolation, but no content was configured to be prefetched.\"\n  exit 0\nfi\n\ncachi2 fetch-deps \\\n--source=/workspace/source/source \\\n--output=/workspace/source/cachi2/output \\\n\"${INPUT}\"\n\ncachi2 generate-env /workspace/source/cachi2/output \\\n--format env \\\n--for-output-dir=/cachi2/output \\\n--output /workspace/source/cachi2/cachi2.env\n\ncachi2 inject-files /workspace/source/cachi2/output \\\n--for-output-dir=/cachi2/output\n",
+                    "entryPoint": "if [ -z \"${INPUT}\" ]\nthen\n  # Confirm input was provided though it's likely the whole task would be skipped if it wasn't\n  echo \"No prefetch will be performed because no input was provided for cachi2 fetch-deps\"\n  exit 0\nfi\n\nif [ \"$DEV_PACKAGE_MANAGERS\" = \"true\" ]; then\n  dev_pacman_flag=--dev-package-managers\nelse\n  dev_pacman_flag=\"\"\nfi\n\n# Copied from https://github.com/konflux-ci/build-definitions/blob/main/task/git-clone/0.1/git-clone.yaml\nif [ \"${WORKSPACE_GIT_AUTH_BOUND}\" = \"true\" ] ; then\n  if [ -f \"${WORKSPACE_GIT_AUTH_PATH}/.git-credentials\" ] && [ -f \"${WORKSPACE_GIT_AUTH_PATH}/.gitconfig\" ]; then\n    cp \"${WORKSPACE_GIT_AUTH_PATH}/.git-credentials\" \"${HOME}/.git-credentials\"\n    cp \"${WORKSPACE_GIT_AUTH_PATH}/.gitconfig\" \"${HOME}/.gitconfig\"\n  # Compatibility with kubernetes.io/basic-auth secrets\n  elif [ -f \"${WORKSPACE_GIT_AUTH_PATH}/username\" ] && [ -f \"${WORKSPACE_GIT_AUTH_PATH}/password\" ]; then\n    HOSTNAME=$(cd \"/workspace/source/source\" && git remote get-url origin | awk -F/ '{print $3}')\n    echo \"https://$(cat ${WORKSPACE_GIT_AUTH_PATH}/username):$(cat ${WORKSPACE_GIT_AUTH_PATH}/password)@$HOSTNAME\" > \"${HOME}/.git-credentials\"\n    echo -e \"[credential \\\"https://$HOSTNAME\\\"]\\n  helper = store\" > \"${HOME}/.gitconfig\"\n  else\n    echo \"Unknown git-basic-auth workspace format\"\n    exit 1\n  fi\n  chmod 400 \"${HOME}/.git-credentials\"\n  chmod 400 \"${HOME}/.gitconfig\"\nfi\n\nca_bundle=/mnt/trusted-ca/ca-bundle.crt\nif [ -f \"$ca_bundle\" ]; then\n  echo \"INFO: Using mounted CA bundle: $ca_bundle\"\n  cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors\n  update-ca-trust\nfi\n\ncachi2 --log-level=\"$LOG_LEVEL\" fetch-deps \\\n$dev_pacman_flag \\\n--source=/workspace/source/source \\\n--output=/workspace/source/cachi2/output \\\n\"${INPUT}\"\n\ncachi2 --log-level=\"$LOG_LEVEL\" generate-env /workspace/source/cachi2/output \\\n--format env \\\n--for-output-dir=/cachi2/output \\\n--output /workspace/source/cachi2/cachi2.env\n\ncachi2 --log-level=\"$LOG_LEVEL\" inject-files /workspace/source/cachi2/output \\\n--for-output-dir=/cachi2/output\n",
                     "arguments": null,
                     "environment": {
                       "container": "prefetch-dependencies",
-                      "image": "oci://quay.io/redhat-appstudio/cachi2@sha256:46097f22b57e4d48a3fce96d931e08ccfe3a3e6421362d5f9353961279078eef"
+                      "image": "oci://quay.io/redhat-appstudio/cachi2@sha256:1fc772aa3636fd0b43d62120d832e5913843e028e8cac42814b487c3a0a32bd8"
                     },
                     "annotations": null
                   }
@@ -359,56 +379,60 @@
                 "invocation": {
                   "configSource": {},
                   "parameters": {
-                    "input": ""
+                    "caTrustConfigMapKey": "ca-bundle.crt",
+                    "caTrustConfigMapName": "trusted-ca",
+                    "dev-package-managers": "false",
+                    "input": "",
+                    "log-level": "info"
                   },
                   "environment": {
                     "annotations": {
-                      "build.appstudio.openshift.io/repo": "https://github.com/enterprise-contract/golden-container?rev=68b69547cad3c4ba856fe6b06154012f33dd8b5a",
-                      "build.appstudio.redhat.com/commit_sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "build.appstudio.openshift.io/repo": "https://github.com/enterprise-contract/golden-container?rev=b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "build.appstudio.redhat.com/commit_sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "build.appstudio.redhat.com/target_branch": "main",
-                      "pipeline.tekton.dev/release": "876b81e",
+                      "pipeline.tekton.dev/release": "34d8c0f",
                       "pipelinesascode.tekton.dev/branch": "main",
-                      "pipelinesascode.tekton.dev/check-run-id": "20539638032",
+                      "pipelinesascode.tekton.dev/check-run-id": "25796873737",
+                      "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
                       "pipelinesascode.tekton.dev/event-type": "push",
-                      "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-iiug",
+                      "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-yoreai",
                       "pipelinesascode.tekton.dev/git-provider": "github",
                       "pipelinesascode.tekton.dev/installation-id": "34493006",
-                      "pipelinesascode.tekton.dev/log-url": "https://console.redhat.com/preview/application-pipeline",
+                      "pipelinesascode.tekton.dev/log-url": "https://console.redhat.com/preview/application-pipeline/ns/rhtap-contract-tenant/pipelinerun/golden-container-on-push-xd69b",
                       "pipelinesascode.tekton.dev/max-keep-runs": "3",
                       "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"main\"",
                       "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
                       "pipelinesascode.tekton.dev/repo-url": "https://github.com/enterprise-contract/golden-container",
                       "pipelinesascode.tekton.dev/repository": "golden-container",
                       "pipelinesascode.tekton.dev/sender": "renovate[bot]",
-                      "pipelinesascode.tekton.dev/sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
-                      "pipelinesascode.tekton.dev/sha-title": "Update quay.io/redhat-appstudio-tekton-catalog/task-clair-scan:0.1 Docker digest to 63b42c0",
-                      "pipelinesascode.tekton.dev/sha-url": "https://github.com/enterprise-contract/golden-container/commit/68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "pipelinesascode.tekton.dev/sha-title": "Update github/codeql-action action to v3.25.8",
+                      "pipelinesascode.tekton.dev/sha-url": "https://github.com/enterprise-contract/golden-container/commit/b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "pipelinesascode.tekton.dev/state": "started",
                       "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
                       "pipelinesascode.tekton.dev/url-repository": "golden-container",
+                      "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"golden-container\",\"commit\":\"b0d7c600114b39f0f14e4e85a7c8aed7c4de316e\",\"eventType\":\"push\"}",
                       "tekton.dev/pipelines.minVersion": "0.12.1",
-                      "tekton.dev/tags": "image-build, hacbs"
+                      "tekton.dev/tags": "image-build, hacbs",
+                      "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-d93a888b435563acf59b69d48e089821-35f7e0b558b2ae52-01\"}"
                     },
                     "labels": {
                       "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
-                      "app.kubernetes.io/version": "v0.22.4",
+                      "app.kubernetes.io/version": "v0.27.0",
                       "appstudio.openshift.io/application": "golden-container",
                       "appstudio.openshift.io/component": "golden-container",
                       "pipelines.appstudio.openshift.io/type": "build",
-                      "pipelinesascode.tekton.dev/branch": "main",
-                      "pipelinesascode.tekton.dev/check-run-id": "20539638032",
+                      "pipelinesascode.tekton.dev/check-run-id": "25796873737",
                       "pipelinesascode.tekton.dev/event-type": "push",
-                      "pipelinesascode.tekton.dev/git-provider": "github",
                       "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
                       "pipelinesascode.tekton.dev/repository": "golden-container",
-                      "pipelinesascode.tekton.dev/sender": "renovate__bot",
-                      "pipelinesascode.tekton.dev/sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "pipelinesascode.tekton.dev/state": "started",
                       "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
                       "pipelinesascode.tekton.dev/url-repository": "golden-container",
                       "tekton.dev/memberOf": "tasks",
-                      "tekton.dev/pipeline": "golden-container-on-push-fdv54",
-                      "tekton.dev/pipelineRun": "golden-container-on-push-fdv54",
+                      "tekton.dev/pipeline": "golden-container-on-push-xd69b",
+                      "tekton.dev/pipelineRun": "golden-container-on-push-xd69b",
                       "tekton.dev/pipelineTask": "prefetch-dependencies",
                       "tekton.dev/task": "prefetch-dependencies"
                     }
@@ -416,10 +440,13 @@
                 }
               },
               {
-                "name": "build-container",
-                "after": ["prefetch-dependencies", "clone-repository", "init"],
+                "name": "build-container-amd64",
+                "after": [
+                  "prefetch-dependencies",
+                  "clone-repository",
+                  "init"
+                ],
                 "ref": {
-                  "kind": "Task",
                   "resolver": "bundles",
                   "params": [
                     {
@@ -428,7 +455,7 @@
                     },
                     {
                       "name": "bundle",
-                      "value": "quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.1@sha256:351af2c0e5eeb92a5d6d4083847c1559475b596cda7671f489756d5302a4c847"
+                      "value": "quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.1@sha256:b8d50716c01160be5deb27dd30f79ae33cc89c72952285cd850323fa0a88b8db"
                     },
                     {
                       "name": "kind",
@@ -436,12 +463,12 @@
                     }
                   ]
                 },
-                "startedOn": "2024-01-16T17:03:52Z",
-                "finishedOn": "2024-01-16T17:05:03Z",
+                "startedOn": "2024-06-04T15:54:28Z",
+                "finishedOn": "2024-06-04T15:55:21Z",
                 "status": "Succeeded",
                 "steps": [
                   {
-                    "entryPoint": "SOURCE_CODE_DIR=source\nif [ -e \"$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE\" ]; then\n  dockerfile_path=\"$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE\"\nelif [ -e \"$SOURCE_CODE_DIR/$DOCKERFILE\" ]; then\n  dockerfile_path=\"$SOURCE_CODE_DIR/$DOCKERFILE\"\nelif echo \"$DOCKERFILE\" | grep -q \"^https\\?://\"; then\n  echo \"Fetch Dockerfile from $DOCKERFILE\"\n  dockerfile_path=$(mktemp --suffix=-Dockerfile)\n  http_code=$(curl -s -L -w \"%{http_code}\" --output \"$dockerfile_path\" \"$DOCKERFILE\")\n  if [ $http_code != 200 ]; then\n    echo \"No Dockerfile is fetched. Server responds $http_code\"\n    exit 1\n  fi\n  http_code=$(curl -s -L -w \"%{http_code}\" --output \"$dockerfile_path.dockerignore.tmp\" \"$DOCKERFILE.dockerignore\")\n  if [ $http_code = 200 ]; then\n    echo \"Fetched .dockerignore from $DOCKERFILE.dockerignore\"\n    mv \"$dockerfile_path.dockerignore.tmp\" $SOURCE_CODE_DIR/$CONTEXT/.dockerignore\n  fi\nelse\n  echo \"Cannot find Dockerfile $DOCKERFILE\"\n  exit 1\nfi\nif [ -n \"$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR\" ] && grep -q '^\\s*RUN \\(./\\)\\?mvn' \"$dockerfile_path\"; then\n  sed -i -e \"s|^\\s*RUN \\(\\(./\\)\\?mvn\\)\\(.*\\)|RUN echo \\\"<settings><mirrors><mirror><id>mirror.default</id><url>http://$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR/v1/cache/default/0/</url><mirrorOf>*</mirrorOf></mirror></mirrors></settings>\\\" > /tmp/settings.yaml; \\1 -s /tmp/settings.yaml \\3|g\" \"$dockerfile_path\"\n  touch /var/lib/containers/java\nfi\n\n# Fixing group permission on /var/lib/containers\nchown root:root /var/lib/containers\n\nsed -i 's/^\\s*short-name-mode\\s*=\\s*.*/short-name-mode = \"disabled\"/' /etc/containers/registries.conf\n\n# Setting new namespace to run buildah - 2^32-2\necho 'root:1:4294967294' | tee -a /etc/subuid >> /etc/subgid\n\nif [ \"${HERMETIC}\" == \"true\" ]; then\n  BUILDAH_ARGS=\"--pull=never\"\n  UNSHARE_ARGS=\"--net\"\n  for image in $(grep -i '^\\s*FROM' \"$dockerfile_path\" | sed 's/--platform=\\S*//' | awk '{print $2}'); do\n    if [ \"${image}\" != \"scratch\" ]; then\n      unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image\n    fi\n  done\n  echo \"Build will be executed with network isolation\"\nfi\n\nif [ -n \"${PREFETCH_INPUT}\" ]; then\n  cp -r cachi2 /tmp/\n  chmod -R go+rwX /tmp/cachi2\n  VOLUME_MOUNTS=\"--volume /tmp/cachi2:/cachi2\"\n  sed -i 's|^\\s*run |RUN . /cachi2/cachi2.env \\&\\& \\\\\\n    |i' \"$dockerfile_path\"\n  echo \"Prefetched content will be made available\"\nfi\n\n# if yum repofiles stored in git, copy them to mount point outside the source dir\nif [ -d \"${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}\" ]; then\n  mkdir -p ${YUM_REPOS_D_FETCHED}\n  cp -r ${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}/* ${YUM_REPOS_D_FETCHED}\nfi\n\n# if anything in the repofiles mount point (either fetched or from git), mount it\nif [ -d \"${YUM_REPOS_D_FETCHED}\" ]; then\n  chmod -R go+rwX ${YUM_REPOS_D_FETCHED}\n  mount_point=$(realpath ${YUM_REPOS_D_FETCHED})\n  VOLUME_MOUNTS=\"${VOLUME_MOUNTS} --volume ${mount_point}:${YUM_REPOS_D_TARGET}\"\nfi\n\nLABELS=(\n  \"--label\" \"build-date=$(date -u +'%Y-%m-%dT%H:%M:%S')\"\n  \"--label\" \"architecture=$(uname -m)\"\n  \"--label\" \"vcs-type=git\"\n)\n[ -n \"$COMMIT_SHA\" ] && LABELS+=(\"--label\" \"vcs-ref=$COMMIT_SHA\")\n[ -n \"$IMAGE_EXPIRES_AFTER\" ] && LABELS+=(\"--label\" \"quay.expires-after=$IMAGE_EXPIRES_AFTER\")\n\nunshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah build \\\n  $VOLUME_MOUNTS \\\n  $BUILDAH_ARGS \\\n  ${LABELS[@]} \\\n  --tls-verify=$TLSVERIFY --no-cache \\\n  --ulimit nofile=4096:4096 \\\n  -f \"$dockerfile_path\" -t $IMAGE $SOURCE_CODE_DIR/$CONTEXT\n\ncontainer=$(buildah from --pull-never $IMAGE)\nbuildah mount $container | tee /workspace/container_path\necho $container > /workspace/container_name\n\n# Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later\nif [ -n \"${PREFETCH_INPUT}\" ]; then\n  cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json\nfi\n\n# Expose base image digests\nbuildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' | grep -v $IMAGE > /tekton/results/BASE_IMAGES_DIGESTS\n",
+                    "entryPoint": "if [ -n \"${PARAM_BUILDER_IMAGE}\" ]; then\n  echo \"WARNING: provided deprecated BUILDER_IMAGE parameter has no effect.\"\nfi\n\nca_bundle=/mnt/trusted-ca/ca-bundle.crt\nif [ -f \"$ca_bundle\" ]; then\n  echo \"INFO: Using mounted CA bundle: $ca_bundle\"\n  cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors\n  update-ca-trust\nfi\n\nSOURCE_CODE_DIR=source\nif [ -e \"$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE\" ]; then\n  dockerfile_path=\"$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE\"\nelif [ -e \"$SOURCE_CODE_DIR/$DOCKERFILE\" ]; then\n  dockerfile_path=\"$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE\"\nelif echo \"$DOCKERFILE\" | grep -q \"^https\\?://\"; then\n  echo \"Fetch Dockerfile from $DOCKERFILE\"\n  dockerfile_path=$(mktemp --suffix=-Dockerfile)\n  http_code=$(curl -s -L -w \"%{http_code}\" --output \"$dockerfile_path\" \"$DOCKERFILE\")\n  if [ $http_code != 200 ]; then\n    echo \"No Dockerfile is fetched. Server responds $http_code\"\n    exit 1\n  fi\n  http_code=$(curl -s -L -w \"%{http_code}\" --output \"$dockerfile_path.dockerignore.tmp\" \"$DOCKERFILE.dockerignore\")\n  if [ $http_code = 200 ]; then\n    echo \"Fetched .dockerignore from $DOCKERFILE.dockerignore\"\n    mv \"$dockerfile_path.dockerignore.tmp\" $SOURCE_CODE_DIR/$CONTEXT/.dockerignore\n  fi\nelse\n  echo \"Cannot find Dockerfile $DOCKERFILE\"\n  exit 1\nfi\nif [ -n \"$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR\" ] && grep -q '^\\s*RUN \\(./\\)\\?mvn' \"$dockerfile_path\"; then\n  sed -i -e \"s|^\\s*RUN \\(\\(./\\)\\?mvn\\)\\(.*\\)|RUN echo \\\"<settings><mirrors><mirror><id>mirror.default</id><url>http://$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR/v1/cache/default/0/</url><mirrorOf>*</mirrorOf></mirror></mirrors></settings>\\\" > /tmp/settings.yaml; \\1 -s /tmp/settings.yaml \\3|g\" \"$dockerfile_path\"\n  touch /var/lib/containers/java\nfi\n\n# Fixing group permission on /var/lib/containers\nchown root:root /var/lib/containers\n\nsed -i 's/^\\s*short-name-mode\\s*=\\s*.*/short-name-mode = \"disabled\"/' /etc/containers/registries.conf\n\n# Setting new namespace to run buildah - 2^32-2\necho 'root:1:4294967294' | tee -a /etc/subuid >> /etc/subgid\n\nBUILDAH_ARGS=()\n\nBASE_IMAGES=$(grep -i '^\\s*FROM' \"$dockerfile_path\" | sed 's/--platform=\\S*//' | awk '{print $2}')\nif [ \"${HERMETIC}\" == \"true\" ]; then\n  BUILDAH_ARGS+=(\"--pull=never\")\n  UNSHARE_ARGS=\"--net\"\n  for image in $BASE_IMAGES; do\n    if [ \"${image}\" != \"scratch\" ]; then\n      unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image\n    fi\n  done\n  echo \"Build will be executed with network isolation\"\nfi\n\nif [ -n \"${TARGET_STAGE}\" ]; then\n  BUILDAH_ARGS+=(\"--target=${TARGET_STAGE}\")\nfi\n\nif [ -n \"${BUILD_ARGS_FILE}\" ]; then\n  BUILDAH_ARGS+=(\"--build-arg-file=$(pwd)/$SOURCE_CODE_DIR/${BUILD_ARGS_FILE}\")\nfi\n\nfor build_arg in \"$@\"; do\n  BUILDAH_ARGS+=(\"--build-arg=$build_arg\")\ndone\n\nif [ -f \"/workspace/source/cachi2/cachi2.env\" ]; then\n  cp -r \"/workspace/source/cachi2\" /tmp/\n  chmod -R go+rwX /tmp/cachi2\n  VOLUME_MOUNTS=\"--volume /tmp/cachi2:/cachi2\"\n  sed -i 's|^\\s*run |RUN . /cachi2/cachi2.env \\&\\& \\\\\\n    |i' \"$dockerfile_path\"\n  echo \"Prefetched content will be made available\"\n\n  prefetched_repo_for_my_arch=\"/tmp/cachi2/output/deps/rpm/$(uname -m)/repos.d/cachi2.repo\"\n  if [ -f \"$prefetched_repo_for_my_arch\" ]; then\n    echo \"Adding $prefetched_repo_for_my_arch to $YUM_REPOS_D_FETCHED\"\n    mkdir -p \"$YUM_REPOS_D_FETCHED\"\n    cp --no-clobber \"$prefetched_repo_for_my_arch\" \"$YUM_REPOS_D_FETCHED\"\n  fi\nfi\n\n# if yum repofiles stored in git, copy them to mount point outside the source dir\nif [ -d \"${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}\" ]; then\n  mkdir -p ${YUM_REPOS_D_FETCHED}\n  cp -r ${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}/* ${YUM_REPOS_D_FETCHED}\nfi\n\n# if anything in the repofiles mount point (either fetched or from git), mount it\nif [ -d \"${YUM_REPOS_D_FETCHED}\" ]; then\n  chmod -R go+rwX ${YUM_REPOS_D_FETCHED}\n  mount_point=$(realpath ${YUM_REPOS_D_FETCHED})\n  VOLUME_MOUNTS=\"${VOLUME_MOUNTS} --volume ${mount_point}:${YUM_REPOS_D_TARGET}\"\nfi\n\nLABELS=(\n  \"--label\" \"build-date=$(date -u +'%Y-%m-%dT%H:%M:%S')\"\n  \"--label\" \"architecture=$(uname -m)\"\n  \"--label\" \"vcs-type=git\"\n)\n[ -n \"$COMMIT_SHA\" ] && LABELS+=(\"--label\" \"vcs-ref=$COMMIT_SHA\")\n[ -n \"$IMAGE_EXPIRES_AFTER\" ] && LABELS+=(\"--label\" \"quay.expires-after=$IMAGE_EXPIRES_AFTER\")\n\nENTITLEMENT_PATH=\"/entitlement\"\nif [ -d \"$ENTITLEMENT_PATH\" ]; then\n  cp -r --preserve=mode \"$ENTITLEMENT_PATH\" /tmp/entitlement\n  VOLUME_MOUNTS=\"${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement\"\n  echo \"Adding the entitlement to the build\"\nfi\n\nunshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \\\n  $VOLUME_MOUNTS \\\n  \"${BUILDAH_ARGS[@]}\" \\\n  \"${LABELS[@]}\" \\\n  --tls-verify=$TLSVERIFY --no-cache \\\n  --ulimit nofile=4096:4096 \\\n  -f \"$dockerfile_path\" -t $IMAGE .\n\ncontainer=$(buildah from --pull-never $IMAGE)\nbuildah mount $container | tee /workspace/container_path\necho $container > /workspace/container_name\n\n# Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later\nif [ -f \"/tmp/cachi2/output/bom.json\" ]; then\n  cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json\nfi\n\n# Expose base image digests\nfor image in $BASE_IMAGES; do\n  if [ \"${image}\" != \"scratch\" ]; then\n    buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference=\"$image\" >> /tekton/results/BASE_IMAGES_DIGESTS\n  fi\ndone\n\n# Needed to generate base images SBOM\necho \"$BASE_IMAGES\" > /workspace/source/base_images_from_dockerfile\n",
                     "arguments": null,
                     "environment": {
                       "container": "build",
@@ -450,16 +477,16 @@
                     "annotations": null
                   },
                   {
-                    "entryPoint": "syft dir:/workspace/source/source --output cyclonedx-json=/workspace/source/sbom-source.json\nfind $(cat /workspace/container_path) -xtype l -delete\nsyft dir:$(cat /workspace/container_path) --output cyclonedx-json=/workspace/source/sbom-image.json\n",
+                    "entryPoint": "echo \"Running syft on the source directory\"\nsyft dir:/workspace/source/source --output cyclonedx-json=/workspace/source/sbom-source.json\nfind $(cat /workspace/container_path) -xtype l -delete\necho \"Running syft on the image filesystem\"\nsyft dir:$(cat /workspace/container_path) --output cyclonedx-json=/workspace/source/sbom-image.json\n",
                     "arguments": null,
                     "environment": {
                       "container": "sbom-syft-generate",
-                      "image": "oci://quay.io/redhat-appstudio/syft@sha256:4d3856e6a2622700b9a9d5d74d9aaf5d8a55671653f80bf6c636677658680ede"
+                      "image": "oci://quay.io/redhat-appstudio/syft@sha256:1910b829997650c696881e5fc2fc654ddf3184c27edb1b2024e9cb2ba51ac431"
                     },
                     "annotations": null
                   },
                   {
-                    "entryPoint": "if [ -f /var/lib/containers/java ]; then\n  /opt/jboss/container/java/run/run-java.sh analyse-dependencies path $(cat /workspace/container_path) -s /workspace/source/sbom-image.json --task-run-name golden-container-on-push-fdv54-build-container --publishers /tekton/results/SBOM_JAVA_COMPONENTS_COUNT\n  sed -i 's/^/ /' /tekton/results/SBOM_JAVA_COMPONENTS_COUNT # Workaround for SRVKP-2875\nelse\n  touch /tekton/results/JAVA_COMMUNITY_DEPENDENCIES\nfi\n",
+                    "entryPoint": "if [ -f /var/lib/containers/java ]; then\n  /opt/jboss/container/java/run/run-java.sh analyse-dependencies path $(cat /workspace/container_path) -s /workspace/source/sbom-image.json --task-run-name golden-container-on-push-xd69b-build-container-amd64 --publishers /tekton/results/SBOM_JAVA_COMPONENTS_COUNT\n  sed -i 's/^/ /' /tekton/results/SBOM_JAVA_COMPONENTS_COUNT # Workaround for SRVKP-2875\nelse\n  touch /tekton/results/JAVA_COMMUNITY_DEPENDENCIES\nfi\n",
                     "arguments": null,
                     "environment": {
                       "container": "analyse-dependencies-java-sbom",
@@ -472,16 +499,16 @@
                     "arguments": null,
                     "environment": {
                       "container": "merge-syft-sboms",
-                      "image": "oci://registry.access.redhat.com/ubi9/python-39@sha256:65cab0cf8b364d56e4a70789b65cda83f49b321b11fff5b228c959f3c992c596"
+                      "image": "oci://registry.access.redhat.com/ubi9/python-39@sha256:5b8dd87d19a7f9e5ba0b900471f0920e109e0412fbdc49539073ed86afdadf8a"
                     },
                     "annotations": null
                   },
                   {
-                    "entryPoint": "if [ -n \"${PREFETCH_INPUT}\" ]; then\n  echo \"Merging contents of sbom-cachi2.json into sbom-cyclonedx.json\"\n  /src/utils/merge_syft_sbom.py sbom-cachi2.json sbom-cyclonedx.json > sbom-temp.json\n  mv sbom-temp.json sbom-cyclonedx.json\nelse\n  echo \"Skipping step since no Cachi2 SBOM was produced\"\nfi\n",
+                    "entryPoint": "if [ -f \"sbom-cachi2.json\" ]; then\n  echo \"Merging contents of sbom-cachi2.json into sbom-cyclonedx.json\"\n  /src/utils/merge_syft_sbom.py sbom-cachi2.json sbom-cyclonedx.json > sbom-temp.json\n  mv sbom-temp.json sbom-cyclonedx.json\nelse\n  echo \"Skipping step since no Cachi2 SBOM was produced\"\nfi\n",
                     "arguments": null,
                     "environment": {
                       "container": "merge-cachi2-sbom",
-                      "image": "oci://quay.io/redhat-appstudio/cachi2@sha256:001acfbad47e132a90998d45076a0dbe0d8beacf0bec12b4d9a5aa796f4a9cad"
+                      "image": "oci://quay.io/redhat-appstudio/cachi2@sha256:1fc772aa3636fd0b43d62120d832e5913843e028e8cac42814b487c3a0a32bd8"
                     },
                     "annotations": null
                   },
@@ -490,12 +517,21 @@
                     "arguments": null,
                     "environment": {
                       "container": "create-purl-sbom",
-                      "image": "oci://registry.access.redhat.com/ubi9/python-39@sha256:65cab0cf8b364d56e4a70789b65cda83f49b321b11fff5b228c959f3c992c596"
+                      "image": "oci://registry.access.redhat.com/ubi9/python-39@sha256:5b8dd87d19a7f9e5ba0b900471f0920e109e0412fbdc49539073ed86afdadf8a"
                     },
                     "annotations": null
                   },
                   {
-                    "entryPoint": "base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations \"org.opencontainers.image.base.name\"}}' $IMAGE | cut -f1 -d'@')\nbase_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations \"org.opencontainers.image.base.digest\"}}' $IMAGE)\ncontainer=$(buildah from --pull-never $IMAGE)\nbuildah copy $container sbom-cyclonedx.json sbom-purl.json /root/buildinfo/content_manifests/\nbuildah config -a org.opencontainers.image.base.name=${base_image_name} -a org.opencontainers.image.base.digest=${base_image_digest} $container\nbuildah commit $container $IMAGE\n\nstatus=-1\nmax_run=5\nsleep_sec=10\nfor run in $(seq 1 $max_run); do\n  status=0\n  [ \"$run\" -gt 1 ] && sleep $sleep_sec\n  echo \"Pushing sbom image to registry\"\n  buildah push \\\n    --tls-verify=$TLSVERIFY \\\n    --digestfile /workspace/source/image-digest $IMAGE \\\n    docker://$IMAGE && break || status=$?\ndone\nif [ \"$status\" -ne 0 ]; then\n    echo \"Failed to push sbom image to registry after ${max_run} tries\"\n    exit 1\nfi\n\ncat \"/workspace/source\"/image-digest | tee /tekton/results/IMAGE_DIGEST\necho -n \"$IMAGE\" | tee /tekton/results/IMAGE_URL\n",
+                    "entryPoint": "python3 /app/base_images_sbom_script.py --sbom=sbom-cyclonedx.json --base-images-from-dockerfile=base_images_from_dockerfile --base-images-digests=$BASE_IMAGES_DIGESTS_PATH\n",
+                    "arguments": null,
+                    "environment": {
+                      "container": "create-base-images-sbom",
+                      "image": "oci://quay.io/redhat-appstudio/base-images-sbom-script@sha256:667669e3def018f9dbb8eaf8868887a40bc07842221e9a98f6787edcff021840"
+                    },
+                    "annotations": null
+                  },
+                  {
+                    "entryPoint": "if [ -n \"${PARAM_BUILDER_IMAGE}\" ]; then\n  echo \"WARNING: provided deprecated BUILDER_IMAGE parameter has no effect.\"\nfi\n\nbase_image_name=$(buildah inspect --format '{{ index .ImageAnnotations \"org.opencontainers.image.base.name\"}}' $IMAGE | cut -f1 -d'@')\nbase_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations \"org.opencontainers.image.base.digest\"}}' $IMAGE)\ncontainer=$(buildah from --pull-never $IMAGE)\nbuildah copy $container sbom-cyclonedx.json sbom-purl.json /root/buildinfo/content_manifests/\nbuildah config -a org.opencontainers.image.base.name=${base_image_name} -a org.opencontainers.image.base.digest=${base_image_digest} $container\nbuildah commit $container $IMAGE\n\nstatus=-1\nmax_run=5\nsleep_sec=10\nfor run in $(seq 1 $max_run); do\n  status=0\n  [ \"$run\" -gt 1 ] && sleep $sleep_sec\n  echo \"Pushing sbom image to registry\"\n  buildah push \\\n    --tls-verify=$TLSVERIFY \\\n    --digestfile /workspace/source/image-digest $IMAGE \\\n    docker://$IMAGE && break || status=$?\ndone\nif [ \"$status\" -ne 0 ]; then\n    echo \"Failed to push sbom image to registry after ${max_run} tries\"\n    exit 1\nfi\n\ncat \"/workspace/source\"/image-digest | tee /tekton/results/IMAGE_DIGEST\necho -n \"$IMAGE\" | tee /tekton/results/IMAGE_URL\n",
                     "arguments": null,
                     "environment": {
                       "container": "inject-sbom-and-push",
@@ -512,7 +548,7 @@
                       "sbom-cyclonedx.json",
                       "--type",
                       "cyclonedx",
-                      "quay.io/redhat-appstudio/ec-golden-image:68b69547cad3c4ba856fe6b06154012f33dd8b5a"
+                      "quay.io/redhat-appstudio/ec-golden-image:b0d7c600114b39f0f14e4e85a7c8aed7c4de316e-amd64"
                     ],
                     "environment": {
                       "container": "upload-sbom",
@@ -524,70 +560,77 @@
                 "invocation": {
                   "configSource": {},
                   "parameters": {
-                    "BUILDER_IMAGE": "quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb",
-                    "COMMIT_SHA": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                    "BUILDER_IMAGE": "",
+                    "BUILD_ARGS": [],
+                    "BUILD_ARGS_FILE": "",
+                    "COMMIT_SHA": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                     "CONTEXT": ".",
                     "DOCKERFILE": "Containerfile",
                     "DOCKER_AUTH": "",
+                    "ENTITLEMENT_SECRET": "etc-pki-entitlement",
                     "HERMETIC": "true",
-                    "IMAGE": "quay.io/redhat-appstudio/ec-golden-image:68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                    "IMAGE": "quay.io/redhat-appstudio/ec-golden-image:b0d7c600114b39f0f14e4e85a7c8aed7c4de316e-amd64",
                     "IMAGE_EXPIRES_AFTER": "",
+                    "PLATFORM": "linux/amd64",
                     "PREFETCH_INPUT": "",
+                    "TARGET_STAGE": "",
                     "TLSVERIFY": "true",
                     "YUM_REPOS_D_FETCHED": "fetched.repos.d",
                     "YUM_REPOS_D_SRC": "repos.d",
-                    "YUM_REPOS_D_TARGET": "/etc/yum.repos.d"
+                    "YUM_REPOS_D_TARGET": "/etc/yum.repos.d",
+                    "caTrustConfigMapKey": "ca-bundle.crt",
+                    "caTrustConfigMapName": "trusted-ca"
                   },
                   "environment": {
                     "annotations": {
-                      "build.appstudio.openshift.io/repo": "https://github.com/enterprise-contract/golden-container?rev=68b69547cad3c4ba856fe6b06154012f33dd8b5a",
-                      "build.appstudio.redhat.com/commit_sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "build.appstudio.openshift.io/repo": "https://github.com/enterprise-contract/golden-container?rev=b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "build.appstudio.redhat.com/commit_sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "build.appstudio.redhat.com/target_branch": "main",
-                      "pipeline.tekton.dev/release": "876b81e",
+                      "pipeline.tekton.dev/release": "34d8c0f",
                       "pipelinesascode.tekton.dev/branch": "main",
-                      "pipelinesascode.tekton.dev/check-run-id": "20539638032",
+                      "pipelinesascode.tekton.dev/check-run-id": "25796873737",
+                      "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
                       "pipelinesascode.tekton.dev/event-type": "push",
-                      "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-iiug",
+                      "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-yoreai",
                       "pipelinesascode.tekton.dev/git-provider": "github",
                       "pipelinesascode.tekton.dev/installation-id": "34493006",
-                      "pipelinesascode.tekton.dev/log-url": "https://console.redhat.com/preview/application-pipeline",
+                      "pipelinesascode.tekton.dev/log-url": "https://console.redhat.com/preview/application-pipeline/ns/rhtap-contract-tenant/pipelinerun/golden-container-on-push-xd69b",
                       "pipelinesascode.tekton.dev/max-keep-runs": "3",
                       "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"main\"",
                       "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
                       "pipelinesascode.tekton.dev/repo-url": "https://github.com/enterprise-contract/golden-container",
                       "pipelinesascode.tekton.dev/repository": "golden-container",
                       "pipelinesascode.tekton.dev/sender": "renovate[bot]",
-                      "pipelinesascode.tekton.dev/sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
-                      "pipelinesascode.tekton.dev/sha-title": "Update quay.io/redhat-appstudio-tekton-catalog/task-clair-scan:0.1 Docker digest to 63b42c0",
-                      "pipelinesascode.tekton.dev/sha-url": "https://github.com/enterprise-contract/golden-container/commit/68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "pipelinesascode.tekton.dev/sha-title": "Update github/codeql-action action to v3.25.8",
+                      "pipelinesascode.tekton.dev/sha-url": "https://github.com/enterprise-contract/golden-container/commit/b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "pipelinesascode.tekton.dev/state": "started",
                       "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
                       "pipelinesascode.tekton.dev/url-repository": "golden-container",
+                      "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"golden-container\",\"commit\":\"b0d7c600114b39f0f14e4e85a7c8aed7c4de316e\",\"eventType\":\"push\"}",
                       "tekton.dev/pipelines.minVersion": "0.12.1",
-                      "tekton.dev/tags": "image-build, appstudio, hacbs"
+                      "tekton.dev/tags": "image-build, appstudio, hacbs",
+                      "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-d93a888b435563acf59b69d48e089821-3396942a9f22c798-01\"}"
                     },
                     "labels": {
                       "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
-                      "app.kubernetes.io/version": "v0.22.4",
+                      "app.kubernetes.io/version": "v0.27.0",
                       "appstudio.openshift.io/application": "golden-container",
                       "appstudio.openshift.io/component": "golden-container",
                       "build.appstudio.redhat.com/build_type": "docker",
                       "pipelines.appstudio.openshift.io/type": "build",
-                      "pipelinesascode.tekton.dev/branch": "main",
-                      "pipelinesascode.tekton.dev/check-run-id": "20539638032",
+                      "pipelinesascode.tekton.dev/check-run-id": "25796873737",
                       "pipelinesascode.tekton.dev/event-type": "push",
-                      "pipelinesascode.tekton.dev/git-provider": "github",
                       "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
                       "pipelinesascode.tekton.dev/repository": "golden-container",
-                      "pipelinesascode.tekton.dev/sender": "renovate__bot",
-                      "pipelinesascode.tekton.dev/sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "pipelinesascode.tekton.dev/state": "started",
                       "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
                       "pipelinesascode.tekton.dev/url-repository": "golden-container",
                       "tekton.dev/memberOf": "tasks",
-                      "tekton.dev/pipeline": "golden-container-on-push-fdv54",
-                      "tekton.dev/pipelineRun": "golden-container-on-push-fdv54",
-                      "tekton.dev/pipelineTask": "build-container",
+                      "tekton.dev/pipeline": "golden-container-on-push-xd69b",
+                      "tekton.dev/pipelineRun": "golden-container-on-push-xd69b",
+                      "tekton.dev/pipelineTask": "build-container-amd64",
                       "tekton.dev/task": "buildah"
                     }
                   }
@@ -596,7 +639,7 @@
                   {
                     "name": "BASE_IMAGES_DIGESTS",
                     "type": "string",
-                    "value": "registry.access.redhat.com/ubi9/ubi-micro:<none>@sha256:14a2cd49b11eb39586f5abdefc63739f47cd5b8099e0d6946d7ee24812e7e746\n"
+                    "value": "registry.access.redhat.com/ubi9/ubi-micro:<none>@sha256:1c8483e0fda0e990175eb9855a5f15e0910d2038dd397d9e2b357630f0321e6d\n"
                   },
                   {
                     "name": "JAVA_COMMUNITY_DEPENDENCIES",
@@ -606,20 +649,478 @@
                   {
                     "name": "IMAGE_DIGEST",
                     "type": "string",
-                    "value": "sha256:6fa252a7df2735b84674e64b78ac66279af0f2cbbb7ed1dd6a534daf0a4b8738"
+                    "value": "sha256:b4cfd7c1fc510d6b934c195cf5bf1d647ff332215104a0d05942fc0aa1fe09e7"
                   },
                   {
                     "name": "IMAGE_URL",
                     "type": "string",
-                    "value": "quay.io/redhat-appstudio/ec-golden-image:68b69547cad3c4ba856fe6b06154012f33dd8b5a"
+                    "value": "quay.io/redhat-appstudio/ec-golden-image:b0d7c600114b39f0f14e4e85a7c8aed7c4de316e-amd64"
+                  }
+                ]
+              },
+              {
+                "name": "build-container-arm64",
+                "after": [
+                  "clone-repository",
+                  "init"
+                ],
+                "ref": {
+                  "resolver": "bundles",
+                  "params": [
+                    {
+                      "name": "name",
+                      "value": "buildah-remote"
+                    },
+                    {
+                      "name": "bundle",
+                      "value": "quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.1@sha256:09ad5680c2b9ed61abb40c2f0071b7e889f799a47e1ece546299617d79e299f1"
+                    },
+                    {
+                      "name": "kind",
+                      "value": "task"
+                    }
+                  ]
+                },
+                "startedOn": "2024-06-04T15:53:59Z",
+                "finishedOn": "2024-06-04T15:56:40Z",
+                "status": "Succeeded",
+                "steps": [
+                  {
+                    "entryPoint": "set -o verbose\nmkdir -p ~/.ssh\nif [ -e \"/ssh/error\" ]; then\n  #no server could be provisioned\n  cat /ssh/error\n  exit 1\nelif [ -e \"/ssh/otp\" ]; then\n curl --cacert /ssh/otp-ca -XPOST -d @/ssh/otp $(cat /ssh/otp-server) >~/.ssh/id_rsa\n echo \"\" >> ~/.ssh/id_rsa\nelse\n  cp /ssh/id_rsa ~/.ssh\nfi\nchmod 0400 ~/.ssh/id_rsa\nexport SSH_HOST=$(cat /ssh/host)\nexport BUILD_DIR=$(cat /ssh/user-dir)\nexport SSH_ARGS=\"-o StrictHostKeyChecking=no\"\nmkdir -p scripts\necho \"$BUILD_DIR\"\nssh $SSH_ARGS \"$SSH_HOST\"  mkdir -p \"$BUILD_DIR/workspaces\" \"$BUILD_DIR/scripts\"\n\nPORT_FORWARD=\"\"\nPODMAN_PORT_FORWARD=\"\"\nif [ -n \"$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR\" ] ; then\nPORT_FORWARD=\" -L 80:$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR:80\"\nPODMAN_PORT_FORWARD=\" -e JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR=localhost\"\nfi\n\nrsync -ra /workspace/source/ \"$SSH_HOST:$BUILD_DIR/workspaces/source/\"\nrsync -ra \"$HOME/.docker/\" \"$SSH_HOST:$BUILD_DIR/.docker/\"\nrsync -ra \"/tekton/results/\" \"$SSH_HOST:$BUILD_DIR/tekton-results/\"\ncat >scripts/script-build.sh <<'REMOTESSHEOF'\n#!/bin/bash\nset -o verbose\nset -e\ncd /workspace/source\nif [ -n \"${PARAM_BUILDER_IMAGE}\" ]; then\n  echo \"WARNING: provided deprecated BUILDER_IMAGE parameter has no effect.\"\nfi\n\nca_bundle=/mnt/trusted-ca/ca-bundle.crt\nif [ -f \"$ca_bundle\" ]; then\n  echo \"INFO: Using mounted CA bundle: $ca_bundle\"\n  cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors\n  update-ca-trust\nfi\n\nSOURCE_CODE_DIR=source\nif [ -e \"$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE\" ]; then\n  dockerfile_path=\"$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE\"\nelif [ -e \"$SOURCE_CODE_DIR/$DOCKERFILE\" ]; then\n  dockerfile_path=\"$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE\"\nelif echo \"$DOCKERFILE\" | grep -q \"^https\\?://\"; then\n  echo \"Fetch Dockerfile from $DOCKERFILE\"\n  dockerfile_path=$(mktemp --suffix=-Dockerfile)\n  http_code=$(curl -s -L -w \"%{http_code}\" --output \"$dockerfile_path\" \"$DOCKERFILE\")\n  if [ $http_code != 200 ]; then\n    echo \"No Dockerfile is fetched. Server responds $http_code\"\n    exit 1\n  fi\n  http_code=$(curl -s -L -w \"%{http_code}\" --output \"$dockerfile_path.dockerignore.tmp\" \"$DOCKERFILE.dockerignore\")\n  if [ $http_code = 200 ]; then\n    echo \"Fetched .dockerignore from $DOCKERFILE.dockerignore\"\n    mv \"$dockerfile_path.dockerignore.tmp\" $SOURCE_CODE_DIR/$CONTEXT/.dockerignore\n  fi\nelse\n  echo \"Cannot find Dockerfile $DOCKERFILE\"\n  exit 1\nfi\nif [ -n \"$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR\" ] && grep -q '^\\s*RUN \\(./\\)\\?mvn' \"$dockerfile_path\"; then\n  sed -i -e \"s|^\\s*RUN \\(\\(./\\)\\?mvn\\)\\(.*\\)|RUN echo \\\"<settings><mirrors><mirror><id>mirror.default</id><url>http://$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR/v1/cache/default/0/</url><mirrorOf>*</mirrorOf></mirror></mirrors></settings>\\\" > /tmp/settings.yaml; \\1 -s /tmp/settings.yaml \\3|g\" \"$dockerfile_path\"\n  touch /var/lib/containers/java\nfi\n\n# Fixing group permission on /var/lib/containers\nchown root:root /var/lib/containers\n\nsed -i 's/^\\s*short-name-mode\\s*=\\s*.*/short-name-mode = \"disabled\"/' /etc/containers/registries.conf\n\n# Setting new namespace to run buildah - 2^32-2\necho 'root:1:4294967294' | tee -a /etc/subuid >> /etc/subgid\n\nBUILDAH_ARGS=()\n\nBASE_IMAGES=$(grep -i '^\\s*FROM' \"$dockerfile_path\" | sed 's/--platform=\\S*//' | awk '{print $2}')\nif [ \"${HERMETIC}\" == \"true\" ]; then\n  BUILDAH_ARGS+=(\"--pull=never\")\n  UNSHARE_ARGS=\"--net\"\n  for image in $BASE_IMAGES; do\n    if [ \"${image}\" != \"scratch\" ]; then\n      unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image\n    fi\n  done\n  echo \"Build will be executed with network isolation\"\nfi\n\nif [ -n \"${TARGET_STAGE}\" ]; then\n  BUILDAH_ARGS+=(\"--target=${TARGET_STAGE}\")\nfi\n\nif [ -n \"${BUILD_ARGS_FILE}\" ]; then\n  BUILDAH_ARGS+=(\"--build-arg-file=$(pwd)/$SOURCE_CODE_DIR/${BUILD_ARGS_FILE}\")\nfi\n\nfor build_arg in \"$@\"; do\n  BUILDAH_ARGS+=(\"--build-arg=$build_arg\")\ndone\n\nif [ -f \"/workspace/source/cachi2/cachi2.env\" ]; then\n  cp -r \"/workspace/source/cachi2\" /tmp/\n  chmod -R go+rwX /tmp/cachi2\n  VOLUME_MOUNTS=\"--volume /tmp/cachi2:/cachi2\"\n  sed -i 's|^\\s*run |RUN . /cachi2/cachi2.env \\&\\& \\\\\\n    |i' \"$dockerfile_path\"\n  echo \"Prefetched content will be made available\"\n\n  prefetched_repo_for_my_arch=\"/tmp/cachi2/output/deps/rpm/$(uname -m)/repos.d/cachi2.repo\"\n  if [ -f \"$prefetched_repo_for_my_arch\" ]; then\n    echo \"Adding $prefetched_repo_for_my_arch to $YUM_REPOS_D_FETCHED\"\n    mkdir -p \"$YUM_REPOS_D_FETCHED\"\n    cp --no-clobber \"$prefetched_repo_for_my_arch\" \"$YUM_REPOS_D_FETCHED\"\n  fi\nfi\n\n# if yum repofiles stored in git, copy them to mount point outside the source dir\nif [ -d \"${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}\" ]; then\n  mkdir -p ${YUM_REPOS_D_FETCHED}\n  cp -r ${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}/* ${YUM_REPOS_D_FETCHED}\nfi\n\n# if anything in the repofiles mount point (either fetched or from git), mount it\nif [ -d \"${YUM_REPOS_D_FETCHED}\" ]; then\n  chmod -R go+rwX ${YUM_REPOS_D_FETCHED}\n  mount_point=$(realpath ${YUM_REPOS_D_FETCHED})\n  VOLUME_MOUNTS=\"${VOLUME_MOUNTS} --volume ${mount_point}:${YUM_REPOS_D_TARGET}\"\nfi\n\nLABELS=(\n  \"--label\" \"build-date=$(date -u +'%Y-%m-%dT%H:%M:%S')\"\n  \"--label\" \"architecture=$(uname -m)\"\n  \"--label\" \"vcs-type=git\"\n)\n[ -n \"$COMMIT_SHA\" ] && LABELS+=(\"--label\" \"vcs-ref=$COMMIT_SHA\")\n[ -n \"$IMAGE_EXPIRES_AFTER\" ] && LABELS+=(\"--label\" \"quay.expires-after=$IMAGE_EXPIRES_AFTER\")\n\nENTITLEMENT_PATH=\"/entitlement\"\nif [ -d \"$ENTITLEMENT_PATH\" ]; then\n  cp -r --preserve=mode \"$ENTITLEMENT_PATH\" /tmp/entitlement\n  VOLUME_MOUNTS=\"${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement\"\n  echo \"Adding the entitlement to the build\"\nfi\n\nunshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \\\n  $VOLUME_MOUNTS \\\n  \"${BUILDAH_ARGS[@]}\" \\\n  \"${LABELS[@]}\" \\\n  --tls-verify=$TLSVERIFY --no-cache \\\n  --ulimit nofile=4096:4096 \\\n  -f \"$dockerfile_path\" -t $IMAGE .\n\ncontainer=$(buildah from --pull-never $IMAGE)\nbuildah mount $container | tee /workspace/container_path\necho $container > /workspace/container_name\n\n# Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later\nif [ -f \"/tmp/cachi2/output/bom.json\" ]; then\n  cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json\nfi\n\n# Expose base image digests\nfor image in $BASE_IMAGES; do\n  if [ \"${image}\" != \"scratch\" ]; then\n    buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference=\"$image\" >> /tekton/results/BASE_IMAGES_DIGESTS\n  fi\ndone\n\n# Needed to generate base images SBOM\necho \"$BASE_IMAGES\" > /workspace/source/base_images_from_dockerfile\n\nbuildah push \"$IMAGE\" oci:rhtap-final-image\nREMOTESSHEOF\nchmod +x scripts/script-build.sh\nrsync -ra scripts \"$SSH_HOST:$BUILD_DIR\"\nssh $SSH_ARGS \"$SSH_HOST\" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \\\n -e BUILDAH_FORMAT=\"$BUILDAH_FORMAT\" \\\n -e STORAGE_DRIVER=\"$STORAGE_DRIVER\" \\\n -e HERMETIC=\"$HERMETIC\" \\\n -e CONTEXT=\"$CONTEXT\" \\\n -e DOCKERFILE=\"$DOCKERFILE\" \\\n -e IMAGE=\"$IMAGE\" \\\n -e TLSVERIFY=\"$TLSVERIFY\" \\\n -e IMAGE_EXPIRES_AFTER=\"$IMAGE_EXPIRES_AFTER\" \\\n -e YUM_REPOS_D_SRC=\"$YUM_REPOS_D_SRC\" \\\n -e YUM_REPOS_D_FETCHED=\"$YUM_REPOS_D_FETCHED\" \\\n -e YUM_REPOS_D_TARGET=\"$YUM_REPOS_D_TARGET\" \\\n -e TARGET_STAGE=\"$TARGET_STAGE\" \\\n -e PARAM_BUILDER_IMAGE=\"$PARAM_BUILDER_IMAGE\" \\\n -e ENTITLEMENT_SECRET=\"$ENTITLEMENT_SECRET\" \\\n -e BUILD_ARGS_FILE=\"$BUILD_ARGS_FILE\" \\\n -e COMMIT_SHA=\"$COMMIT_SHA\" \\\n -v \"$BUILD_DIR/workspaces/source:/workspace/source:Z\" \\\n -v \"$BUILD_DIR/.docker/:/root/.docker:Z\" \\\n -v \"$BUILD_DIR/tekton-results/:/tekton/results:Z\" \\\n -v $BUILD_DIR/scripts:/script:Z \\\n--user=0  --rm  \"$BUILDER_IMAGE\" /script/script-build.sh\nrsync -ra \"$SSH_HOST:$BUILD_DIR/workspaces/source/\" \"/workspace/source/\"\nrsync -ra \"$SSH_HOST:$BUILD_DIR/tekton-results/\" \"/tekton/results/\"\nbuildah pull oci:rhtap-final-image\nbuildah images\nbuildah tag localhost/rhtap-final-image \"$IMAGE\"\ncontainer=$(buildah from --pull-never \"$IMAGE\")\nbuildah mount \"$container\" | tee /workspace/container_path\necho $container > /workspace/container_name",
+                    "arguments": null,
+                    "environment": {
+                      "container": "build",
+                      "image": "oci://quay.io/redhat-appstudio/multi-platform-runner@sha256:246adeaaba600e207131d63a7f706cffdcdc37d8f600c56187123ec62823ff44"
+                    },
+                    "annotations": null
+                  },
+                  {
+                    "entryPoint": "echo \"Running syft on the source directory\"\nsyft dir:/workspace/source/source --output cyclonedx-json=/workspace/source/sbom-source.json\nfind $(cat /workspace/container_path) -xtype l -delete\necho \"Running syft on the image filesystem\"\nsyft dir:$(cat /workspace/container_path) --output cyclonedx-json=/workspace/source/sbom-image.json\n",
+                    "arguments": null,
+                    "environment": {
+                      "container": "sbom-syft-generate",
+                      "image": "oci://quay.io/redhat-appstudio/syft@sha256:1910b829997650c696881e5fc2fc654ddf3184c27edb1b2024e9cb2ba51ac431"
+                    },
+                    "annotations": null
+                  },
+                  {
+                    "entryPoint": "if [ -f /var/lib/containers/java ]; then\n  /opt/jboss/container/java/run/run-java.sh analyse-dependencies path $(cat /workspace/container_path) -s /workspace/source/sbom-image.json --task-run-name golden-container-on-push-xd69b-build-container-arm64 --publishers /tekton/results/SBOM_JAVA_COMPONENTS_COUNT\n  sed -i 's/^/ /' /tekton/results/SBOM_JAVA_COMPONENTS_COUNT # Workaround for SRVKP-2875\nelse\n  touch /tekton/results/JAVA_COMMUNITY_DEPENDENCIES\nfi\n",
+                    "arguments": null,
+                    "environment": {
+                      "container": "analyse-dependencies-java-sbom",
+                      "image": "oci://quay.io/redhat-appstudio/hacbs-jvm-build-request-processor@sha256:530d1932dc47d05da42a3a329a05eb30fe7105aa9e0d3f0d682dfa015e33b4ac"
+                    },
+                    "annotations": null
+                  },
+                  {
+                    "entryPoint": "#!/bin/python3\nimport json\n\n# load SBOMs\nwith open(\"./sbom-image.json\") as f:\n  image_sbom = json.load(f)\n\nwith open(\"./sbom-source.json\") as f:\n  source_sbom = json.load(f)\n\n# fetch unique components from available SBOMs\ndef get_identifier(component):\n  return component[\"name\"] + '@' + component.get(\"version\", \"\")\n\nimage_sbom_components = image_sbom.get(\"components\", [])\nexisting_components = [get_identifier(component) for component in image_sbom_components]\n\nsource_sbom_components = source_sbom.get(\"components\", [])\nfor component in source_sbom_components:\n  if get_identifier(component) not in existing_components:\n    image_sbom_components.append(component)\n    existing_components.append(get_identifier(component))\n\nimage_sbom_components.sort(key=lambda c: get_identifier(c))\n\n# write the CycloneDX unified SBOM\nwith open(\"./sbom-cyclonedx.json\", \"w\") as f:\n  json.dump(image_sbom, f, indent=4)\n",
+                    "arguments": null,
+                    "environment": {
+                      "container": "merge-syft-sboms",
+                      "image": "oci://registry.access.redhat.com/ubi9/python-39@sha256:5b8dd87d19a7f9e5ba0b900471f0920e109e0412fbdc49539073ed86afdadf8a"
+                    },
+                    "annotations": null
+                  },
+                  {
+                    "entryPoint": "if [ -f \"sbom-cachi2.json\" ]; then\n  echo \"Merging contents of sbom-cachi2.json into sbom-cyclonedx.json\"\n  /src/utils/merge_syft_sbom.py sbom-cachi2.json sbom-cyclonedx.json > sbom-temp.json\n  mv sbom-temp.json sbom-cyclonedx.json\nelse\n  echo \"Skipping step since no Cachi2 SBOM was produced\"\nfi\n",
+                    "arguments": null,
+                    "environment": {
+                      "container": "merge-cachi2-sbom",
+                      "image": "oci://quay.io/redhat-appstudio/cachi2@sha256:1fc772aa3636fd0b43d62120d832e5913843e028e8cac42814b487c3a0a32bd8"
+                    },
+                    "annotations": null
+                  },
+                  {
+                    "entryPoint": "#!/bin/python3\nimport json\n\nwith open(\"./sbom-cyclonedx.json\") as f:\n  cyclonedx_sbom = json.load(f)\n\npurls = [{\"purl\": component[\"purl\"]} for component in cyclonedx_sbom.get(\"components\", []) if \"purl\" in component]\npurl_content = {\"image_contents\": {\"dependencies\": purls}}\n\nwith open(\"sbom-purl.json\", \"w\") as output_file:\n  json.dump(purl_content, output_file, indent=4)\n",
+                    "arguments": null,
+                    "environment": {
+                      "container": "create-purl-sbom",
+                      "image": "oci://registry.access.redhat.com/ubi9/python-39@sha256:5b8dd87d19a7f9e5ba0b900471f0920e109e0412fbdc49539073ed86afdadf8a"
+                    },
+                    "annotations": null
+                  },
+                  {
+                    "entryPoint": "python3 /app/base_images_sbom_script.py --sbom=sbom-cyclonedx.json --base-images-from-dockerfile=base_images_from_dockerfile --base-images-digests=$BASE_IMAGES_DIGESTS_PATH\n",
+                    "arguments": null,
+                    "environment": {
+                      "container": "create-base-images-sbom",
+                      "image": "oci://quay.io/redhat-appstudio/base-images-sbom-script@sha256:667669e3def018f9dbb8eaf8868887a40bc07842221e9a98f6787edcff021840"
+                    },
+                    "annotations": null
+                  },
+                  {
+                    "entryPoint": "if [ -n \"${PARAM_BUILDER_IMAGE}\" ]; then\n  echo \"WARNING: provided deprecated BUILDER_IMAGE parameter has no effect.\"\nfi\n\nbase_image_name=$(buildah inspect --format '{{ index .ImageAnnotations \"org.opencontainers.image.base.name\"}}' $IMAGE | cut -f1 -d'@')\nbase_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations \"org.opencontainers.image.base.digest\"}}' $IMAGE)\ncontainer=$(buildah from --pull-never $IMAGE)\nbuildah copy $container sbom-cyclonedx.json sbom-purl.json /root/buildinfo/content_manifests/\nbuildah config -a org.opencontainers.image.base.name=${base_image_name} -a org.opencontainers.image.base.digest=${base_image_digest} $container\nbuildah commit $container $IMAGE\n\nstatus=-1\nmax_run=5\nsleep_sec=10\nfor run in $(seq 1 $max_run); do\n  status=0\n  [ \"$run\" -gt 1 ] && sleep $sleep_sec\n  echo \"Pushing sbom image to registry\"\n  buildah push \\\n    --tls-verify=$TLSVERIFY \\\n    --digestfile /workspace/source/image-digest $IMAGE \\\n    docker://$IMAGE && break || status=$?\ndone\nif [ \"$status\" -ne 0 ]; then\n    echo \"Failed to push sbom image to registry after ${max_run} tries\"\n    exit 1\nfi\n\ncat \"/workspace/source\"/image-digest | tee /tekton/results/IMAGE_DIGEST\necho -n \"$IMAGE\" | tee /tekton/results/IMAGE_URL\n",
+                    "arguments": null,
+                    "environment": {
+                      "container": "inject-sbom-and-push",
+                      "image": "oci://quay.io/redhat-appstudio/buildah@sha256:017ec8d3e8e1fefcd47fc11bde655fa9c8f09a279b690be98397875bd542fb44"
+                    },
+                    "annotations": null
+                  },
+                  {
+                    "entryPoint": "",
+                    "arguments": [
+                      "attach",
+                      "sbom",
+                      "--sbom",
+                      "sbom-cyclonedx.json",
+                      "--type",
+                      "cyclonedx",
+                      "quay.io/redhat-appstudio/ec-golden-image:b0d7c600114b39f0f14e4e85a7c8aed7c4de316e-arm64"
+                    ],
+                    "environment": {
+                      "container": "upload-sbom",
+                      "image": "oci://quay.io/redhat-appstudio/cosign@sha256:c883d6f8d39148f2cea71bff4622d196d89df3e510f36c140c097b932f0dd5d5"
+                    },
+                    "annotations": null
+                  }
+                ],
+                "invocation": {
+                  "configSource": {},
+                  "parameters": {
+                    "BUILDER_IMAGE": "",
+                    "BUILD_ARGS": [],
+                    "BUILD_ARGS_FILE": "",
+                    "COMMIT_SHA": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                    "CONTEXT": ".",
+                    "DOCKERFILE": "Containerfile",
+                    "DOCKER_AUTH": "",
+                    "ENTITLEMENT_SECRET": "etc-pki-entitlement",
+                    "HERMETIC": "true",
+                    "IMAGE": "quay.io/redhat-appstudio/ec-golden-image:b0d7c600114b39f0f14e4e85a7c8aed7c4de316e-arm64",
+                    "IMAGE_EXPIRES_AFTER": "",
+                    "PLATFORM": "linux/arm64",
+                    "PREFETCH_INPUT": "",
+                    "TARGET_STAGE": "",
+                    "TLSVERIFY": "true",
+                    "YUM_REPOS_D_FETCHED": "fetched.repos.d",
+                    "YUM_REPOS_D_SRC": "repos.d",
+                    "YUM_REPOS_D_TARGET": "/etc/yum.repos.d",
+                    "caTrustConfigMapKey": "ca-bundle.crt",
+                    "caTrustConfigMapName": "trusted-ca"
+                  },
+                  "environment": {
+                    "annotations": {
+                      "build.appstudio.openshift.io/repo": "https://github.com/enterprise-contract/golden-container?rev=b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "build.appstudio.redhat.com/allocation-start-time": "1717516462",
+                      "build.appstudio.redhat.com/cloud-address": "10.207.4.20",
+                      "build.appstudio.redhat.com/commit_sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "build.appstudio.redhat.com/target_branch": "main",
+                      "pipeline.tekton.dev/release": "34d8c0f",
+                      "pipelinesascode.tekton.dev/branch": "main",
+                      "pipelinesascode.tekton.dev/check-run-id": "25796873737",
+                      "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
+                      "pipelinesascode.tekton.dev/event-type": "push",
+                      "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-yoreai",
+                      "pipelinesascode.tekton.dev/git-provider": "github",
+                      "pipelinesascode.tekton.dev/installation-id": "34493006",
+                      "pipelinesascode.tekton.dev/log-url": "https://console.redhat.com/preview/application-pipeline/ns/rhtap-contract-tenant/pipelinerun/golden-container-on-push-xd69b",
+                      "pipelinesascode.tekton.dev/max-keep-runs": "3",
+                      "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"main\"",
+                      "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
+                      "pipelinesascode.tekton.dev/repo-url": "https://github.com/enterprise-contract/golden-container",
+                      "pipelinesascode.tekton.dev/repository": "golden-container",
+                      "pipelinesascode.tekton.dev/sender": "renovate[bot]",
+                      "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "pipelinesascode.tekton.dev/sha-title": "Update github/codeql-action action to v3.25.8",
+                      "pipelinesascode.tekton.dev/sha-url": "https://github.com/enterprise-contract/golden-container/commit/b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "pipelinesascode.tekton.dev/state": "started",
+                      "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
+                      "pipelinesascode.tekton.dev/url-repository": "golden-container",
+                      "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"golden-container\",\"commit\":\"b0d7c600114b39f0f14e4e85a7c8aed7c4de316e\",\"eventType\":\"push\"}",
+                      "tekton.dev/pipelines.minVersion": "0.12.1",
+                      "tekton.dev/tags": "image-build, appstudio, hacbs",
+                      "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-d93a888b435563acf59b69d48e089821-afd637fabb8edce5-01\"}"
+                    },
+                    "labels": {
+                      "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
+                      "app.kubernetes.io/version": "v0.27.0",
+                      "appstudio.openshift.io/application": "golden-container",
+                      "appstudio.openshift.io/component": "golden-container",
+                      "build.appstudio.redhat.com/build_type": "docker",
+                      "pipelines.appstudio.openshift.io/type": "build",
+                      "pipelinesascode.tekton.dev/check-run-id": "25796873737",
+                      "pipelinesascode.tekton.dev/event-type": "push",
+                      "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
+                      "pipelinesascode.tekton.dev/repository": "golden-container",
+                      "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "pipelinesascode.tekton.dev/state": "started",
+                      "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
+                      "pipelinesascode.tekton.dev/url-repository": "golden-container",
+                      "tekton.dev/memberOf": "tasks",
+                      "tekton.dev/pipeline": "golden-container-on-push-xd69b",
+                      "tekton.dev/pipelineRun": "golden-container-on-push-xd69b",
+                      "tekton.dev/pipelineTask": "build-container-arm64",
+                      "tekton.dev/task": "buildah-remote"
+                    }
+                  }
+                },
+                "results": [
+                  {
+                    "name": "BASE_IMAGES_DIGESTS",
+                    "type": "string",
+                    "value": "registry.access.redhat.com/ubi9/ubi-micro:<none>@sha256:1c8483e0fda0e990175eb9855a5f15e0910d2038dd397d9e2b357630f0321e6d\n"
+                  },
+                  {
+                    "name": "JAVA_COMMUNITY_DEPENDENCIES",
+                    "type": "string",
+                    "value": ""
+                  },
+                  {
+                    "name": "IMAGE_DIGEST",
+                    "type": "string",
+                    "value": "sha256:ade052c249de1420c0f860fef47b620f00135aade4a55bc385de1dd634e8cc7a"
+                  },
+                  {
+                    "name": "IMAGE_URL",
+                    "type": "string",
+                    "value": "quay.io/redhat-appstudio/ec-golden-image:b0d7c600114b39f0f14e4e85a7c8aed7c4de316e-arm64"
+                  }
+                ]
+              },
+              {
+                "name": "build-container",
+                "after": [
+                  "build-container-amd64",
+                  "build-container-arm64",
+                  "clone-repository",
+                  "init"
+                ],
+                "ref": {
+                  "resolver": "bundles",
+                  "params": [
+                    {
+                      "name": "name",
+                      "value": "build-image-manifest"
+                    },
+                    {
+                      "name": "bundle",
+                      "value": "quay.io/redhat-appstudio-tekton-catalog/task-build-image-manifest:0.1@sha256:e064b63b2311d23d6bf6538347cb4eb18c980d61883f48149bc9c728f76b276c"
+                    },
+                    {
+                      "name": "kind",
+                      "value": "task"
+                    }
+                  ]
+                },
+                "startedOn": "2024-06-04T15:56:40Z",
+                "finishedOn": "2024-06-04T15:56:50Z",
+                "status": "Succeeded",
+                "steps": [
+                  {
+                    "entryPoint": "#!/bin/bash\n# Fixing group permission on /var/lib/containers\nset -eu\nset -o pipefail\nchown root:root /var/lib/containers\n\nsed -i 's/^\\s*short-name-mode\\s*=\\s*.*/short-name-mode = \"disabled\"/' /etc/containers/registries.conf\n\nbuildah manifest create \"$IMAGE\"\nfor i in $@\ndo\n  TOADD=\"$i\"\n  if [[ $(echo $i | tr -cd \":\" | wc -c) == 2 ]]; then\n    #we need to remove the tag, and just reference the digest\n    #as tag + digest is not supported\n    TOADD=\"$(echo $i | cut -d: -f1)@sha256:$(echo $i | cut -d: -f3)\"\n  fi\n  echo \"Adding $TOADD\"\n  buildah manifest add $IMAGE \"docker://$TOADD\"\ndone\n\nstatus=-1\nmax_run=5\nsleep_sec=10\nfor run in $(seq 1 $max_run); do\n  status=0\n  [ \"$run\" -gt 1 ] && sleep $sleep_sec\n  echo \"Pushing image to registry\"\n  buildah manifest push \\\n    --tls-verify=$TLSVERIFY \\\n    --digestfile image-digest $IMAGE \\\n    docker://$IMAGE && break || status=$?\ndone\nif [ \"$status\" -ne 0 ]; then\n    echo \"Failed to push image to registry after ${max_run} tries\"\n    exit 1\nfi\n\ncat image-digest | tee /tekton/results/IMAGE_DIGEST\necho -n \"$IMAGE\" | tee /tekton/results/IMAGE_URL\n",
+                    "arguments": [
+                      "quay.io/redhat-appstudio/ec-golden-image:b0d7c600114b39f0f14e4e85a7c8aed7c4de316e-amd64@sha256:b4cfd7c1fc510d6b934c195cf5bf1d647ff332215104a0d05942fc0aa1fe09e7",
+                      "quay.io/redhat-appstudio/ec-golden-image:b0d7c600114b39f0f14e4e85a7c8aed7c4de316e-arm64@sha256:ade052c249de1420c0f860fef47b620f00135aade4a55bc385de1dd634e8cc7a"
+                    ],
+                    "environment": {
+                      "container": "build",
+                      "image": "oci://quay.io/redhat-appstudio/buildah@sha256:017ec8d3e8e1fefcd47fc11bde655fa9c8f09a279b690be98397875bd542fb44"
+                    },
+                    "annotations": null
+                  }
+                ],
+                "invocation": {
+                  "configSource": {},
+                  "parameters": {
+                    "COMMIT_SHA": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                    "IMAGE": "quay.io/redhat-appstudio/ec-golden-image:b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                    "IMAGES": [
+                      "quay.io/redhat-appstudio/ec-golden-image:b0d7c600114b39f0f14e4e85a7c8aed7c4de316e-amd64@sha256:b4cfd7c1fc510d6b934c195cf5bf1d647ff332215104a0d05942fc0aa1fe09e7",
+                      "quay.io/redhat-appstudio/ec-golden-image:b0d7c600114b39f0f14e4e85a7c8aed7c4de316e-arm64@sha256:ade052c249de1420c0f860fef47b620f00135aade4a55bc385de1dd634e8cc7a"
+                    ],
+                    "IMAGE_EXPIRES_AFTER": "",
+                    "TLSVERIFY": "true"
+                  },
+                  "environment": {
+                    "annotations": {
+                      "build.appstudio.openshift.io/repo": "https://github.com/enterprise-contract/golden-container?rev=b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "build.appstudio.redhat.com/commit_sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "build.appstudio.redhat.com/target_branch": "main",
+                      "pipeline.tekton.dev/release": "34d8c0f",
+                      "pipelinesascode.tekton.dev/branch": "main",
+                      "pipelinesascode.tekton.dev/check-run-id": "25796873737",
+                      "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
+                      "pipelinesascode.tekton.dev/event-type": "push",
+                      "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-yoreai",
+                      "pipelinesascode.tekton.dev/git-provider": "github",
+                      "pipelinesascode.tekton.dev/installation-id": "34493006",
+                      "pipelinesascode.tekton.dev/log-url": "https://console.redhat.com/preview/application-pipeline/ns/rhtap-contract-tenant/pipelinerun/golden-container-on-push-xd69b",
+                      "pipelinesascode.tekton.dev/max-keep-runs": "3",
+                      "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"main\"",
+                      "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
+                      "pipelinesascode.tekton.dev/repo-url": "https://github.com/enterprise-contract/golden-container",
+                      "pipelinesascode.tekton.dev/repository": "golden-container",
+                      "pipelinesascode.tekton.dev/sender": "renovate[bot]",
+                      "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "pipelinesascode.tekton.dev/sha-title": "Update github/codeql-action action to v3.25.8",
+                      "pipelinesascode.tekton.dev/sha-url": "https://github.com/enterprise-contract/golden-container/commit/b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "pipelinesascode.tekton.dev/state": "started",
+                      "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
+                      "pipelinesascode.tekton.dev/url-repository": "golden-container",
+                      "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"golden-container\",\"commit\":\"b0d7c600114b39f0f14e4e85a7c8aed7c4de316e\",\"eventType\":\"push\"}",
+                      "tekton.dev/pipelines.minVersion": "0.12.1",
+                      "tekton.dev/tags": "image-build, appstudio, hacbs",
+                      "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-d93a888b435563acf59b69d48e089821-c2d32c4abb7924a5-01\"}"
+                    },
+                    "labels": {
+                      "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
+                      "app.kubernetes.io/version": "v0.27.0",
+                      "appstudio.openshift.io/application": "golden-container",
+                      "appstudio.openshift.io/component": "golden-container",
+                      "build.appstudio.redhat.com/build_type": "docker",
+                      "pipelines.appstudio.openshift.io/type": "build",
+                      "pipelinesascode.tekton.dev/check-run-id": "25796873737",
+                      "pipelinesascode.tekton.dev/event-type": "push",
+                      "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
+                      "pipelinesascode.tekton.dev/repository": "golden-container",
+                      "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "pipelinesascode.tekton.dev/state": "started",
+                      "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
+                      "pipelinesascode.tekton.dev/url-repository": "golden-container",
+                      "tekton.dev/memberOf": "tasks",
+                      "tekton.dev/pipeline": "golden-container-on-push-xd69b",
+                      "tekton.dev/pipelineRun": "golden-container-on-push-xd69b",
+                      "tekton.dev/pipelineTask": "build-container",
+                      "tekton.dev/task": "build-image-manifest"
+                    }
+                  }
+                },
+                "results": [
+                  {
+                    "name": "IMAGE_DIGEST",
+                    "type": "string",
+                    "value": "sha256:e5f4f3669712c98fd37a960479f56d96c7c2743f3c424275d00623f7661d8272"
+                  },
+                  {
+                    "name": "IMAGE_URL",
+                    "type": "string",
+                    "value": "quay.io/redhat-appstudio/ec-golden-image:b0d7c600114b39f0f14e4e85a7c8aed7c4de316e"
+                  }
+                ]
+              },
+              {
+                "name": "build-source-image",
+                "after": [
+                  "build-container",
+                  "build-container-amd64",
+                  "init"
+                ],
+                "ref": {
+                  "resolver": "bundles",
+                  "params": [
+                    {
+                      "name": "name",
+                      "value": "source-build"
+                    },
+                    {
+                      "name": "bundle",
+                      "value": "quay.io/redhat-appstudio-tekton-catalog/task-source-build:0.1@sha256:1a976a35adee9163e455d0c5aee5d9bf9cb3c6a770656ae347558f8c54977709"
+                    },
+                    {
+                      "name": "kind",
+                      "value": "task"
+                    }
+                  ]
+                },
+                "startedOn": "2024-06-04T15:56:50Z",
+                "finishedOn": "2024-06-04T15:57:16Z",
+                "status": "Succeeded",
+                "steps": [
+                  {
+                    "entryPoint": "#!/usr/bin/env bash\nset -euo pipefail\n\napp_dir=/opt/source_build\nregistry_allowlist=\"\nregistry.access.redhat.com\nregistry.redhat.io\n\"\n\n## This is needed for the builds performed by the rpm-ostree task\n## otherwise, we can see this error:\n## \"fatal: detected dubious ownership in repository at '/workspace/workspace/source'\"\n##\ngit config --global --add safe.directory $SOURCE_DIR\n\n${app_dir}/appenv/bin/python3 ${app_dir}/source_build.py \\\n  --output-binary-image \"$BINARY_IMAGE\" \\\n  --workspace /var/source-build \\\n  --source-dir \"$SOURCE_DIR\" \\\n  --base-images \"$BASE_IMAGES\" \\\n  --write-result-to \"$RESULT_FILE\" \\\n  --cachi2-artifacts-dir \"$CACHI2_ARTIFACTS_DIR\" \\\n  --registry-allowlist=\"$registry_allowlist\"\n\ncat \"$RESULT_FILE\" | jq -r \".image_url\" >\"$RESULT_SOURCE_IMAGE_URL\"\ncat \"$RESULT_FILE\" | jq -r \".image_digest\" >\"$RESULT_SOURCE_IMAGE_DIGEST\"\n\ncp \"$RESULT_FILE\" \"$WS_BUILD_RESULT_FILE\"\n",
+                    "arguments": null,
+                    "environment": {
+                      "container": "build",
+                      "image": "oci://quay.io/redhat-appstudio/build-definitions-source-image-build-utils@sha256:cd87bbe51f1c22ff7578f5c9caf19db4f9ee7aefd0307288383b9bd478cdf856"
+                    },
+                    "annotations": null
+                  }
+                ],
+                "invocation": {
+                  "configSource": {},
+                  "parameters": {
+                    "BASE_IMAGES": "registry.access.redhat.com/ubi9/ubi-micro:<none>@sha256:1c8483e0fda0e990175eb9855a5f15e0910d2038dd397d9e2b357630f0321e6d\n",
+                    "BINARY_IMAGE": "quay.io/redhat-appstudio/ec-golden-image:b0d7c600114b39f0f14e4e85a7c8aed7c4de316e"
+                  },
+                  "environment": {
+                    "annotations": {
+                      "build.appstudio.openshift.io/repo": "https://github.com/enterprise-contract/golden-container?rev=b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "build.appstudio.redhat.com/commit_sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "build.appstudio.redhat.com/target_branch": "main",
+                      "pipeline.tekton.dev/release": "34d8c0f",
+                      "pipelinesascode.tekton.dev/branch": "main",
+                      "pipelinesascode.tekton.dev/check-run-id": "25796873737",
+                      "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
+                      "pipelinesascode.tekton.dev/event-type": "push",
+                      "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-yoreai",
+                      "pipelinesascode.tekton.dev/git-provider": "github",
+                      "pipelinesascode.tekton.dev/installation-id": "34493006",
+                      "pipelinesascode.tekton.dev/log-url": "https://console.redhat.com/preview/application-pipeline/ns/rhtap-contract-tenant/pipelinerun/golden-container-on-push-xd69b",
+                      "pipelinesascode.tekton.dev/max-keep-runs": "3",
+                      "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"main\"",
+                      "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
+                      "pipelinesascode.tekton.dev/repo-url": "https://github.com/enterprise-contract/golden-container",
+                      "pipelinesascode.tekton.dev/repository": "golden-container",
+                      "pipelinesascode.tekton.dev/sender": "renovate[bot]",
+                      "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "pipelinesascode.tekton.dev/sha-title": "Update github/codeql-action action to v3.25.8",
+                      "pipelinesascode.tekton.dev/sha-url": "https://github.com/enterprise-contract/golden-container/commit/b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "pipelinesascode.tekton.dev/state": "started",
+                      "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
+                      "pipelinesascode.tekton.dev/url-repository": "golden-container",
+                      "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"golden-container\",\"commit\":\"b0d7c600114b39f0f14e4e85a7c8aed7c4de316e\",\"eventType\":\"push\"}",
+                      "tekton.dev/pipelines.minVersion": "0.12.1",
+                      "tekton.dev/tags": "appstudio",
+                      "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-d93a888b435563acf59b69d48e089821-a43856b38575e9b4-01\"}"
+                    },
+                    "labels": {
+                      "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
+                      "app.kubernetes.io/version": "v0.27.0",
+                      "appstudio.openshift.io/application": "golden-container",
+                      "appstudio.openshift.io/component": "golden-container",
+                      "pipelines.appstudio.openshift.io/type": "build",
+                      "pipelinesascode.tekton.dev/check-run-id": "25796873737",
+                      "pipelinesascode.tekton.dev/event-type": "push",
+                      "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
+                      "pipelinesascode.tekton.dev/repository": "golden-container",
+                      "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "pipelinesascode.tekton.dev/state": "started",
+                      "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
+                      "pipelinesascode.tekton.dev/url-repository": "golden-container",
+                      "tekton.dev/memberOf": "tasks",
+                      "tekton.dev/pipeline": "golden-container-on-push-xd69b",
+                      "tekton.dev/pipelineRun": "golden-container-on-push-xd69b",
+                      "tekton.dev/pipelineTask": "build-source-image",
+                      "tekton.dev/task": "source-build"
+                    }
+                  }
+                },
+                "results": [
+                  {
+                    "name": "BUILD_RESULT",
+                    "type": "string",
+                    "value": "{\"status\": \"success\", \"dependencies_included\": false, \"base_image_source_included\": true, \"image_url\": \"quay.io/redhat-appstudio/ec-golden-image:sha256-e5f4f3669712c98fd37a960479f56d96c7c2743f3c424275d00623f7661d8272.src\", \"image_digest\": \"sha256:d8f4506d1de07b7c28e84503b395a16ebbd25ed668291997b2abedb1629180c7\"}"
+                  },
+                  {
+                    "name": "SOURCE_IMAGE_DIGEST",
+                    "type": "string",
+                    "value": "sha256:d8f4506d1de07b7c28e84503b395a16ebbd25ed668291997b2abedb1629180c7\n"
+                  },
+                  {
+                    "name": "SOURCE_IMAGE_URL",
+                    "type": "string",
+                    "value": "quay.io/redhat-appstudio/ec-golden-image:sha256-e5f4f3669712c98fd37a960479f56d96c7c2743f3c424275d00623f7661d8272.src\n"
                   }
                 ]
               },
               {
                 "name": "deprecated-base-image-check",
-                "after": ["build-container"],
+                "after": [
+                  "build-container",
+                  "build-container-amd64"
+                ],
                 "ref": {
-                  "kind": "Task",
                   "resolver": "bundles",
                   "params": [
                     {
@@ -628,7 +1129,7 @@
                     },
                     {
                       "name": "bundle",
-                      "value": "quay.io/redhat-appstudio-tekton-catalog/task-deprecated-image-check:0.3@sha256:d87f8c50a674f57527a0c4f3df6d9093941a2ae84739b55368b3c11702ce340c"
+                      "value": "quay.io/redhat-appstudio-tekton-catalog/task-deprecated-image-check:0.4@sha256:3793fbf59e7dadff9d1f7e7ea4cc430c69a2de620b20c7fd69d71bdd5f6c4a60"
                     },
                     {
                       "name": "kind",
@@ -636,16 +1137,16 @@
                     }
                   ]
                 },
-                "startedOn": "2024-01-16T17:05:04Z",
-                "finishedOn": "2024-01-16T17:05:15Z",
+                "startedOn": "2024-06-04T15:56:51Z",
+                "finishedOn": "2024-06-04T15:57:06Z",
                 "status": "Succeeded",
                 "steps": [
                   {
-                    "entryPoint": "#!/usr/bin/env bash\nset -euo pipefail\nsource /utils.sh\ntrap 'handle_error /tekton/results/TEST_OUTPUT' EXIT\n\nsuccess_counter=0\nfailure_counter=0\nerror_counter=0\nwarnings_counter=0\n\nreadarray -t IMAGE_ARRAY < <(echo -n \"$BASE_IMAGES_DIGESTS\" | sed 's/\\\\n/\\'$'\\n''/g')\nfor BASE_IMAGE in ${IMAGE_ARRAY[@]};\ndo\n  IFS=:'/' read -r IMAGE_REGISTRY IMAGE_WITH_TAG <<< $BASE_IMAGE\n  IMAGE_REPOSITORY=`echo $IMAGE_WITH_TAG | cut -d \":\" -f1`\n\n  # Red Hat Catalog hack: registry.redhat.io must be queried as registry.access.redhat.com in Red Hat catalog\n  IMAGE_REGISTRY_CATALOG=$(echo \"${IMAGE_REGISTRY}\" | sed 's/^registry.redhat.io$/registry.access.redhat.com/')\n\n  export IMAGE_REPO_PATH=/tmp/${IMAGE_REPOSITORY}\n  mkdir -p ${IMAGE_REPO_PATH}\n  echo \"Querying Red Hat Catalog for $BASE_IMAGE.\"\n  http_code=$(curl -s -o ${IMAGE_REPO_PATH}/repository_data.json -w '%{http_code}' \"https://catalog.redhat.com/api/containers/v1/repositories/registry/${IMAGE_REGISTRY_CATALOG}/repository/${IMAGE_REPOSITORY}\")\n\n  if [ \"$http_code\" == \"200\" ];\n  then\n    echo \"Running conftest using $POLICY_DIR policy, $POLICY_NAMESPACE namespace.\"\n    /usr/bin/conftest test --no-fail ${IMAGE_REPO_PATH}/repository_data.json \\\n    --policy $POLICY_DIR --namespace $POLICY_NAMESPACE \\\n    --output=json | tee ${IMAGE_REPO_PATH}/deprecated_image_check_output.json\n\n    failures_num=$(jq -r '.[].failures|length' ${IMAGE_REPO_PATH}/deprecated_image_check_output.json)\n    if [[ \"${failures_num}\" -gt 0 ]]; then\n      echo \"[FAILURE] Image ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY} has been deprecated\"\n    fi\n    failure_counter=$((failure_counter+failures_num))\n\n    successes_num=$(jq -r '.[].successes' ${IMAGE_REPO_PATH}/deprecated_image_check_output.json)\n    if [[ \"${successes_num}\" -gt 0 ]]; then\n      echo \"[SUCCESS] Image ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY} is valid\"\n    fi\n    success_counter=$((success_counter+successes_num))\n\n  elif [ \"$http_code\" == \"404\" ];\n  then\n    echo \"[WARNING] Registry/image ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY} not found in Red Hat Catalog. Task cannot provide results if image is deprecated.\"\n    warnings_counter=$((warnings_counter+1))\n  else\n    echo \"[ERROR] Unexpected error (HTTP code: ${http_code}) occurred for registry/image ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}.\"\n    error_counter=$((error_counter+1))\n  fi\ndone\n\nnote=\"Task deprecated-image-check failed: Command conftest failed. For details, check Tekton task log.\"\nERROR_OUTPUT=$(make_result_json -r ERROR -n \"$POLICY_NAMESPACE\" -t \"$note\")\n\nnote=\"Task deprecated-image-check completed: Check result for task result.\"\nif [[ \"$error_counter\" == 0 ]];\nthen\n  if [[ \"${failure_counter}\" -gt 0 ]]; then\n    RES=\"FAILURE\"\n  elif [[ \"${warnings_counter}\" -gt 0 ]]; then\n    RES=\"WARNING\"\n  elif [[ \"${success_counter}\" -eq 0 ]]; then\n    # when all counters are 0, there are no base images to check\n    note=\"Task deprecated-image-check success: No base images to check.\"\n    RES=\"SUCCESS\"\n  else\n    RES=\"SUCCESS\"\n  fi\n  TEST_OUTPUT=$(make_result_json \\\n    -r \"${RES}\" -n \"$POLICY_NAMESPACE\" \\\n    -s \"${success_counter}\" -f \"${failure_counter}\" -w \"${warnings_counter}\" -t \"$note\")\nfi\necho \"${TEST_OUTPUT:-${ERROR_OUTPUT}}\" | tee /tekton/results/TEST_OUTPUT\n",
+                    "entryPoint": "#!/usr/bin/env bash\nset -euo pipefail\nsource /utils.sh\ntrap 'handle_error /tekton/results/TEST_OUTPUT' EXIT\n\nIMAGES_TO_BE_PROCESSED_PATH=\"/tmp/images_to_be_processed.txt\"\nSBOM_FILE_PATH=\"/tmp/sbom.json\"\n\nsuccess_counter=0\nfailure_counter=0\nerror_counter=0\nwarnings_counter=0\n\n# Get base images from SBOM\ncosign download sbom \"${IMAGE_URL}@${IMAGE_DIGEST}\" > ${SBOM_FILE_PATH}\n\ncat ${SBOM_FILE_PATH} | jq -r '.formulation? // empty | .[] | .components? // empty | .[] | select(any((.properties // empty)[]; .name | test(\"^konflux:container:is_(base|builder)_image\"))) | .name' > ${IMAGES_TO_BE_PROCESSED_PATH}\necho \"Detected base images from SBOM:\"\ncat \"${IMAGES_TO_BE_PROCESSED_PATH}\"\necho \"\"\n\nif [ -n \"${BASE_IMAGES_DIGESTS}\" ];\nthen\n  echo \"Base images passed by param BASE_IMAGES_DIGESTS: $BASE_IMAGES_DIGESTS\"\n  # Get images from the parameter\n  for IMAGE_WITH_TAG in $(echo -n \"$BASE_IMAGES_DIGESTS\" | sed 's/\\\\n/\\'$'\\n''/g' );\n  do\n    echo $IMAGE_WITH_TAG | cut -d \":\" -f1 >> ${IMAGES_TO_BE_PROCESSED_PATH}\n  done\nfi\n\n# we want to remove duplicated entries\nBASE_IMAGES=$(sort -u \"${IMAGES_TO_BE_PROCESSED_PATH}\")\n\necho \"Images to be checked:\"\necho \"$BASE_IMAGES\"\necho \"\"\n\nfor BASE_IMAGE in ${BASE_IMAGES};\ndo\n  IFS=:'/' read -r IMAGE_REGISTRY IMAGE_REPOSITORY<<< $BASE_IMAGE\n\n  # Red Hat Catalog hack: registry.redhat.io must be queried as registry.access.redhat.com in Red Hat catalog\n  IMAGE_REGISTRY_CATALOG=$(echo \"${IMAGE_REGISTRY}\" | sed 's/^registry.redhat.io$/registry.access.redhat.com/')\n\n  export IMAGE_REPO_PATH=/tmp/${IMAGE_REPOSITORY}\n  mkdir -p ${IMAGE_REPO_PATH}\n  echo \"Querying Red Hat Catalog for $BASE_IMAGE.\"\n  http_code=$(curl -s -o ${IMAGE_REPO_PATH}/repository_data.json -w '%{http_code}' \"https://catalog.redhat.com/api/containers/v1/repositories/registry/${IMAGE_REGISTRY_CATALOG}/repository/${IMAGE_REPOSITORY}\")\n\n  if [ \"$http_code\" == \"200\" ];\n  then\n    echo \"Running conftest using $POLICY_DIR policy, $POLICY_NAMESPACE namespace.\"\n    /usr/bin/conftest test --no-fail ${IMAGE_REPO_PATH}/repository_data.json \\\n    --policy $POLICY_DIR --namespace $POLICY_NAMESPACE \\\n    --output=json | tee ${IMAGE_REPO_PATH}/deprecated_image_check_output.json\n\n    failures_num=$(jq -r '.[].failures|length' ${IMAGE_REPO_PATH}/deprecated_image_check_output.json)\n    if [[ \"${failures_num}\" -gt 0 ]]; then\n      echo \"[FAILURE] Image ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY} has been deprecated\"\n    fi\n    failure_counter=$((failure_counter+failures_num))\n\n    successes_num=$(jq -r '.[].successes' ${IMAGE_REPO_PATH}/deprecated_image_check_output.json)\n    if [[ \"${successes_num}\" -gt 0 ]]; then\n      echo \"[SUCCESS] Image ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY} is valid\"\n    fi\n    success_counter=$((success_counter+successes_num))\n\n  elif [ \"$http_code\" == \"404\" ];\n  then\n    echo \"[WARNING] Registry/image ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY} not found in Red Hat Catalog. Task cannot provide results if image is deprecated.\"\n    warnings_counter=$((warnings_counter+1))\n  else\n    echo \"[ERROR] Unexpected error (HTTP code: ${http_code}) occurred for registry/image ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}.\"\n    error_counter=$((error_counter+1))\n  fi\ndone\n\nnote=\"Task deprecated-image-check failed: Command conftest failed. For details, check Tekton task log.\"\nERROR_OUTPUT=$(make_result_json -r ERROR -n \"$POLICY_NAMESPACE\" -t \"$note\")\n\nnote=\"Task deprecated-image-check completed: Check result for task result.\"\nif [[ \"$error_counter\" == 0 ]];\nthen\n  if [[ \"${failure_counter}\" -gt 0 ]]; then\n    RES=\"FAILURE\"\n  elif [[ \"${warnings_counter}\" -gt 0 ]]; then\n    RES=\"WARNING\"\n  elif [[ \"${success_counter}\" -eq 0 ]]; then\n    # when all counters are 0, there are no base images to check\n    note=\"Task deprecated-image-check success: No base images to check.\"\n    RES=\"SUCCESS\"\n  else\n    RES=\"SUCCESS\"\n  fi\n  TEST_OUTPUT=$(make_result_json \\\n    -r \"${RES}\" -n \"$POLICY_NAMESPACE\" \\\n    -s \"${success_counter}\" -f \"${failure_counter}\" -w \"${warnings_counter}\" -t \"$note\")\nfi\necho \"${TEST_OUTPUT:-${ERROR_OUTPUT}}\" | tee /tekton/results/TEST_OUTPUT\n",
                     "arguments": null,
                     "environment": {
                       "container": "check-images",
-                      "image": "oci://quay.io/redhat-appstudio/hacbs-test@sha256:2c9018dc080e969f013be4f5d25b207522005d236deedb1f8d1534af29ee5364"
+                      "image": "oci://quay.io/redhat-appstudio/konflux-test@sha256:5303e71ad8c63377aadf5e7aaaab258aa7359f899114d57bef0b7d5635c51a31"
                     },
                     "annotations": null
                   }
@@ -653,58 +1154,60 @@
                 "invocation": {
                   "configSource": {},
                   "parameters": {
-                    "BASE_IMAGES_DIGESTS": "registry.access.redhat.com/ubi9/ubi-micro:<none>@sha256:14a2cd49b11eb39586f5abdefc63739f47cd5b8099e0d6946d7ee24812e7e746\n",
+                    "BASE_IMAGES_DIGESTS": "registry.access.redhat.com/ubi9/ubi-micro:<none>@sha256:1c8483e0fda0e990175eb9855a5f15e0910d2038dd397d9e2b357630f0321e6d\n",
+                    "IMAGE_DIGEST": "sha256:b4cfd7c1fc510d6b934c195cf5bf1d647ff332215104a0d05942fc0aa1fe09e7",
+                    "IMAGE_URL": "quay.io/redhat-appstudio/ec-golden-image:b0d7c600114b39f0f14e4e85a7c8aed7c4de316e-amd64",
                     "POLICY_DIR": "/project/repository/",
                     "POLICY_NAMESPACE": "required_checks"
                   },
                   "environment": {
                     "annotations": {
-                      "build.appstudio.openshift.io/repo": "https://github.com/enterprise-contract/golden-container?rev=68b69547cad3c4ba856fe6b06154012f33dd8b5a",
-                      "build.appstudio.redhat.com/commit_sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "build.appstudio.openshift.io/repo": "https://github.com/enterprise-contract/golden-container?rev=b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "build.appstudio.redhat.com/commit_sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "build.appstudio.redhat.com/target_branch": "main",
-                      "pipeline.tekton.dev/release": "876b81e",
+                      "pipeline.tekton.dev/release": "34d8c0f",
                       "pipelinesascode.tekton.dev/branch": "main",
-                      "pipelinesascode.tekton.dev/check-run-id": "20539638032",
+                      "pipelinesascode.tekton.dev/check-run-id": "25796873737",
+                      "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
                       "pipelinesascode.tekton.dev/event-type": "push",
-                      "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-iiug",
+                      "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-yoreai",
                       "pipelinesascode.tekton.dev/git-provider": "github",
                       "pipelinesascode.tekton.dev/installation-id": "34493006",
-                      "pipelinesascode.tekton.dev/log-url": "https://console.redhat.com/preview/application-pipeline",
+                      "pipelinesascode.tekton.dev/log-url": "https://console.redhat.com/preview/application-pipeline/ns/rhtap-contract-tenant/pipelinerun/golden-container-on-push-xd69b",
                       "pipelinesascode.tekton.dev/max-keep-runs": "3",
                       "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"main\"",
                       "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
                       "pipelinesascode.tekton.dev/repo-url": "https://github.com/enterprise-contract/golden-container",
                       "pipelinesascode.tekton.dev/repository": "golden-container",
                       "pipelinesascode.tekton.dev/sender": "renovate[bot]",
-                      "pipelinesascode.tekton.dev/sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
-                      "pipelinesascode.tekton.dev/sha-title": "Update quay.io/redhat-appstudio-tekton-catalog/task-clair-scan:0.1 Docker digest to 63b42c0",
-                      "pipelinesascode.tekton.dev/sha-url": "https://github.com/enterprise-contract/golden-container/commit/68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "pipelinesascode.tekton.dev/sha-title": "Update github/codeql-action action to v3.25.8",
+                      "pipelinesascode.tekton.dev/sha-url": "https://github.com/enterprise-contract/golden-container/commit/b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "pipelinesascode.tekton.dev/state": "started",
                       "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
                       "pipelinesascode.tekton.dev/url-repository": "golden-container",
+                      "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"golden-container\",\"commit\":\"b0d7c600114b39f0f14e4e85a7c8aed7c4de316e\",\"eventType\":\"push\"}",
                       "tekton.dev/pipelines.minVersion": "0.12.1",
-                      "tekton.dev/tags": "appstudio, hacbs"
+                      "tekton.dev/tags": "appstudio, hacbs",
+                      "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-d93a888b435563acf59b69d48e089821-1ecfe3d53a9fd91c-01\"}"
                     },
                     "labels": {
                       "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
-                      "app.kubernetes.io/version": "v0.22.4",
+                      "app.kubernetes.io/version": "v0.27.0",
                       "appstudio.openshift.io/application": "golden-container",
                       "appstudio.openshift.io/component": "golden-container",
                       "pipelines.appstudio.openshift.io/type": "build",
-                      "pipelinesascode.tekton.dev/branch": "main",
-                      "pipelinesascode.tekton.dev/check-run-id": "20539638032",
+                      "pipelinesascode.tekton.dev/check-run-id": "25796873737",
                       "pipelinesascode.tekton.dev/event-type": "push",
-                      "pipelinesascode.tekton.dev/git-provider": "github",
                       "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
                       "pipelinesascode.tekton.dev/repository": "golden-container",
-                      "pipelinesascode.tekton.dev/sender": "renovate__bot",
-                      "pipelinesascode.tekton.dev/sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "pipelinesascode.tekton.dev/state": "started",
                       "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
                       "pipelinesascode.tekton.dev/url-repository": "golden-container",
                       "tekton.dev/memberOf": "tasks",
-                      "tekton.dev/pipeline": "golden-container-on-push-fdv54",
-                      "tekton.dev/pipelineRun": "golden-container-on-push-fdv54",
+                      "tekton.dev/pipeline": "golden-container-on-push-xd69b",
+                      "tekton.dev/pipelineRun": "golden-container-on-push-xd69b",
                       "tekton.dev/pipelineTask": "deprecated-base-image-check",
                       "tekton.dev/task": "deprecated-image-check"
                     }
@@ -714,15 +1217,16 @@
                   {
                     "name": "TEST_OUTPUT",
                     "type": "string",
-                    "value": "{\"result\":\"SUCCESS\",\"timestamp\":\"1705424714\",\"note\":\"Task deprecated-image-check completed: Check result for task result.\",\"namespace\":\"required_checks\",\"successes\":1,\"failures\":0,\"warnings\":0}\n"
+                    "value": "{\"result\":\"SUCCESS\",\"timestamp\":\"1717516624\",\"note\":\"Task deprecated-image-check completed: Check result for task result.\",\"namespace\":\"required_checks\",\"successes\":1,\"failures\":0,\"warnings\":0}\n"
                   }
                 ]
               },
               {
                 "name": "clair-scan",
-                "after": ["build-container"],
+                "after": [
+                  "build-container"
+                ],
                 "ref": {
-                  "kind": "Task",
                   "resolver": "bundles",
                   "params": [
                     {
@@ -731,7 +1235,7 @@
                     },
                     {
                       "name": "bundle",
-                      "value": "quay.io/redhat-appstudio-tekton-catalog/task-clair-scan:0.1@sha256:63b42c0fc23d05e26776a0e7c4f0ab00750096ebfe1eed9a7ba96f8b27713fbf"
+                      "value": "quay.io/redhat-appstudio-tekton-catalog/task-clair-scan:0.1@sha256:44d0df70080e082e72d2694b14130ff512e5e7f2611190161a9b016b4df9fb22"
                     },
                     {
                       "name": "kind",
@@ -739,25 +1243,34 @@
                     }
                   ]
                 },
-                "startedOn": "2024-01-16T17:05:04Z",
-                "finishedOn": "2024-01-16T17:05:13Z",
+                "startedOn": "2024-06-04T15:56:50Z",
+                "finishedOn": "2024-06-04T15:57:02Z",
                 "status": "Succeeded",
                 "steps": [
                   {
-                    "entryPoint": "#!/usr/bin/env bash\n\nimagewithouttag=$(echo $IMAGE_URL | sed \"s/\\(.*\\):.*/\\1/\" | tr -d '\\n')\n# strip new-line escape symbol from parameter and save it to variable\nimageanddigest=$(echo $imagewithouttag@$IMAGE_DIGEST)\n\nclair-action report --image-ref=$imageanddigest --db-path=/tmp/matcher.db --format=quay | tee /tekton/home/clair-result.json || true\n",
+                    "entryPoint": "#!/usr/bin/env bash\nset -euo pipefail\n. /utils.sh\n\nimagewithouttag=$(echo -n $IMAGE_URL | sed \"s/\\(.*\\):.*/\\1/\")\n# strip new-line escape symbol from parameter and save it to variable\nimageanddigest=$(echo $imagewithouttag@$IMAGE_DIGEST)\necho \"Inspecting raw image manifest $imageanddigest.\"\n\n# Get the arch and image manifests by inspecting the image. This is mainly for identifying image indexes\nimage_manifests=$(get_image_manifests -i ${imageanddigest})\nif [ -n \"$image_manifests\" ]; then\n  echo \"$image_manifests\" | jq -r 'to_entries[] | \"\\(.key) \\(.value)\"' | while read -r arch arch_sha; do\n    echo \"$arch_sha\" > /tekton/home/image-manifest-$arch.sha\n  done\nfi\n",
                     "arguments": null,
                     "environment": {
-                      "container": "get-vulnerabilities",
-                      "image": "oci://quay.io/redhat-appstudio/clair-in-ci@sha256:8d177929079a8a42046edd27e6c3f5c7c620b75f78bcaa8c4726428aa621edf2"
+                      "container": "get-image-manifests",
+                      "image": "oci://quay.io/redhat-appstudio/hacbs-test@sha256:5303e71ad8c63377aadf5e7aaaab258aa7359f899114d57bef0b7d5635c51a31"
                     },
                     "annotations": null
                   },
                   {
-                    "entryPoint": "#!/usr/bin/env bash\nset -euo pipefail\n. /utils.sh\ntrap 'handle_error /tekton/results/TEST_OUTPUT' EXIT\n\nif [ ! -s /tekton/home/clair-result.json ]; then\n  echo \"Previous step [get-vulnerabilities] failed: /tekton/home/clair-result.json is empty.\"\nelse\n  /usr/bin/conftest test --no-fail /tekton/home/clair-result.json \\\n  --policy /project/clair/vulnerabilities-check.rego --namespace required_checks \\\n  --output=json | tee /tekton/home/clair-vulnerabilities.json || true\nfi\n\nif [[ ! -f /tekton/home/clair-vulnerabilities.json ]]; then\n  note=\"Task clair-scan failed: /tekton/home/clair-vulnerabilities.json did not generate. For details, check Tekton task log.\"\n  TEST_OUTPUT=$(make_result_json -r \"ERROR\" -t \"$note\")\n  echo \"/tekton/home/clair-vulnerabilities.json did not generate correctly. For details, check conftest command in Tekton task log.\"\n  echo \"${TEST_OUTPUT}\" | tee /tekton/results/TEST_OUTPUT\n  exit 0\nfi\n\njq -rce \\\n  '{vulnerabilities:{\n      critical: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_critical_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n      high: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_high_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n      medium: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_medium_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n      low: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_low_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n      unknown: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unknown_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0)\n    }}' /tekton/home/clair-vulnerabilities.json | tee /tekton/results/CLAIR_SCAN_RESULT\n\nnote=\"Task clair-scan completed: Refer to Tekton task result CLAIR_SCAN_RESULT for vulnerabilities scanned by Clair.\"\nTEST_OUTPUT=$(make_result_json -r \"SUCCESS\" -t \"$note\")\necho \"${TEST_OUTPUT}\" | tee /tekton/results/TEST_OUTPUT\n",
+                    "entryPoint": "#!/usr/bin/env bash\n\nimagewithouttag=$(echo -n $IMAGE_URL | sed \"s/\\(.*\\):.*/\\1/\")\nimages_processed_template='{\"image\": {\"pullspec\": \"'\"$IMAGE_URL\"'\", \"digests\": [%s]}}'\ndigests_processed=()\n\nfor sha_file in /tekton/home/image-manifest-*.sha; do\n  if [ -e \"$sha_file\" ]; then\n    arch_sha=$(cat \"$sha_file\")\n    arch=$(basename \"$sha_file\" | sed 's/image-manifest-//;s/.sha//')\n    arch_specific_digest=\"$imagewithouttag@$arch_sha\"\n\n    echo \"Running clair-action on $arch image manifest.\"\n    # run the scan for each image manifest in the image index\n    clair-action report --image-ref=$arch_specific_digest --db-path=/tmp/matcher.db --format=quay | tee /tekton/home/clair-result-$arch.json || true\n\n    digests_processed+=(\"\\\"$arch_sha\\\"\")\n  fi\ndone\n\ndigests_processed_string=$(IFS=,; echo \"${digests_processed[*]}\")\n\n# add the image_index to the processed digests list and store the result in a file\nimages_processed=$(echo \"${images_processed_template/\\[%s]/[$digests_processed_string]}\")\necho \"$images_processed\" > /tekton/home/images-processed.json\n",
+                    "arguments": null,
+                    "environment": {
+                      "container": "get-vulnerabilities",
+                      "image": "oci://quay.io/redhat-appstudio/clair-in-ci@sha256:28afeba25188d8c45d277397147bbade19f63915f3719308443745750970772f"
+                    },
+                    "annotations": null
+                  },
+                  {
+                    "entryPoint": "#!/usr/bin/env bash\nset -euo pipefail\n. /utils.sh\ntrap 'handle_error /tekton/results/TEST_OUTPUT' EXIT\n\nclair_result_files=$(ls /tekton/home/clair-result-*.json)\nif [ -z \"$clair_result_files\" ]; then\n  echo \"Previous step [get-vulnerabilities] failed: No clair-result files found in /tekton/home.\"\nfi\n\nmissing_vulnerabilities_files=\"\"\nfor file in $clair_result_files; do\n  file_suffix=$(basename \"$file\" | sed 's/clair-result-//;s/.json//')\n  if [ ! -s \"$file\" ]; then\n    echo \"Previous step [get-vulnerabilities] failed: $file is empty.\"\n  else\n    /usr/bin/conftest test --no-fail $file \\\n    --policy /project/clair/vulnerabilities-check.rego --namespace required_checks \\\n    --output=json | tee /tekton/home/clair-vulnerabilities-$file_suffix.json || true\n  fi\n\n  #check for missing \"clair-vulnerabilities-<arch>/image-index\" file and create a string\n  if [ ! -f \"/tekton/home/clair-vulnerabilities-$file_suffix.json\" ]; then\n    missing_vulnerabilities_files+=\"${missing_vulnerabilities_files:+, }/tekton/home/clair-vulnerabilities-$file_suffix.json\"\n  fi\ndone\n\nif [ -n \"$missing_vulnerabilities_files\" ]; then\n  note=\"Task clair-scan failed: $missing_vulnerabilities_files did not generate. For details, check Tekton task log.\"\n  TEST_OUTPUT=$(make_result_json -r \"ERROR\" -t \"$note\")\n  echo \"$missing_vulnerabilities_files did not generate correctly. For details, check conftest command in Tekton task log.\"\n  echo \"${TEST_OUTPUT}\" | tee /tekton/results/TEST_OUTPUT\n  exit 0\nfi\n\nscan_result='{\"vulnerabilities\":{\"critical\":0, \"high\":0, \"medium\":0, \"low\":0, \"unknown\":0}, \"unpatched_vulnerabilities\":{\"critical\":0, \"high\":0, \"medium\":0, \"low\":0, \"unknown\":0}}'\nfor file in /tekton/home/clair-vulnerabilities-*.json; do\n    result=$(jq -rce \\\n        '{\n            vulnerabilities:{\n              critical: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_critical_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              high: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_high_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              medium: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_medium_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              low: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_low_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              unknown: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unknown_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0)\n            },\n            unpatched_vulnerabilities:{\n              critical: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unpatched_critical_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              high: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unpatched_high_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              medium: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unpatched_medium_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              low: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unpatched_low_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              unknown: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unpatched_unknown_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0)\n            }\n        }' \"$file\")\n\n    scan_result=$(jq -s -rce \\\n          '.[0].vulnerabilities.critical += .[1].vulnerabilities.critical |\n          .[0].vulnerabilities.high += .[1].vulnerabilities.high |\n          .[0].vulnerabilities.medium += .[1].vulnerabilities.medium |\n          .[0].vulnerabilities.low += .[1].vulnerabilities.low |\n          .[0].vulnerabilities.unknown += .[1].vulnerabilities.unknown |\n          .[0].unpatched_vulnerabilities.critical += .[1].unpatched_vulnerabilities.critical |\n          .[0].unpatched_vulnerabilities.high += .[1].unpatched_vulnerabilities.high |\n          .[0].unpatched_vulnerabilities.medium += .[1].unpatched_vulnerabilities.medium |\n          .[0].unpatched_vulnerabilities.low += .[1].unpatched_vulnerabilities.low |\n          .[0].unpatched_vulnerabilities.unknown += .[1].unpatched_vulnerabilities.unknown |\n          .[0]' <<<\"$scan_result $result\")\ndone\n\necho \"$scan_result\" | tee /tekton/results/CLAIR_SCAN_RESULT\n\ncat /tekton/home/images-processed.json | tee /tekton/results/IMAGES_PROCESSED\n\nnote=\"Task clair-scan completed: Refer to Tekton task result CLAIR_SCAN_RESULT for vulnerabilities scanned by Clair.\"\nTEST_OUTPUT=$(make_result_json -r \"SUCCESS\" -t \"$note\")\necho \"${TEST_OUTPUT}\" | tee /tekton/results/TEST_OUTPUT\n",
                     "arguments": null,
                     "environment": {
                       "container": "conftest-vulnerabilities",
-                      "image": "oci://quay.io/redhat-appstudio/hacbs-test@sha256:866675ee3064cf4768691ecca478063ce12f0556fb9d4f24ca95c98664ffbd43"
+                      "image": "oci://quay.io/redhat-appstudio/hacbs-test@sha256:5303e71ad8c63377aadf5e7aaaab258aa7359f899114d57bef0b7d5635c51a31"
                     },
                     "annotations": null
                   }
@@ -766,57 +1279,57 @@
                   "configSource": {},
                   "parameters": {
                     "docker-auth": "",
-                    "image-digest": "sha256:6fa252a7df2735b84674e64b78ac66279af0f2cbbb7ed1dd6a534daf0a4b8738",
-                    "image-url": "quay.io/redhat-appstudio/ec-golden-image:68b69547cad3c4ba856fe6b06154012f33dd8b5a"
+                    "image-digest": "sha256:e5f4f3669712c98fd37a960479f56d96c7c2743f3c424275d00623f7661d8272",
+                    "image-url": "quay.io/redhat-appstudio/ec-golden-image:b0d7c600114b39f0f14e4e85a7c8aed7c4de316e"
                   },
                   "environment": {
                     "annotations": {
-                      "build.appstudio.openshift.io/repo": "https://github.com/enterprise-contract/golden-container?rev=68b69547cad3c4ba856fe6b06154012f33dd8b5a",
-                      "build.appstudio.redhat.com/commit_sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "build.appstudio.openshift.io/repo": "https://github.com/enterprise-contract/golden-container?rev=b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "build.appstudio.redhat.com/commit_sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "build.appstudio.redhat.com/target_branch": "main",
-                      "pipeline.tekton.dev/release": "876b81e",
+                      "pipeline.tekton.dev/release": "34d8c0f",
                       "pipelinesascode.tekton.dev/branch": "main",
-                      "pipelinesascode.tekton.dev/check-run-id": "20539638032",
+                      "pipelinesascode.tekton.dev/check-run-id": "25796873737",
+                      "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
                       "pipelinesascode.tekton.dev/event-type": "push",
-                      "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-iiug",
+                      "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-yoreai",
                       "pipelinesascode.tekton.dev/git-provider": "github",
                       "pipelinesascode.tekton.dev/installation-id": "34493006",
-                      "pipelinesascode.tekton.dev/log-url": "https://console.redhat.com/preview/application-pipeline",
+                      "pipelinesascode.tekton.dev/log-url": "https://console.redhat.com/preview/application-pipeline/ns/rhtap-contract-tenant/pipelinerun/golden-container-on-push-xd69b",
                       "pipelinesascode.tekton.dev/max-keep-runs": "3",
                       "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"main\"",
                       "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
                       "pipelinesascode.tekton.dev/repo-url": "https://github.com/enterprise-contract/golden-container",
                       "pipelinesascode.tekton.dev/repository": "golden-container",
                       "pipelinesascode.tekton.dev/sender": "renovate[bot]",
-                      "pipelinesascode.tekton.dev/sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
-                      "pipelinesascode.tekton.dev/sha-title": "Update quay.io/redhat-appstudio-tekton-catalog/task-clair-scan:0.1 Docker digest to 63b42c0",
-                      "pipelinesascode.tekton.dev/sha-url": "https://github.com/enterprise-contract/golden-container/commit/68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "pipelinesascode.tekton.dev/sha-title": "Update github/codeql-action action to v3.25.8",
+                      "pipelinesascode.tekton.dev/sha-url": "https://github.com/enterprise-contract/golden-container/commit/b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "pipelinesascode.tekton.dev/state": "started",
                       "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
                       "pipelinesascode.tekton.dev/url-repository": "golden-container",
+                      "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"golden-container\",\"commit\":\"b0d7c600114b39f0f14e4e85a7c8aed7c4de316e\",\"eventType\":\"push\"}",
                       "tekton.dev/pipelines.minVersion": "0.12.1",
-                      "tekton.dev/tags": "appstudio, hacbs"
+                      "tekton.dev/tags": "appstudio, hacbs",
+                      "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-d93a888b435563acf59b69d48e089821-86d28eeb1f2be1dd-01\"}"
                     },
                     "labels": {
                       "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
-                      "app.kubernetes.io/version": "v0.22.4",
+                      "app.kubernetes.io/version": "v0.27.0",
                       "appstudio.openshift.io/application": "golden-container",
                       "appstudio.openshift.io/component": "golden-container",
                       "pipelines.appstudio.openshift.io/type": "build",
-                      "pipelinesascode.tekton.dev/branch": "main",
-                      "pipelinesascode.tekton.dev/check-run-id": "20539638032",
+                      "pipelinesascode.tekton.dev/check-run-id": "25796873737",
                       "pipelinesascode.tekton.dev/event-type": "push",
-                      "pipelinesascode.tekton.dev/git-provider": "github",
                       "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
                       "pipelinesascode.tekton.dev/repository": "golden-container",
-                      "pipelinesascode.tekton.dev/sender": "renovate__bot",
-                      "pipelinesascode.tekton.dev/sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "pipelinesascode.tekton.dev/state": "started",
                       "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
                       "pipelinesascode.tekton.dev/url-repository": "golden-container",
                       "tekton.dev/memberOf": "tasks",
-                      "tekton.dev/pipeline": "golden-container-on-push-fdv54",
-                      "tekton.dev/pipelineRun": "golden-container-on-push-fdv54",
+                      "tekton.dev/pipeline": "golden-container-on-push-xd69b",
+                      "tekton.dev/pipelineRun": "golden-container-on-push-xd69b",
                       "tekton.dev/pipelineTask": "clair-scan",
                       "tekton.dev/task": "clair-scan"
                     }
@@ -826,20 +1339,26 @@
                   {
                     "name": "CLAIR_SCAN_RESULT",
                     "type": "string",
-                    "value": "{\"vulnerabilities\":{\"critical\":0,\"high\":0,\"medium\":0,\"low\":0,\"unknown\":0}}\n"
+                    "value": "{\"vulnerabilities\":{\"critical\":0,\"high\":0,\"medium\":0,\"low\":0,\"unknown\":0},\"unpatched_vulnerabilities\":{\"critical\":0,\"high\":0,\"medium\":0,\"low\":14,\"unknown\":0}}\n"
+                  },
+                  {
+                    "name": "IMAGES_PROCESSED",
+                    "type": "string",
+                    "value": "{\"image\": {\"pullspec\": \"quay.io/redhat-appstudio/ec-golden-image:b0d7c600114b39f0f14e4e85a7c8aed7c4de316e\", \"digests\": [\"sha256:b4cfd7c1fc510d6b934c195cf5bf1d647ff332215104a0d05942fc0aa1fe09e7\",\"sha256:ade052c249de1420c0f860fef47b620f00135aade4a55bc385de1dd634e8cc7a\"]}}\n"
                   },
                   {
                     "name": "TEST_OUTPUT",
                     "type": "string",
-                    "value": "{\"result\":\"SUCCESS\",\"timestamp\":\"1705424712\",\"note\":\"Task clair-scan completed: Refer to Tekton task result CLAIR_SCAN_RESULT for vulnerabilities scanned by Clair.\",\"namespace\":\"default\",\"successes\":0,\"failures\":0,\"warnings\":0}\n"
+                    "value": "{\"result\":\"SUCCESS\",\"timestamp\":\"1717516622\",\"note\":\"Task clair-scan completed: Refer to Tekton task result CLAIR_SCAN_RESULT for vulnerabilities scanned by Clair.\",\"namespace\":\"default\",\"successes\":0,\"failures\":0,\"warnings\":0}\n"
                   }
                 ]
               },
               {
                 "name": "sast-snyk-check",
-                "after": ["clone-repository"],
+                "after": [
+                  "clone-repository"
+                ],
                 "ref": {
-                  "kind": "Task",
                   "resolver": "bundles",
                   "params": [
                     {
@@ -848,7 +1367,7 @@
                     },
                     {
                       "name": "bundle",
-                      "value": "quay.io/redhat-appstudio-tekton-catalog/task-sast-snyk-check:0.1@sha256:eee508768b14655275fbcc2f42f9da1ab553b872dcbe113b0896aa9bcf7e1adf"
+                      "value": "quay.io/redhat-appstudio-tekton-catalog/task-sast-snyk-check:0.1@sha256:242acc527a06a11fac9dd6524467f62f3a086c186c5f885973e5780a04d4289c"
                     },
                     {
                       "name": "kind",
@@ -856,16 +1375,16 @@
                     }
                   ]
                 },
-                "startedOn": "2024-01-16T17:03:46Z",
-                "finishedOn": "2024-01-16T17:04:18Z",
+                "startedOn": "2024-06-04T15:53:59Z",
+                "finishedOn": "2024-06-04T15:54:41Z",
                 "status": "Succeeded",
                 "steps": [
                   {
-                    "entryPoint": "#!/usr/bin/env bash\nset -euo pipefail\n. /utils.sh\ntrap 'handle_error /tekton/results/TEST_OUTPUT' EXIT\n\nSNYK_TOKEN_PATH=\"/etc/secrets/snyk_token\"\n\nif [ -f \"${SNYK_TOKEN_PATH}\" ] && [ -s \"${SNYK_TOKEN_PATH}\" ]; then\n  # SNYK token is provided\n  SNYK_TOKEN=\"$(cat ${SNYK_TOKEN_PATH})\"\n  export SNYK_TOKEN\nelse\n  note=\"Task sast-snyk-check skipped: If you wish to use the Snyk code SAST task, please create a secret named snyk-secret with the key \"snyk_token\" containing the Snyk token.\"\n  TEST_OUTPUT=$(make_result_json -r SKIPPED -t \"$note\")\n  echo \"${TEST_OUTPUT}\" | tee \"/tekton/results/TEST_OUTPUT\"\n  exit 0\nfi\n\nSNYK_EXIT_CODE=0\nSOURCE_CODE_DIR=/workspace/workspace/source\nsnyk code test $ARGS $SOURCE_CODE_DIR --sarif-file-output=sast_snyk_check_out.json 1>&2>> stdout.txt || SNYK_EXIT_CODE=$?\ntest_not_skipped=0\nSKIP_MSG=\"We found 0 supported files\"\ngrep -q \"$SKIP_MSG\" stdout.txt || test_not_skipped=$?\n\nif [[ \"$SNYK_EXIT_CODE\" -eq 0 ]] || [[ \"$SNYK_EXIT_CODE\" -eq 1 ]]; then\n  cat sast_snyk_check_out.json\n  TEST_OUTPUT=\n  parse_test_output sast-snyk-check sarif sast_snyk_check_out.json  || true\n\n# When the test is skipped, the \"SNYK_EXIT_CODE\" is 3 and it can also be 3 in some other situation\nelif [[ \"$test_not_skipped\" -eq 0 ]]; then\n  note=\"Task sast-snyk-check success: Snyk code test found zero supported files.\"\n  ERROR_OUTPUT=$(make_result_json -r SUCCESS -t \"$note\")\nelse\n  echo \"sast-snyk-check test failed because of the following issues:\"\n  cat stdout.txt\n  note=\"Task sast-snyk-check failed: For details, check Tekton task log.\"\n  ERROR_OUTPUT=$(make_result_json -r ERROR -t \"$note\")\nfi\necho \"${TEST_OUTPUT:-${ERROR_OUTPUT}}\" | tee /tekton/results/TEST_OUTPUT\n",
+                    "entryPoint": "#!/usr/bin/env bash\nset -euo pipefail\n. /utils.sh\ntrap 'handle_error /tekton/results/TEST_OUTPUT' EXIT\n\nSNYK_TOKEN_PATH=\"/etc/secrets/snyk_token\"\n\nif [ -f \"${SNYK_TOKEN_PATH}\" ] && [ -s \"${SNYK_TOKEN_PATH}\" ]; then\n  # SNYK token is provided\n  SNYK_TOKEN=\"$(cat ${SNYK_TOKEN_PATH})\"\n  export SNYK_TOKEN\nelse\n  to_enable_snyk='[here](https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/how-to-guides/testing_applications/enable_snyk_check_for_a_product/)'\n  note=\"Task sast-snyk-check skipped: If you wish to use the Snyk code SAST task, please create a secret name snyk-secret with the key \"snyk_token\" containing the Snyk token by following the steps given ${to_enable_snyk}\"\n  TEST_OUTPUT=$(make_result_json -r SKIPPED -t \"$note\")\n  echo \"${TEST_OUTPUT}\" | tee \"/tekton/results/TEST_OUTPUT\"\n  exit 0\nfi\n\nSNYK_EXIT_CODE=0\nSOURCE_CODE_DIR=/workspace/workspace/source\nsnyk code test $ARGS $SOURCE_CODE_DIR --sarif-file-output=sast_snyk_check_out.json 1>&2>> stdout.txt || SNYK_EXIT_CODE=$?\ntest_not_skipped=0\nSKIP_MSG=\"We found 0 supported files\"\ngrep -q \"$SKIP_MSG\" stdout.txt || test_not_skipped=$?\n\nif [[ \"$SNYK_EXIT_CODE\" -eq 0 ]] || [[ \"$SNYK_EXIT_CODE\" -eq 1 ]]; then\n  cat sast_snyk_check_out.json\n  TEST_OUTPUT=\n  parse_test_output sast-snyk-check sarif sast_snyk_check_out.json  || true\n\n# When the test is skipped, the \"SNYK_EXIT_CODE\" is 3 and it can also be 3 in some other situation\nelif [[ \"$test_not_skipped\" -eq 0 ]]; then\n  note=\"Task sast-snyk-check success: Snyk code test found zero supported files.\"\n  ERROR_OUTPUT=$(make_result_json -r SUCCESS -t \"$note\")\nelse\n  echo \"sast-snyk-check test failed because of the following issues:\"\n  cat stdout.txt\n  note=\"Task sast-snyk-check failed: For details, check Tekton task log.\"\n  ERROR_OUTPUT=$(make_result_json -r ERROR -t \"$note\")\nfi\necho \"${TEST_OUTPUT:-${ERROR_OUTPUT}}\" | tee /tekton/results/TEST_OUTPUT\n",
                     "arguments": null,
                     "environment": {
                       "container": "sast-snyk-check",
-                      "image": "oci://quay.io/redhat-appstudio/hacbs-test@sha256:2c9018dc080e969f013be4f5d25b207522005d236deedb1f8d1534af29ee5364"
+                      "image": "oci://quay.io/redhat-appstudio/hacbs-test@sha256:5303e71ad8c63377aadf5e7aaaab258aa7359f899114d57bef0b7d5635c51a31"
                     },
                     "annotations": null
                   }
@@ -878,52 +1397,52 @@
                   },
                   "environment": {
                     "annotations": {
-                      "build.appstudio.openshift.io/repo": "https://github.com/enterprise-contract/golden-container?rev=68b69547cad3c4ba856fe6b06154012f33dd8b5a",
-                      "build.appstudio.redhat.com/commit_sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "build.appstudio.openshift.io/repo": "https://github.com/enterprise-contract/golden-container?rev=b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "build.appstudio.redhat.com/commit_sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "build.appstudio.redhat.com/target_branch": "main",
-                      "pipeline.tekton.dev/release": "876b81e",
+                      "pipeline.tekton.dev/release": "34d8c0f",
                       "pipelinesascode.tekton.dev/branch": "main",
-                      "pipelinesascode.tekton.dev/check-run-id": "20539638032",
+                      "pipelinesascode.tekton.dev/check-run-id": "25796873737",
+                      "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
                       "pipelinesascode.tekton.dev/event-type": "push",
-                      "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-iiug",
+                      "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-yoreai",
                       "pipelinesascode.tekton.dev/git-provider": "github",
                       "pipelinesascode.tekton.dev/installation-id": "34493006",
-                      "pipelinesascode.tekton.dev/log-url": "https://console.redhat.com/preview/application-pipeline",
+                      "pipelinesascode.tekton.dev/log-url": "https://console.redhat.com/preview/application-pipeline/ns/rhtap-contract-tenant/pipelinerun/golden-container-on-push-xd69b",
                       "pipelinesascode.tekton.dev/max-keep-runs": "3",
                       "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"main\"",
                       "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
                       "pipelinesascode.tekton.dev/repo-url": "https://github.com/enterprise-contract/golden-container",
                       "pipelinesascode.tekton.dev/repository": "golden-container",
                       "pipelinesascode.tekton.dev/sender": "renovate[bot]",
-                      "pipelinesascode.tekton.dev/sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
-                      "pipelinesascode.tekton.dev/sha-title": "Update quay.io/redhat-appstudio-tekton-catalog/task-clair-scan:0.1 Docker digest to 63b42c0",
-                      "pipelinesascode.tekton.dev/sha-url": "https://github.com/enterprise-contract/golden-container/commit/68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "pipelinesascode.tekton.dev/sha-title": "Update github/codeql-action action to v3.25.8",
+                      "pipelinesascode.tekton.dev/sha-url": "https://github.com/enterprise-contract/golden-container/commit/b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "pipelinesascode.tekton.dev/state": "started",
                       "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
                       "pipelinesascode.tekton.dev/url-repository": "golden-container",
+                      "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"golden-container\",\"commit\":\"b0d7c600114b39f0f14e4e85a7c8aed7c4de316e\",\"eventType\":\"push\"}",
                       "tekton.dev/pipelines.minVersion": "0.12.1",
-                      "tekton.dev/tags": "appstudio, hacbs"
+                      "tekton.dev/tags": "appstudio, hacbs",
+                      "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-d93a888b435563acf59b69d48e089821-d51f6a5a30e88a5b-01\"}"
                     },
                     "labels": {
                       "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
-                      "app.kubernetes.io/version": "v0.22.4",
+                      "app.kubernetes.io/version": "v0.27.0",
                       "appstudio.openshift.io/application": "golden-container",
                       "appstudio.openshift.io/component": "golden-container",
                       "pipelines.appstudio.openshift.io/type": "build",
-                      "pipelinesascode.tekton.dev/branch": "main",
-                      "pipelinesascode.tekton.dev/check-run-id": "20539638032",
+                      "pipelinesascode.tekton.dev/check-run-id": "25796873737",
                       "pipelinesascode.tekton.dev/event-type": "push",
-                      "pipelinesascode.tekton.dev/git-provider": "github",
                       "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
                       "pipelinesascode.tekton.dev/repository": "golden-container",
-                      "pipelinesascode.tekton.dev/sender": "renovate__bot",
-                      "pipelinesascode.tekton.dev/sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "pipelinesascode.tekton.dev/state": "started",
                       "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
                       "pipelinesascode.tekton.dev/url-repository": "golden-container",
                       "tekton.dev/memberOf": "tasks",
-                      "tekton.dev/pipeline": "golden-container-on-push-fdv54",
-                      "tekton.dev/pipelineRun": "golden-container-on-push-fdv54",
+                      "tekton.dev/pipeline": "golden-container-on-push-xd69b",
+                      "tekton.dev/pipelineRun": "golden-container-on-push-xd69b",
                       "tekton.dev/pipelineTask": "sast-snyk-check",
                       "tekton.dev/task": "sast-snyk-check"
                     }
@@ -933,15 +1452,16 @@
                   {
                     "name": "TEST_OUTPUT",
                     "type": "string",
-                    "value": "{\"result\":\"SUCCESS\",\"timestamp\":\"1705424657\",\"note\":\"Task sast-snyk-check success: Snyk code test found zero supported files.\",\"namespace\":\"default\",\"successes\":0,\"failures\":0,\"warnings\":0}\n"
+                    "value": "{\"result\":\"SUCCESS\",\"timestamp\":\"1717516480\",\"note\":\"Task sast-snyk-check success: Snyk code test found zero supported files.\",\"namespace\":\"default\",\"successes\":0,\"failures\":0,\"warnings\":0}\n"
                   }
                 ]
               },
               {
                 "name": "clamav-scan",
-                "after": ["build-container"],
+                "after": [
+                  "build-container"
+                ],
                 "ref": {
-                  "kind": "Task",
                   "resolver": "bundles",
                   "params": [
                     {
@@ -950,7 +1470,7 @@
                     },
                     {
                       "name": "bundle",
-                      "value": "quay.io/redhat-appstudio-tekton-catalog/task-clamav-scan:0.1@sha256:d72cb58db88289559676676c3db43906718028e07279f70ddb12ed8bdc8e2860"
+                      "value": "quay.io/redhat-appstudio-tekton-catalog/task-clamav-scan:0.1@sha256:5dbe6c646c3502ddc7fbe6016b8584bed6ce3ab7028b0c405ebaabc7e6e9e64c"
                     },
                     {
                       "name": "kind",
@@ -958,34 +1478,16 @@
                     }
                   ]
                 },
-                "startedOn": "2024-01-16T17:05:04Z",
-                "finishedOn": "2024-01-16T17:05:37Z",
+                "startedOn": "2024-06-04T15:56:51Z",
+                "finishedOn": "2024-06-04T15:58:08Z",
                 "status": "Succeeded",
                 "steps": [
                   {
-                    "entryPoint": "#!/usr/bin/env bash\nset -euo pipefail\n. /utils.sh\ntrap 'handle_error' EXIT\n\nimagewithouttag=$(echo $IMAGE_URL | sed \"s/\\(.*\\):.*/\\1/\" | tr -d '\\n')\n\n# strip new-line escape symbol from parameter and save it to variable\nimageanddigest=$(echo $imagewithouttag@$IMAGE_DIGEST)\n\n# check if image is attestation one, skip the clamav scan in such case\nif [[ $imageanddigest == *.att ]]\nthen\n    echo \"$imageanddigest is an attestation image. Skipping ClamAV scan.\"\n    exit 0\nfi\nmkdir content\ncd content\necho Extracting image.\nif ! oc image extract --registry-config ~/.docker/config.json $imageanddigest; then\n  echo \"Unable to extract image. Skipping ClamAV scan!\"\n  exit 0\nfi\n\necho \"Scanning image. This operation may take a while.\"\nclamscan -ri --max-scansize=4095M --max-filesize=4095M \\\n  --max-scantime=0 --max-files=0 --max-recursion=1000 --max-dir-recursion=20000 --max-embeddedpe=4095M \\\n  --max-htmlnormalize=4095M --max-htmlnotags=4095M --max-scriptnormalize=4095M --max-ziptypercg=4095M \\\n  --max-partitions=50000 --max-iconspe=100000 --max-rechwp3=20000 --pcre-match-limit=100000000 --pcre-recmatch-limit=2000000 \\\n  --pcre-max-filesize=4095M --alert-broken=yes --alert-exceeds-max=yes --alert-broken-media=yes \\\n  --alert-encrypted=yes --alert-encrypted-archive=yes --alert-encrypted-doc=yes --alert-macros=yes \\\n  --alert-phishing-ssl=yes --alert-phishing-cloak=yes --alert-partition-intersection=yes \\\n  | tee /tekton/home/clamscan-result.log || true\necho \"Executed-on: Scan was executed on version - $(clamscan --version)\" | tee -a /tekton/home/clamscan-result.log\n",
+                    "entryPoint": "#!/usr/bin/env bash\nset -euo pipefail\n. /utils.sh\ntrap 'handle_error' EXIT\n\nimagewithouttag=$(echo $IMAGE_URL | sed \"s/\\(.*\\):.*/\\1/\" | tr -d '\\n')\n\n# strip new-line escape symbol from parameter and save it to variable\nimageanddigest=$(echo $imagewithouttag@$IMAGE_DIGEST)\n\n# check if image is attestation one, skip the clamav scan in such case\nif [[ $imageanddigest == *.att ]]\nthen\n    echo \"$imageanddigest is an attestation image. Skipping ClamAV scan.\"\n    exit 0\nfi\n\nimages_processed_template='{\"image\": {\"pullspec\": \"'\"$IMAGE_URL\"'\", \"digests\": [%s]}}'\ndigests_processed=()\nmkdir content\ncd content\necho \"Extracting image(s).\"\n\n# Get the arch and image manifests by inspecting the image. This is mainly for identifying image indexes\nimage_manifests=$(get_image_manifests -i ${imageanddigest})\nif [ -n \"$image_manifests\" ]; then\n  while read -r arch arch_sha; do\n    destination=$(echo content-$arch)\n    mkdir -p \"$destination\"\n    arch_imageanddigest=$(echo $imagewithouttag@$arch_sha)\n\n    echo \"Running \\\"oc image extract\\\" on image of arch $arch\"\n    oc image extract --registry-config ~/.docker/config.json $arch_imageanddigest --path=\"/:${destination}\" --filter-by-os=\"linux/${arch}\"\n    if [ $? -ne 0 ]; then\n      echo \"Unable to extract image for arch $arch. Skipping ClamAV scan!\"\n      exit 0\n    fi\n\n    echo \"Scanning image for arch $arch. This operation may take a while.\"\n    clamscan $destination -ri --max-scansize=4095M --max-filesize=4095M \\\n      --max-scantime=0 --max-files=0 --max-recursion=1000 --max-dir-recursion=20000 --max-embeddedpe=4095M \\\n      --max-htmlnormalize=10M --max-htmlnotags=4095M --max-scriptnormalize=5M --max-ziptypercg=4095M \\\n      --max-partitions=50000 --max-iconspe=100000 --max-rechwp3=20000 --pcre-match-limit=100000000 --pcre-recmatch-limit=2000000 \\\n      --pcre-max-filesize=4095M --alert-exceeds-max=yes \\\n      --alert-encrypted=yes --alert-encrypted-archive=yes --alert-encrypted-doc=yes --alert-macros=yes \\\n      --alert-phishing-ssl=yes --alert-phishing-cloak=yes --alert-partition-intersection=yes \\\n      | tee /tekton/home/clamscan-result-$arch.log || true\n    echo \"Executed-on: Scan was executed on version - $(clamscan --version)\" | tee -a /tekton/home/clamscan-result-$arch.log\n\n    digests_processed+=(\"\\\"$arch_sha\\\"\")\n\n    if [[ -e \"/tekton/home/clamscan-result-$arch.log\" ]]; then\n      # file_suffix=$(basename \"$file\" | sed 's/clamscan-result-//;s/.log//')\n      # OPA/EC requires structured data input, add clamAV log into json\n      jq -Rs '{ output: . }' /tekton/home/clamscan-result-$arch.log > /tekton/home/clamscan-result-log-$arch.json\n\n      EC_EXPERIMENTAL=1 ec test \\\n        --namespace required_checks \\\n        --policy /project/clamav/virus-check.rego \\\n        -o json \\\n        /tekton/home/clamscan-result-log-$arch.json || true\n\n      # workaround: due to a bug in ec-cli, we cannot generate json and appstudio output at the same time, running it again\n      EC_EXPERIMENTAL=1 ec test \\\n        --namespace required_checks \\\n        --policy /project/clamav/virus-check.rego \\\n        -o appstudio \\\n        /tekton/home/clamscan-result-log-$arch.json | tee /tekton/home/clamscan-ec-test-$arch.json || true\n\n      cat /tekton/home/clamscan-ec-test-$arch.json\n    fi\n  done < <(echo \"$image_manifests\" | jq -r 'to_entries[] | \"\\(.key) \\(.value)\"')\nfi\n\njq -s -rce '\n  reduce .[] as $item ({\"timestamp\":\"0\",\"namespace\":\"\",\"successes\":0,\"failures\":0,\"warnings\":0,\"result\":\"\",\"note\":\"\"};\n    {\n    \"timestamp\" : (if .timestamp < $item.timestamp then $item.timestamp else .timestamp end),\n    \"namespace\" : $item.namespace,\n    \"successes\" : (.successes + $item.successes),\n    \"failures\" : (.failures + $item.failures),\n    \"warnings\" : (.warnings + $item.warnings),\n    \"result\" : (if .result == \"\" or ($item.result == \"SKIPPED\" and .result == \"SUCCESS\") or ($item.result == \"WARNING\" and (.result == \"SUCCESS\" or .result == \"SKIPPED\")) or ($item.result == \"FAILURE\" and .result != \"ERROR\") or $item.result == \"ERROR\" then $item.result else .result end),\n    \"note\" : (if .result == \"\" or ($item.result == \"SKIPPED\" and .result == \"SUCCESS\") or ($item.result == \"WARNING\" and (.result == \"SUCCESS\" or .result == \"SKIPPED\")) or ($item.result == \"FAILURE\" and .result != \"ERROR\") or $item.result == \"ERROR\" then $item.note else .note end)\n    })' /tekton/home/clamscan-ec-test-*.json | tee /tekton/results/TEST_OUTPUT\n\ndigests_processed_string=$(IFS=,; echo \"${digests_processed[*]}\")\necho \"${images_processed_template/\\[%s]/[$digests_processed_string]}\" | tee /tekton/results/IMAGES_PROCESSED\n",
                     "arguments": null,
                     "environment": {
                       "container": "extract-and-scan-image",
-                      "image": "oci://quay.io/redhat-appstudio/hacbs-test@sha256:2c9018dc080e969f013be4f5d25b207522005d236deedb1f8d1534af29ee5364"
-                    },
-                    "annotations": null
-                  },
-                  {
-                    "entryPoint": "#!/usr/bin/env python3.9\nimport json\nimport dateutil.parser as parser\nimport os\n\nclamscan_result = \"/tekton/home/clamscan-result.log\"\nif not os.path.exists(clamscan_result) or os.stat(clamscan_result).st_size == 0:\n    print(\"clamscan-result.log file is empty, so compiled code not extracted. Parsing skipped.\")\n    exit(0)\n\nwith open(clamscan_result, \"r\") as file:\n    clam_result_str = file.read()\n\ndef clam_result_str_to_json(clam_result_str):\n\n    clam_result_list = clam_result_str.split(\"\\n\")\n    clam_result_list.remove('')\n\n    results_marker = \\\n        clam_result_list.index(\"----------- SCAN SUMMARY -----------\")\n\n    hit_list = clam_result_list[:results_marker]\n    summary_list = clam_result_list[(results_marker + 1):]\n\n    r_dict = { \"hits\": hit_list }\n    for item in summary_list:\n        # in case of blank lines\n        if not item:\n            continue\n        split_index = [c == ':' for c in item].index(True)\n        key = item[:split_index].lower()\n        key = key.replace(\" \", \"_\")\n        value = item[(split_index + 1):].strip(\" \")\n        if (key == \"start_date\" or key == \"end_date\"):\n          isodate = parser.parse(value)\n          value = isodate.isoformat()\n        r_dict[key] = value\n    print(json.dumps(r_dict))\n    with open('/tekton/home/clamscan-result.json', 'w') as f:\n      print(json.dumps(r_dict), file=f)\n\ndef main():\n    clam_result_str_to_json(clam_result_str)\n\nif __name__ == \"__main__\":\n    main()\n",
-                    "arguments": null,
-                    "environment": {
-                      "container": "modify-clam-output-to-json",
-                      "image": "oci://quay.io/redhat-appstudio/hacbs-test@sha256:2c9018dc080e969f013be4f5d25b207522005d236deedb1f8d1534af29ee5364"
-                    },
-                    "annotations": null
-                  },
-                  {
-                    "entryPoint": "#!/usr/bin/env bash\nset -euo pipefail\nsource /utils.sh\ntrap 'handle_error /tekton/results/TEST_OUTPUT' EXIT\n\nif [ -f /tekton/home/clamscan-result.json ];\nthen\n  cat /tekton/home/clamscan-result.json\n  INFECTED_FILES=$(jq -r '.infected_files' /tekton/home/clamscan-result.json || true )\n  WARNING_FILES=$(jq -r '.hits|length' /tekton/home/clamscan-result.json || true )\n  if [ -z \"${INFECTED_FILES}\" ]; then\n    echo \"Failed to get number of infected files.\"\n    note=\"Task clamav-scan failed: Unable to get number of infected files from /tekton/home/clamscan-result.json. For details, check Tekton task log.\"\n  else\n    if [[ \"${INFECTED_FILES}\" -gt 0 ]]; then\n     RES=\"FAILURE\";\n    elif [[ \"${WARNING_FILES}\" -gt 0 ]]; then\n      RES=\"WARNING\";\n    else\n      RES=\"SUCCESS\";\n    fi\n    note=\"Task clamav-scan completed: Check result for antivirus scan result.\"\n    TEST_OUTPUT=$(make_result_json -r \"${RES}\" -s 1 -f \"${INFECTED_FILES}\" -w \"${WARNING_FILES}\" -t \"$note\")\n  fi\nelse\n  note=\"Task clamav-scan failed: /tekton/home/clamscan-result.json doesn't exist. For details, check Tekton task log.\"\nfi\n\nERROR_OUTPUT=$(make_result_json -r \"ERROR\" -t \"$note\")\necho \"${TEST_OUTPUT:-${ERROR_OUTPUT}}\" | tee /tekton/results/TEST_OUTPUT\n",
-                    "arguments": null,
-                    "environment": {
-                      "container": "store-hacbs-test-output-result",
-                      "image": "oci://quay.io/redhat-appstudio/hacbs-test@sha256:2c9018dc080e969f013be4f5d25b207522005d236deedb1f8d1534af29ee5364"
+                      "image": "oci://quay.io/redhat-appstudio/konflux-test@sha256:5303e71ad8c63377aadf5e7aaaab258aa7359f899114d57bef0b7d5635c51a31"
                     },
                     "annotations": null
                   }
@@ -994,57 +1496,57 @@
                   "configSource": {},
                   "parameters": {
                     "docker-auth": "",
-                    "image-digest": "sha256:6fa252a7df2735b84674e64b78ac66279af0f2cbbb7ed1dd6a534daf0a4b8738",
-                    "image-url": "quay.io/redhat-appstudio/ec-golden-image:68b69547cad3c4ba856fe6b06154012f33dd8b5a"
+                    "image-digest": "sha256:e5f4f3669712c98fd37a960479f56d96c7c2743f3c424275d00623f7661d8272",
+                    "image-url": "quay.io/redhat-appstudio/ec-golden-image:b0d7c600114b39f0f14e4e85a7c8aed7c4de316e"
                   },
                   "environment": {
                     "annotations": {
-                      "build.appstudio.openshift.io/repo": "https://github.com/enterprise-contract/golden-container?rev=68b69547cad3c4ba856fe6b06154012f33dd8b5a",
-                      "build.appstudio.redhat.com/commit_sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "build.appstudio.openshift.io/repo": "https://github.com/enterprise-contract/golden-container?rev=b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "build.appstudio.redhat.com/commit_sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "build.appstudio.redhat.com/target_branch": "main",
-                      "pipeline.tekton.dev/release": "876b81e",
+                      "pipeline.tekton.dev/release": "34d8c0f",
                       "pipelinesascode.tekton.dev/branch": "main",
-                      "pipelinesascode.tekton.dev/check-run-id": "20539638032",
+                      "pipelinesascode.tekton.dev/check-run-id": "25796873737",
+                      "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
                       "pipelinesascode.tekton.dev/event-type": "push",
-                      "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-iiug",
+                      "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-yoreai",
                       "pipelinesascode.tekton.dev/git-provider": "github",
                       "pipelinesascode.tekton.dev/installation-id": "34493006",
-                      "pipelinesascode.tekton.dev/log-url": "https://console.redhat.com/preview/application-pipeline",
+                      "pipelinesascode.tekton.dev/log-url": "https://console.redhat.com/preview/application-pipeline/ns/rhtap-contract-tenant/pipelinerun/golden-container-on-push-xd69b",
                       "pipelinesascode.tekton.dev/max-keep-runs": "3",
                       "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"main\"",
                       "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
                       "pipelinesascode.tekton.dev/repo-url": "https://github.com/enterprise-contract/golden-container",
                       "pipelinesascode.tekton.dev/repository": "golden-container",
                       "pipelinesascode.tekton.dev/sender": "renovate[bot]",
-                      "pipelinesascode.tekton.dev/sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
-                      "pipelinesascode.tekton.dev/sha-title": "Update quay.io/redhat-appstudio-tekton-catalog/task-clair-scan:0.1 Docker digest to 63b42c0",
-                      "pipelinesascode.tekton.dev/sha-url": "https://github.com/enterprise-contract/golden-container/commit/68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "pipelinesascode.tekton.dev/sha-title": "Update github/codeql-action action to v3.25.8",
+                      "pipelinesascode.tekton.dev/sha-url": "https://github.com/enterprise-contract/golden-container/commit/b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "pipelinesascode.tekton.dev/state": "started",
                       "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
                       "pipelinesascode.tekton.dev/url-repository": "golden-container",
+                      "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"golden-container\",\"commit\":\"b0d7c600114b39f0f14e4e85a7c8aed7c4de316e\",\"eventType\":\"push\"}",
                       "tekton.dev/pipelines.minVersion": "0.12.1",
-                      "tekton.dev/tags": "virus, appstudio, hacbs"
+                      "tekton.dev/tags": "virus, appstudio, hacbs",
+                      "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-d93a888b435563acf59b69d48e089821-c0a12ab2889f04d0-01\"}"
                     },
                     "labels": {
                       "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
-                      "app.kubernetes.io/version": "v0.22.4",
+                      "app.kubernetes.io/version": "v0.27.0",
                       "appstudio.openshift.io/application": "golden-container",
                       "appstudio.openshift.io/component": "golden-container",
                       "pipelines.appstudio.openshift.io/type": "build",
-                      "pipelinesascode.tekton.dev/branch": "main",
-                      "pipelinesascode.tekton.dev/check-run-id": "20539638032",
+                      "pipelinesascode.tekton.dev/check-run-id": "25796873737",
                       "pipelinesascode.tekton.dev/event-type": "push",
-                      "pipelinesascode.tekton.dev/git-provider": "github",
                       "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
                       "pipelinesascode.tekton.dev/repository": "golden-container",
-                      "pipelinesascode.tekton.dev/sender": "renovate__bot",
-                      "pipelinesascode.tekton.dev/sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "pipelinesascode.tekton.dev/state": "started",
                       "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
                       "pipelinesascode.tekton.dev/url-repository": "golden-container",
                       "tekton.dev/memberOf": "tasks",
-                      "tekton.dev/pipeline": "golden-container-on-push-fdv54",
-                      "tekton.dev/pipelineRun": "golden-container-on-push-fdv54",
+                      "tekton.dev/pipeline": "golden-container-on-push-xd69b",
+                      "tekton.dev/pipelineRun": "golden-container-on-push-xd69b",
                       "tekton.dev/pipelineTask": "clamav-scan",
                       "tekton.dev/task": "clamav-scan"
                     }
@@ -1052,17 +1554,23 @@
                 },
                 "results": [
                   {
+                    "name": "IMAGES_PROCESSED",
+                    "type": "string",
+                    "value": "{\"image\": {\"pullspec\": \"quay.io/redhat-appstudio/ec-golden-image:b0d7c600114b39f0f14e4e85a7c8aed7c4de316e\", \"digests\": [\"sha256:b4cfd7c1fc510d6b934c195cf5bf1d647ff332215104a0d05942fc0aa1fe09e7\",\"sha256:ade052c249de1420c0f860fef47b620f00135aade4a55bc385de1dd634e8cc7a\"]}}\n"
+                  },
+                  {
                     "name": "TEST_OUTPUT",
                     "type": "string",
-                    "value": "{\"result\":\"SUCCESS\",\"timestamp\":\"1705424736\",\"note\":\"Task clamav-scan completed: Check result for antivirus scan result.\",\"namespace\":\"default\",\"successes\":1,\"failures\":0,\"warnings\":0}\n"
+                    "value": "{\"timestamp\":\"1717516687\",\"namespace\":\"required_checks\",\"successes\":4,\"failures\":0,\"warnings\":0,\"result\":\"SUCCESS\",\"note\":\"All checks passed successfully\"}\n"
                   }
                 ]
               },
               {
                 "name": "sbom-json-check",
-                "after": ["build-container"],
+                "after": [
+                  "build-container"
+                ],
                 "ref": {
-                  "kind": "Task",
                   "resolver": "bundles",
                   "params": [
                     {
@@ -1071,7 +1579,7 @@
                     },
                     {
                       "name": "bundle",
-                      "value": "quay.io/redhat-appstudio-tekton-catalog/task-sbom-json-check:0.1@sha256:717e6e33f02dbe1a28fb743f32699e002c944680c251a50b644f27becb9208e9"
+                      "value": "quay.io/redhat-appstudio-tekton-catalog/task-sbom-json-check:0.1@sha256:f9cc253c3a07594bfb51e09c78b46598591cb353e19b16ef514f8312a8b0bada"
                     },
                     {
                       "name": "kind",
@@ -1079,16 +1587,16 @@
                     }
                   ]
                 },
-                "startedOn": "2024-01-16T17:05:04Z",
-                "finishedOn": "2024-01-16T17:05:19Z",
+                "startedOn": "2024-06-04T15:56:51Z",
+                "finishedOn": "2024-06-04T15:57:01Z",
                 "status": "Succeeded",
                 "steps": [
                   {
-                    "entryPoint": "#!/usr/bin/env bash\nset -euo pipefail\nsource /utils.sh\ntrap 'handle_error /tekton/results/TEST_OUTPUT' EXIT\n\nmkdir /manifests/ && cd /manifests/\n\nimage_with_digest=\"${IMAGE_URL}@${IMAGE_DIGEST}\"\n\nif ! oc image extract --registry-config ~/.docker/config.json \"${image_with_digest}\" --path '/root/buildinfo/content_manifests/*:/manifests/'; then\n  echo \"Failed to extract manifests from image ${image_with_digest}.\"\n  note=\"Task sbom-json-check failed: Failed to extract manifests from image ${image_with_digest} with oc extract. For details, check Tekton task log.\"\n  ERROR_OUTPUT=$(make_result_json -r \"ERROR\" -t \"$note\")\nfi\n\ntouch fail_result.txt\nif [ -f \"sbom-cyclonedx.json\" ]\nthen\n  result=$(echo -n $(sbom-utility validate --input-file sbom-cyclonedx.json))\n  if [[ ! $result =~ \"SBOM valid against JSON schema: `true`\" ]]\n  then\n    echo \"sbom-cyclonedx.json: $result\" > fail_result.txt\n  fi\nelse\n  echo \"Cannot access sbom-cyclonedx.json: No such file or directory exists.\" > fail_result.txt\nfi\n\nFAIL_RESULTS=\"$(cat fail_result.txt)\"\nif [[ -z $FAIL_RESULTS ]]\nthen\n  note=\"Task sbom-json-check completed: Check result for JSON check result.\"\n  TEST_OUTPUT=$(make_result_json -r \"SUCCESS\" -s 1 -t \"$note\")\nelse\n  echo \"Failed to verify sbom-cyclonedx.json for image $IMAGE_URL with reason: $FAIL_RESULTS.\"\n  note=\"Task sbom-json-check failed: Failed to verify SBOM for image $IMAGE_URL.\"\n  ERROR_OUTPUT=$(make_result_json -r \"FAILURE\" -f 1 -t \"$note\")\nfi\n\necho \"${TEST_OUTPUT:-${ERROR_OUTPUT}}\" | tee /tekton/results/TEST_OUTPUT\n",
+                    "entryPoint": "#!/usr/bin/env bash\nset -euo pipefail\nsource /utils.sh\ntrap 'handle_error /tekton/results/TEST_OUTPUT' EXIT\n\nimages_processed_template='{\"image\": {\"pullspec\": \"'\"$IMAGE_URL\"'\", \"digests\": [%s]}}'\nmkdir /manifests/ && cd /manifests/\n\nimagewithouttag=$(echo -n $IMAGE_URL | sed \"s/\\(.*\\):.*/\\1/\")\nimage_with_digest=$(echo $imagewithouttag@$IMAGE_DIGEST)\ndigests_processed=()\n\nimage_manifests=$(get_image_manifests -i ${image_with_digest})\necho \"$image_manifests\"\nif [ -n \"$image_manifests\" ]; then\n  while read -r arch arch_sha; do\n    destination=$(echo content-$arch)\n    mkdir -p \"$destination\"\n    arch_imageanddigest=$(echo $imagewithouttag@$arch_sha)\n    echo \"arch sha is $arch_sha\"\n\n    echo \"Running \\\"oc image extract\\\" on image of arch $arch\"\n    oc image extract --registry-config ~/.docker/config.json $arch_imageanddigest --path=\"/root/buildinfo/content_manifests/*:/manifests/${destination}\" --filter-by-os=\"linux/${arch}\"\n    if [ $? -ne 0 ]; then\n      echo \"Failed to extract manifests from image $arch_imageanddigest of arch $arch.\"\n      note=\"Task sbom-json-check failed: Failed to extract manifests from image ${arch_imageanddigest} with oc extract. For details, check Tekton task log.\"\n      ERROR_OUTPUT=$(make_result_json -r \"ERROR\" -t \"$note\")\n    fi\n    digests_processed+=(\"\\\"$arch_sha\\\"\")\n  done < <(echo \"$image_manifests\" | jq -r 'to_entries[] | \"\\(.key) \\(.value)\"')\nfi\n\n# arrays to keep count of successful and failed checks\nsuccesses=()\nfailures=()\nfor directory in content-*; do\n  if [[ -d \"$directory\" ]]; then\n    directory_suffix=$(basename \"$directory\" | sed 's/content-//')\n\n    touch fail_result.txt\n    if [ -f \"$directory/sbom-cyclonedx.json\" ]; then\n      result=$(echo -n $(sbom-utility validate --input-file \"$directory/sbom-cyclonedx.json\"))\n      if [[ ! $result =~ \"SBOM valid against JSON schema: `true`\" ]]; then\n        echo -e \"$directory_suffix sbom-cyclonedx.json: $result\\n\" > fail_result.txt\n        failures+=(\"$directory_suffix\")\n      else\n        successes+=(\"$directory_suffix\")\n      fi\n    else\n      echo -e \"Cannot access sbom-cyclonedx.json for directory_suffix : No such file or directory exists.\\n\" > fail_result.txt\n      failures+=(\"$directory_suffix\")\n    fi\n  fi\ndone\n\necho \"Success: (${successes[@]}) and Failures: (${failures[@]})\"\nsuccess_count=${#successes[@]}\nfailure_count=${#failures[@]}\n\nFAIL_RESULTS=\"$(cat fail_result.txt)\"\nif [[ -z $FAIL_RESULTS ]]; then\n  echo \"SBOMs were validated for image $IMAGE_URL (${successes[@]})\"\n  note=\"Task sbom-json-check completed: Check result for JSON check result.\"\n  TEST_OUTPUT=$(make_result_json -r \"SUCCESS\" -s $success_count -f $failure_count -t \"$note\")\nelse\n  echo \"Failed to verify sbom-cyclonedx.json for image $IMAGE_URL (${failures[@]}) with reason: $FAIL_RESULTS.\"\n  note=\"Task sbom-json-check failed: Failed to verify SBOM for image $IMAGE_URL.\"\n  ERROR_OUTPUT=$(make_result_json -r \"FAILURE\" -s $success_count -f $failure_count -t \"$note\")\nfi\n\necho \"${TEST_OUTPUT:-${ERROR_OUTPUT}}\" | tee /tekton/results/TEST_OUTPUT\n\ndigests_processed_string=$(IFS=,; echo \"${digests_processed[*]}\")\necho \"${images_processed_template/\\[%s]/[$digests_processed_string]}\" | tee /tekton/results/IMAGES_PROCESSED\n",
                     "arguments": null,
                     "environment": {
                       "container": "sbom-json-check",
-                      "image": "oci://quay.io/redhat-appstudio/hacbs-test@sha256:2c9018dc080e969f013be4f5d25b207522005d236deedb1f8d1534af29ee5364"
+                      "image": "oci://quay.io/redhat-appstudio/hacbs-test@sha256:5303e71ad8c63377aadf5e7aaaab258aa7359f899114d57bef0b7d5635c51a31"
                     },
                     "annotations": null
                   }
@@ -1096,55 +1604,55 @@
                 "invocation": {
                   "configSource": {},
                   "parameters": {
-                    "IMAGE_DIGEST": "sha256:6fa252a7df2735b84674e64b78ac66279af0f2cbbb7ed1dd6a534daf0a4b8738",
-                    "IMAGE_URL": "quay.io/redhat-appstudio/ec-golden-image:68b69547cad3c4ba856fe6b06154012f33dd8b5a"
+                    "IMAGE_DIGEST": "sha256:e5f4f3669712c98fd37a960479f56d96c7c2743f3c424275d00623f7661d8272",
+                    "IMAGE_URL": "quay.io/redhat-appstudio/ec-golden-image:b0d7c600114b39f0f14e4e85a7c8aed7c4de316e"
                   },
                   "environment": {
                     "annotations": {
-                      "build.appstudio.openshift.io/repo": "https://github.com/enterprise-contract/golden-container?rev=68b69547cad3c4ba856fe6b06154012f33dd8b5a",
-                      "build.appstudio.redhat.com/commit_sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "build.appstudio.openshift.io/repo": "https://github.com/enterprise-contract/golden-container?rev=b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "build.appstudio.redhat.com/commit_sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "build.appstudio.redhat.com/target_branch": "main",
-                      "pipeline.tekton.dev/release": "876b81e",
+                      "pipeline.tekton.dev/release": "34d8c0f",
                       "pipelinesascode.tekton.dev/branch": "main",
-                      "pipelinesascode.tekton.dev/check-run-id": "20539638032",
+                      "pipelinesascode.tekton.dev/check-run-id": "25796873737",
+                      "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
                       "pipelinesascode.tekton.dev/event-type": "push",
-                      "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-iiug",
+                      "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-yoreai",
                       "pipelinesascode.tekton.dev/git-provider": "github",
                       "pipelinesascode.tekton.dev/installation-id": "34493006",
-                      "pipelinesascode.tekton.dev/log-url": "https://console.redhat.com/preview/application-pipeline",
+                      "pipelinesascode.tekton.dev/log-url": "https://console.redhat.com/preview/application-pipeline/ns/rhtap-contract-tenant/pipelinerun/golden-container-on-push-xd69b",
                       "pipelinesascode.tekton.dev/max-keep-runs": "3",
                       "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"main\"",
                       "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
                       "pipelinesascode.tekton.dev/repo-url": "https://github.com/enterprise-contract/golden-container",
                       "pipelinesascode.tekton.dev/repository": "golden-container",
                       "pipelinesascode.tekton.dev/sender": "renovate[bot]",
-                      "pipelinesascode.tekton.dev/sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
-                      "pipelinesascode.tekton.dev/sha-title": "Update quay.io/redhat-appstudio-tekton-catalog/task-clair-scan:0.1 Docker digest to 63b42c0",
-                      "pipelinesascode.tekton.dev/sha-url": "https://github.com/enterprise-contract/golden-container/commit/68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "pipelinesascode.tekton.dev/sha-title": "Update github/codeql-action action to v3.25.8",
+                      "pipelinesascode.tekton.dev/sha-url": "https://github.com/enterprise-contract/golden-container/commit/b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "pipelinesascode.tekton.dev/state": "started",
                       "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
-                      "pipelinesascode.tekton.dev/url-repository": "golden-container"
+                      "pipelinesascode.tekton.dev/url-repository": "golden-container",
+                      "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"golden-container\",\"commit\":\"b0d7c600114b39f0f14e4e85a7c8aed7c4de316e\",\"eventType\":\"push\"}",
+                      "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-d93a888b435563acf59b69d48e089821-7c84b338f427173e-01\"}"
                     },
                     "labels": {
                       "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
-                      "app.kubernetes.io/version": "v0.22.4",
+                      "app.kubernetes.io/version": "v0.27.0",
                       "appstudio.openshift.io/application": "golden-container",
                       "appstudio.openshift.io/component": "golden-container",
                       "pipelines.appstudio.openshift.io/type": "build",
-                      "pipelinesascode.tekton.dev/branch": "main",
-                      "pipelinesascode.tekton.dev/check-run-id": "20539638032",
+                      "pipelinesascode.tekton.dev/check-run-id": "25796873737",
                       "pipelinesascode.tekton.dev/event-type": "push",
-                      "pipelinesascode.tekton.dev/git-provider": "github",
                       "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
                       "pipelinesascode.tekton.dev/repository": "golden-container",
-                      "pipelinesascode.tekton.dev/sender": "renovate__bot",
-                      "pipelinesascode.tekton.dev/sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "pipelinesascode.tekton.dev/state": "started",
                       "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
                       "pipelinesascode.tekton.dev/url-repository": "golden-container",
                       "tekton.dev/memberOf": "tasks",
-                      "tekton.dev/pipeline": "golden-container-on-push-fdv54",
-                      "tekton.dev/pipelineRun": "golden-container-on-push-fdv54",
+                      "tekton.dev/pipeline": "golden-container-on-push-xd69b",
+                      "tekton.dev/pipelineRun": "golden-container-on-push-xd69b",
                       "tekton.dev/pipelineTask": "sbom-json-check",
                       "tekton.dev/task": "sbom-json-check"
                     }
@@ -1152,17 +1660,23 @@
                 },
                 "results": [
                   {
+                    "name": "IMAGES_PROCESSED",
+                    "type": "string",
+                    "value": "{\"image\": {\"pullspec\": \"quay.io/redhat-appstudio/ec-golden-image:b0d7c600114b39f0f14e4e85a7c8aed7c4de316e\", \"digests\": [\"sha256:b4cfd7c1fc510d6b934c195cf5bf1d647ff332215104a0d05942fc0aa1fe09e7\",\"sha256:ade052c249de1420c0f860fef47b620f00135aade4a55bc385de1dd634e8cc7a\"]}}\n"
+                  },
+                  {
                     "name": "TEST_OUTPUT",
                     "type": "string",
-                    "value": "{\"result\":\"SUCCESS\",\"timestamp\":\"1705424718\",\"note\":\"Task sbom-json-check completed: Check result for JSON check result.\",\"namespace\":\"default\",\"successes\":1,\"failures\":0,\"warnings\":0}\n"
+                    "value": "{\"result\":\"SUCCESS\",\"timestamp\":\"1717516620\",\"note\":\"Task sbom-json-check completed: Check result for JSON check result.\",\"namespace\":\"default\",\"successes\":2,\"failures\":0,\"warnings\":0}\n"
                   }
                 ]
               },
               {
                 "name": "show-sbom",
-                "after": ["build-container"],
+                "after": [
+                  "build-container"
+                ],
                 "ref": {
-                  "kind": "Task",
                   "resolver": "bundles",
                   "params": [
                     {
@@ -1171,7 +1685,7 @@
                     },
                     {
                       "name": "bundle",
-                      "value": "quay.io/redhat-appstudio-tekton-catalog/task-show-sbom:0.1@sha256:202d3c3385120ea847d8f0a82bd8d9d5e873d67f981d6f8a51fb1706caaf6bef"
+                      "value": "quay.io/redhat-appstudio-tekton-catalog/task-show-sbom:0.1@sha256:1f1504c5d8b135864111a993ac6f9ab1212907fa0c609223714cdd7bd825e2ca"
                     },
                     {
                       "name": "kind",
@@ -1179,16 +1693,16 @@
                     }
                   ]
                 },
-                "startedOn": "2024-01-16T17:05:37Z",
-                "finishedOn": "2024-01-16T17:05:43Z",
+                "startedOn": "2024-06-04T15:58:09Z",
+                "finishedOn": "2024-06-04T15:58:16Z",
                 "status": "Succeeded",
                 "steps": [
                   {
-                    "entryPoint": "#!/busybox/sh\ncosign download sbom $IMAGE_URL 2>err\nRET=$?\nif [ $RET -ne 0 ]; then\n  echo Failed to get SBOM >&2\n  cat err >&2\nfi\nexit $RET\n",
+                    "entryPoint": "#!/bin/bash\n\ndownload_sbom_with_retry() {\n  status=-1\n  max_try=5\n  wait_sec=2\n\n  PLATFORM_ARG=\"$1\"\n  for run in $(seq 1 $max_try); do\n    status=0\n    cosign download sbom $PLATFORM_ARG $IMAGE_URL 2>>err\n    status=$?\n    if [ \"$status\" -eq 0 ]; then\n      break\n    fi\n    sleep $wait_sec\n  done\n  if [ \"$status\" -ne 0 ]; then\n    echo \"Failed to get SBOM after ${max_try} tries\" >&2\n    cat err >&2\n  fi\n}\n\nRAW_OUTPUT=$(skopeo inspect --no-tags --raw docker://${IMAGE_URL})\nif [ $(jq -r '.mediaType' <<< $RAW_OUTPUT) == \"application/vnd.oci.image.manifest.v1+json\" ] ; then\n  ARCHES=\"\"\nelse\n  # Multi arch\n  ARCHES=$(jq -r '.manifests[].platform.architecture' <<< $RAW_OUTPUT)\nfi\n\nif [ -z \"${ARCHES}\" ] ; then\n  # single arch image\n  download_sbom_with_retry \"\"\nelse\n  download_sbom_with_retry \" --platform=$PLATFORM \"\nfi\n",
                     "arguments": null,
                     "environment": {
                       "container": "show-sbom",
-                      "image": "oci://quay.io/redhat-appstudio/cosign@sha256:c883d6f8d39148f2cea71bff4622d196d89df3e510f36c140c097b932f0dd5d5"
+                      "image": "oci://quay.io/redhat-appstudio/appstudio-utils@sha256:efd1a0b46f03dc9b6b2b2a14a1dac91494f9c6e7935fd418deeb7f49601b14d1"
                     },
                     "annotations": null
                   }
@@ -1196,56 +1710,57 @@
                 "invocation": {
                   "configSource": {},
                   "parameters": {
-                    "IMAGE_URL": "quay.io/redhat-appstudio/ec-golden-image:68b69547cad3c4ba856fe6b06154012f33dd8b5a"
+                    "IMAGE_URL": "quay.io/redhat-appstudio/ec-golden-image:b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                    "PLATFORM": "linux/amd64"
                   },
                   "environment": {
                     "annotations": {
-                      "build.appstudio.openshift.io/repo": "https://github.com/enterprise-contract/golden-container?rev=68b69547cad3c4ba856fe6b06154012f33dd8b5a",
-                      "build.appstudio.redhat.com/commit_sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "build.appstudio.openshift.io/repo": "https://github.com/enterprise-contract/golden-container?rev=b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "build.appstudio.redhat.com/commit_sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "build.appstudio.redhat.com/target_branch": "main",
-                      "pipeline.tekton.dev/release": "876b81e",
+                      "pipeline.tekton.dev/release": "34d8c0f",
                       "pipelinesascode.tekton.dev/branch": "main",
-                      "pipelinesascode.tekton.dev/check-run-id": "20539638032",
+                      "pipelinesascode.tekton.dev/check-run-id": "25796873737",
+                      "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
                       "pipelinesascode.tekton.dev/event-type": "push",
-                      "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-iiug",
+                      "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-yoreai",
                       "pipelinesascode.tekton.dev/git-provider": "github",
                       "pipelinesascode.tekton.dev/installation-id": "34493006",
-                      "pipelinesascode.tekton.dev/log-url": "https://console.redhat.com/preview/application-pipeline",
+                      "pipelinesascode.tekton.dev/log-url": "https://console.redhat.com/preview/application-pipeline/ns/rhtap-contract-tenant/pipelinerun/golden-container-on-push-xd69b",
                       "pipelinesascode.tekton.dev/max-keep-runs": "3",
                       "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"main\"",
                       "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
                       "pipelinesascode.tekton.dev/repo-url": "https://github.com/enterprise-contract/golden-container",
                       "pipelinesascode.tekton.dev/repository": "golden-container",
                       "pipelinesascode.tekton.dev/sender": "renovate[bot]",
-                      "pipelinesascode.tekton.dev/sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
-                      "pipelinesascode.tekton.dev/sha-title": "Update quay.io/redhat-appstudio-tekton-catalog/task-clair-scan:0.1 Docker digest to 63b42c0",
-                      "pipelinesascode.tekton.dev/sha-url": "https://github.com/enterprise-contract/golden-container/commit/68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "pipelinesascode.tekton.dev/sha-title": "Update github/codeql-action action to v3.25.8",
+                      "pipelinesascode.tekton.dev/sha-url": "https://github.com/enterprise-contract/golden-container/commit/b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "pipelinesascode.tekton.dev/state": "started",
                       "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
                       "pipelinesascode.tekton.dev/url-repository": "golden-container",
+                      "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"golden-container\",\"commit\":\"b0d7c600114b39f0f14e4e85a7c8aed7c4de316e\",\"eventType\":\"push\"}",
                       "tekton.dev/pipelines.minVersion": "0.12.1",
-                      "tekton.dev/tags": "appstudio, hacbs"
+                      "tekton.dev/tags": "appstudio, hacbs",
+                      "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-d93a888b435563acf59b69d48e089821-2df7ff11359c6098-01\"}"
                     },
                     "labels": {
                       "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
-                      "app.kubernetes.io/version": "v0.22.4",
+                      "app.kubernetes.io/version": "v0.27.0",
                       "appstudio.openshift.io/application": "golden-container",
                       "appstudio.openshift.io/component": "golden-container",
                       "pipelines.appstudio.openshift.io/type": "build",
-                      "pipelinesascode.tekton.dev/branch": "main",
-                      "pipelinesascode.tekton.dev/check-run-id": "20539638032",
+                      "pipelinesascode.tekton.dev/check-run-id": "25796873737",
                       "pipelinesascode.tekton.dev/event-type": "push",
-                      "pipelinesascode.tekton.dev/git-provider": "github",
                       "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
                       "pipelinesascode.tekton.dev/repository": "golden-container",
-                      "pipelinesascode.tekton.dev/sender": "renovate__bot",
-                      "pipelinesascode.tekton.dev/sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "pipelinesascode.tekton.dev/state": "started",
                       "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
                       "pipelinesascode.tekton.dev/url-repository": "golden-container",
                       "tekton.dev/memberOf": "finally",
-                      "tekton.dev/pipeline": "golden-container-on-push-fdv54",
-                      "tekton.dev/pipelineRun": "golden-container-on-push-fdv54",
+                      "tekton.dev/pipeline": "golden-container-on-push-xd69b",
+                      "tekton.dev/pipelineRun": "golden-container-on-push-xd69b",
                       "tekton.dev/pipelineTask": "show-sbom",
                       "tekton.dev/task": "show-sbom"
                     }
@@ -1254,9 +1769,10 @@
               },
               {
                 "name": "show-summary",
-                "after": ["clone-repository"],
+                "after": [
+                  "clone-repository"
+                ],
                 "ref": {
-                  "kind": "Task",
                   "resolver": "bundles",
                   "params": [
                     {
@@ -1265,7 +1781,7 @@
                     },
                     {
                       "name": "bundle",
-                      "value": "quay.io/redhat-appstudio-tekton-catalog/task-summary:0.1@sha256:f65a69aaf71cbab382eff685eee522ad35068a4d91d233e76cef7d42ff15a686"
+                      "value": "quay.io/redhat-appstudio-tekton-catalog/task-summary:0.2@sha256:c718319bd57c4f0ab1843cf98d813d0a26a73e0c8ce66218079c3c865508b0fb"
                     },
                     {
                       "name": "kind",
@@ -1273,16 +1789,16 @@
                     }
                   ]
                 },
-                "startedOn": "2024-01-16T17:05:37Z",
-                "finishedOn": "2024-01-16T17:05:43Z",
+                "startedOn": "2024-06-04T15:58:09Z",
+                "finishedOn": "2024-06-04T15:58:17Z",
                 "status": "Succeeded",
                 "steps": [
                   {
-                    "entryPoint": "#!/usr/bin/env bash\necho\necho \"Build Summary:\"\necho\necho \"Build repository: $GIT_URL\"\nif [ \"$BUILD_TASK_STATUS\" == \"Succeeded\" ]; then\n  echo \"Generated Image is in : $IMAGE_URL\"\nfi\necho\necho End Summary\n",
+                    "entryPoint": "#!/usr/bin/env bash\necho\necho \"Build Summary:\"\necho\necho \"Build repository: $GIT_URL\"\nif [ \"$BUILD_TASK_STATUS\" == \"Succeeded\" ]; then\n  echo \"Generated Image is in : $IMAGE_URL\"\nfi\nif [ -e \"$SOURCE_BUILD_RESULT_FILE\" ]; then\n  url=$(jq -r \".image_url\" <\"$SOURCE_BUILD_RESULT_FILE\")\n  echo \"Generated Source Image is in : $url\"\nfi\necho\necho End Summary\n",
                     "arguments": null,
                     "environment": {
                       "container": "appstudio-summary",
-                      "image": "oci://registry.access.redhat.com/ubi9/ubi-minimal@sha256:3e313209ac617a92b50350286752311d99ea2dafc429ef0e5311889294b0bc21"
+                      "image": "oci://quay.io/redhat-appstudio/appstudio-utils@sha256:8c7fcf86af40c71aeb58e4279625c8308af5144e2f6b8e28b0ec7e795260e5f7"
                     },
                     "annotations": null
                   }
@@ -1291,58 +1807,58 @@
                   "configSource": {},
                   "parameters": {
                     "build-task-status": "Succeeded",
-                    "git-url": "https://github.com/enterprise-contract/golden-container?rev=68b69547cad3c4ba856fe6b06154012f33dd8b5a",
-                    "image-url": "quay.io/redhat-appstudio/ec-golden-image:68b69547cad3c4ba856fe6b06154012f33dd8b5a",
-                    "pipelinerun-name": "golden-container-on-push-fdv54"
+                    "git-url": "https://github.com/enterprise-contract/golden-container?rev=b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                    "image-url": "quay.io/redhat-appstudio/ec-golden-image:b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                    "pipelinerun-name": "golden-container-on-push-xd69b"
                   },
                   "environment": {
                     "annotations": {
-                      "build.appstudio.openshift.io/repo": "https://github.com/enterprise-contract/golden-container?rev=68b69547cad3c4ba856fe6b06154012f33dd8b5a",
-                      "build.appstudio.redhat.com/commit_sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "build.appstudio.openshift.io/repo": "https://github.com/enterprise-contract/golden-container?rev=b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "build.appstudio.redhat.com/commit_sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "build.appstudio.redhat.com/target_branch": "main",
-                      "pipeline.tekton.dev/release": "876b81e",
+                      "pipeline.tekton.dev/release": "34d8c0f",
                       "pipelinesascode.tekton.dev/branch": "main",
-                      "pipelinesascode.tekton.dev/check-run-id": "20539638032",
+                      "pipelinesascode.tekton.dev/check-run-id": "25796873737",
+                      "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
                       "pipelinesascode.tekton.dev/event-type": "push",
-                      "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-iiug",
+                      "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-yoreai",
                       "pipelinesascode.tekton.dev/git-provider": "github",
                       "pipelinesascode.tekton.dev/installation-id": "34493006",
-                      "pipelinesascode.tekton.dev/log-url": "https://console.redhat.com/preview/application-pipeline",
+                      "pipelinesascode.tekton.dev/log-url": "https://console.redhat.com/preview/application-pipeline/ns/rhtap-contract-tenant/pipelinerun/golden-container-on-push-xd69b",
                       "pipelinesascode.tekton.dev/max-keep-runs": "3",
                       "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"main\"",
                       "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
                       "pipelinesascode.tekton.dev/repo-url": "https://github.com/enterprise-contract/golden-container",
                       "pipelinesascode.tekton.dev/repository": "golden-container",
                       "pipelinesascode.tekton.dev/sender": "renovate[bot]",
-                      "pipelinesascode.tekton.dev/sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
-                      "pipelinesascode.tekton.dev/sha-title": "Update quay.io/redhat-appstudio-tekton-catalog/task-clair-scan:0.1 Docker digest to 63b42c0",
-                      "pipelinesascode.tekton.dev/sha-url": "https://github.com/enterprise-contract/golden-container/commit/68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
+                      "pipelinesascode.tekton.dev/sha-title": "Update github/codeql-action action to v3.25.8",
+                      "pipelinesascode.tekton.dev/sha-url": "https://github.com/enterprise-contract/golden-container/commit/b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "pipelinesascode.tekton.dev/state": "started",
                       "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
                       "pipelinesascode.tekton.dev/url-repository": "golden-container",
+                      "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"golden-container\",\"commit\":\"b0d7c600114b39f0f14e4e85a7c8aed7c4de316e\",\"eventType\":\"push\"}",
                       "tekton.dev/pipelines.minVersion": "0.12.1",
-                      "tekton.dev/tags": "appstudio, hacbs"
+                      "tekton.dev/tags": "appstudio, hacbs",
+                      "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-d93a888b435563acf59b69d48e089821-8d802ef59b97b03d-01\"}"
                     },
                     "labels": {
                       "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
-                      "app.kubernetes.io/version": "v0.22.4",
+                      "app.kubernetes.io/version": "v0.27.0",
                       "appstudio.openshift.io/application": "golden-container",
                       "appstudio.openshift.io/component": "golden-container",
                       "pipelines.appstudio.openshift.io/type": "build",
-                      "pipelinesascode.tekton.dev/branch": "main",
-                      "pipelinesascode.tekton.dev/check-run-id": "20539638032",
+                      "pipelinesascode.tekton.dev/check-run-id": "25796873737",
                       "pipelinesascode.tekton.dev/event-type": "push",
-                      "pipelinesascode.tekton.dev/git-provider": "github",
                       "pipelinesascode.tekton.dev/original-prname": "golden-container-on-push",
                       "pipelinesascode.tekton.dev/repository": "golden-container",
-                      "pipelinesascode.tekton.dev/sender": "renovate__bot",
-                      "pipelinesascode.tekton.dev/sha": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+                      "pipelinesascode.tekton.dev/sha": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
                       "pipelinesascode.tekton.dev/state": "started",
                       "pipelinesascode.tekton.dev/url-org": "enterprise-contract",
                       "pipelinesascode.tekton.dev/url-repository": "golden-container",
                       "tekton.dev/memberOf": "finally",
-                      "tekton.dev/pipeline": "golden-container-on-push-fdv54",
-                      "tekton.dev/pipelineRun": "golden-container-on-push-fdv54",
+                      "tekton.dev/pipeline": "golden-container-on-push-xd69b",
+                      "tekton.dev/pipelineRun": "golden-container-on-push-xd69b",
                       "tekton.dev/pipelineTask": "show-summary",
                       "tekton.dev/task": "summary"
                     }
@@ -1352,8 +1868,8 @@
             ]
           },
           "metadata": {
-            "buildStartedOn": "2024-01-16T17:03:17Z",
-            "buildFinishedOn": "2024-01-16T17:05:43Z",
+            "buildStartedOn": "2024-06-04T15:53:28Z",
+            "buildFinishedOn": "2024-06-04T15:58:17Z",
             "completeness": {
               "parameters": false,
               "environment": false,
@@ -1363,27 +1879,21 @@
           },
           "materials": [
             {
-              "uri": "oci://registry.redhat.io/openshift4/ose-cli",
+              "uri": "oci://registry.access.redhat.com/ubi9/skopeo",
               "digest": {
-                "sha256": "73df37794ffff7de1101016c23dc623e4990810390ebdabcbbfa065214352c7c"
+                "sha256": "23557ecf3de07618968affb59adfb3db80336b976501032b5da9e4e92b943776"
               }
             },
             {
-              "uri": "oci://registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8",
+              "uri": "oci://quay.io/konflux-ci/git-clone",
               "digest": {
-                "sha256": "2fa0b06d52b04f377c696412e19307a9eff27383f81d87aae0b4f71672a1cd0b"
-              }
-            },
-            {
-              "uri": "oci://registry.redhat.io/ubi9",
-              "digest": {
-                "sha256": "089bd3b82a78ac45c0eed231bb58bfb43bfcd0560d9bba240fc6355502c92976"
+                "sha256": "005487d3967e7a90490f96b2ff3b0c6d0463b647d212cd809683b494e20146a8"
               }
             },
             {
               "uri": "oci://quay.io/redhat-appstudio/cachi2",
               "digest": {
-                "sha256": "46097f22b57e4d48a3fce96d931e08ccfe3a3e6421362d5f9353961279078eef"
+                "sha256": "1fc772aa3636fd0b43d62120d832e5913843e028e8cac42814b487c3a0a32bd8"
               }
             },
             {
@@ -1395,7 +1905,7 @@
             {
               "uri": "oci://quay.io/redhat-appstudio/syft",
               "digest": {
-                "sha256": "4d3856e6a2622700b9a9d5d74d9aaf5d8a55671653f80bf6c636677658680ede"
+                "sha256": "1910b829997650c696881e5fc2fc654ddf3184c27edb1b2024e9cb2ba51ac431"
               }
             },
             {
@@ -1407,13 +1917,13 @@
             {
               "uri": "oci://registry.access.redhat.com/ubi9/python-39",
               "digest": {
-                "sha256": "65cab0cf8b364d56e4a70789b65cda83f49b321b11fff5b228c959f3c992c596"
+                "sha256": "5b8dd87d19a7f9e5ba0b900471f0920e109e0412fbdc49539073ed86afdadf8a"
               }
             },
             {
-              "uri": "oci://quay.io/redhat-appstudio/cachi2",
+              "uri": "oci://quay.io/redhat-appstudio/base-images-sbom-script",
               "digest": {
-                "sha256": "001acfbad47e132a90998d45076a0dbe0d8beacf0bec12b4d9a5aa796f4a9cad"
+                "sha256": "667669e3def018f9dbb8eaf8868887a40bc07842221e9a98f6787edcff021840"
               }
             },
             {
@@ -1423,39 +1933,57 @@
               }
             },
             {
+              "uri": "oci://quay.io/redhat-appstudio/multi-platform-runner",
+              "digest": {
+                "sha256": "246adeaaba600e207131d63a7f706cffdcdc37d8f600c56187123ec62823ff44"
+              }
+            },
+            {
+              "uri": "oci://quay.io/redhat-appstudio/build-definitions-source-image-build-utils",
+              "digest": {
+                "sha256": "cd87bbe51f1c22ff7578f5c9caf19db4f9ee7aefd0307288383b9bd478cdf856"
+              }
+            },
+            {
+              "uri": "oci://quay.io/redhat-appstudio/konflux-test",
+              "digest": {
+                "sha256": "5303e71ad8c63377aadf5e7aaaab258aa7359f899114d57bef0b7d5635c51a31"
+              }
+            },
+            {
               "uri": "oci://quay.io/redhat-appstudio/hacbs-test",
               "digest": {
-                "sha256": "2c9018dc080e969f013be4f5d25b207522005d236deedb1f8d1534af29ee5364"
+                "sha256": "5303e71ad8c63377aadf5e7aaaab258aa7359f899114d57bef0b7d5635c51a31"
               }
             },
             {
               "uri": "oci://quay.io/redhat-appstudio/clair-in-ci",
               "digest": {
-                "sha256": "8d177929079a8a42046edd27e6c3f5c7c620b75f78bcaa8c4726428aa621edf2"
-              }
-            },
-            {
-              "uri": "oci://quay.io/redhat-appstudio/hacbs-test",
-              "digest": {
-                "sha256": "866675ee3064cf4768691ecca478063ce12f0556fb9d4f24ca95c98664ffbd43"
+                "sha256": "28afeba25188d8c45d277397147bbade19f63915f3719308443745750970772f"
               }
             },
             {
               "uri": "oci://quay.io/redhat-appstudio/clamav-db",
               "digest": {
-                "sha256": "75cdf3413409f5b48440269d41b38b5de4369e79bd82ae02d8033d160487256f"
+                "sha256": "7be2a1de817b8ec75f1cb1ff4faad8aca5ad60f26da8ad3dd0d95389a1b37b2d"
               }
             },
             {
-              "uri": "oci://registry.access.redhat.com/ubi9/ubi-minimal",
+              "uri": "oci://quay.io/redhat-appstudio/appstudio-utils",
               "digest": {
-                "sha256": "3e313209ac617a92b50350286752311d99ea2dafc429ef0e5311889294b0bc21"
+                "sha256": "efd1a0b46f03dc9b6b2b2a14a1dac91494f9c6e7935fd418deeb7f49601b14d1"
+              }
+            },
+            {
+              "uri": "oci://quay.io/redhat-appstudio/appstudio-utils",
+              "digest": {
+                "sha256": "8c7fcf86af40c71aeb58e4279625c8308af5144e2f6b8e28b0ec7e795260e5f7"
               }
             },
             {
               "uri": "git+https://github.com/enterprise-contract/golden-container.git",
               "digest": {
-                "sha1": "68b69547cad3c4ba856fe6b06154012f33dd8b5a"
+                "sha1": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e"
               }
             }
           ]
@@ -1464,27 +1992,31 @@
       "signatures": [
         {
           "keyid": "SHA256:IhiN7gY+Z3uSSd7tmj6w5Zfhqafzdhm3DZjIvGc6iYY",
-          "sig": "MEQCIEWRzKvnzW5LgLFUUbBMAXWRCXF+3Z4iKMNg+ipLjZZYAiBFCTgswObTC7W7LJLZg/JWXzGWJ1My7k4yju0hAEjQUw=="
+          "sig": "MEYCIQCckvtRYk0cbuJEjVqD9qiuAkKKKbN2md9yBujxA9ZXoAIhAOt79YU86G0bM4cLvm+ZNjQzWNtQgaBv7Wx1z9VVTgRk"
         }
       ]
     }
   ],
   "image": {
-    "ref": "quay.io/redhat-appstudio/ec-golden-image@sha256:6fa252a7df2735b84674e64b78ac66279af0f2cbbb7ed1dd6a534daf0a4b8738",
+    "ref": "quay.io/redhat-appstudio/ec-golden-image@sha256:ade052c249de1420c0f860fef47b620f00135aade4a55bc385de1dd634e8cc7a",
     "signatures": [
       {
         "keyid": "",
-        "sig": "MEUCIQD4UBVTUOCzIFPhA09e/aJGAj8pSZYKekAec31XO9XuyQIgJ9hqJ5+q7f0G0nP6jOOoJXeERqQgN3D/9ceLVfippP8="
+        "sig": "MEQCIBoQPy4jb7qELp3btLs1qsbHtPhyx76mwLGl611kopLrAiBGD+Dh0jkq9y5WpQ8WoDWpQLAcaOWxsopLymrI03B8oQ=="
       }
     ],
     "config": {
-      "Cmd": ["/bin/sh", "-c", "/bin/sh"],
+      "Cmd": [
+        "/bin/sh",
+        "-c",
+        "/bin/sh"
+      ],
       "Env": [
         "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
       ],
       "Labels": {
-        "architecture": "x86_64",
-        "build-date": "2024-01-16T17:04:52",
+        "architecture": "aarch64",
+        "build-date": "2024-06-04T15:56:27",
         "com.redhat.build-host": "somewhere.over.the.rainbow",
         "com.redhat.component": "enterprise-contract-golden-container",
         "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
@@ -1500,22 +2032,26 @@
         "release": "1",
         "summary": "Trivial image build in compliance with Enterprise Contract policy",
         "url": "https://github.com/enterprise-contract/golden-container",
-        "vcs-ref": "68b69547cad3c4ba856fe6b06154012f33dd8b5a",
+        "vcs-ref": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e",
         "vcs-type": "git",
-        "vendor": "Enterprise Contract",
+        "vendor": "Red Hat, Inc.",
         "version": "1"
       }
     },
     "parent": {
-      "ref": "registry.access.redhat.com/ubi9/ubi-micro@sha256:f9426baf6a67db59561e58d7ae098e7de22264adcaf5f9fdb882a4283be5a7ed",
+      "ref": "registry.access.redhat.com/ubi9/ubi-micro@sha256:c72c705fe4e9de2e065a817be2fbf1b6406010610532243727fdc3042227c71b",
       "config": {
-        "Cmd": ["/bin/sh", "-c", "/bin/sh"],
+        "Cmd": [
+          "/bin/sh",
+          "-c",
+          "/bin/sh"
+        ],
         "Env": [
           "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
         ],
         "Labels": {
-          "architecture": "x86_64",
-          "build-date": "2023-12-07T06:07:13",
+          "architecture": "aarch64",
+          "build-date": "2024-05-23T13:47:39",
           "com.redhat.component": "ubi9-micro-container",
           "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
           "description": "Very small image which doesn't install the package manager.",
@@ -1526,20 +2062,2234 @@
           "io.openshift.expose-services": "",
           "maintainer": "Red Hat, Inc.",
           "name": "ubi9/ubi-micro",
-          "release": "9",
+          "release": "6.1716471860",
           "summary": "ubi9 micro image",
-          "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi9/ubi-micro/images/9.3-9",
-          "vcs-ref": "7c8efa4a6b572674bf941c8ad74c59eb3ac8b9df",
+          "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi9/ubi-micro/images/9.4-6.1716471860",
+          "vcs-ref": "433dec61d526247ac9533c1d9b97e98a1127c782",
           "vcs-type": "git",
           "vendor": "Red Hat, Inc.",
-          "version": "9.3"
+          "version": "9.4"
+        }
+      }
+    },
+    "files": {
+      "root/buildinfo/content_manifests/sbom-cyclonedx.json": {
+        "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+        "bomFormat": "CycloneDX",
+        "components": [
+          {
+            "bom-ref": "pkg:github/actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29?package-id=62df2edd496b85e4",
+            "cpe": "cpe:2.3:a:actions\\/checkout:actions\\/checkout:a5ac7e51b41094c92402da3b24376905380afc29:*:*:*:*:*:*:*",
+            "name": "actions/checkout",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "github-actions-usage-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "github-action"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/.github/workflows/release.yaml"
+              }
+            ],
+            "purl": "pkg:github/actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29",
+            "type": "library",
+            "version": "a5ac7e51b41094c92402da3b24376905380afc29"
+          },
+          {
+            "bom-ref": "pkg:github/actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808?package-id=469ce94e09862385",
+            "cpe": "cpe:2.3:a:actions\\/upload-artifact:actions\\/upload-artifact:65462800fd760344b1a7b4382951275a0abb4808:*:*:*:*:*:*:*",
+            "name": "actions/upload-artifact",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "github-actions-usage-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "github-action"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:actions\\/upload-artifact:actions\\/upload_artifact:65462800fd760344b1a7b4382951275a0abb4808:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:actions\\/upload_artifact:actions\\/upload-artifact:65462800fd760344b1a7b4382951275a0abb4808:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:actions\\/upload_artifact:actions\\/upload_artifact:65462800fd760344b1a7b4382951275a0abb4808:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:actions\\/upload:actions\\/upload-artifact:65462800fd760344b1a7b4382951275a0abb4808:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:actions\\/upload:actions\\/upload_artifact:65462800fd760344b1a7b4382951275a0abb4808:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/.github/workflows/scorecards.yml"
+              }
+            ],
+            "purl": "pkg:github/actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808",
+            "type": "library",
+            "version": "65462800fd760344b1a7b4382951275a0abb4808"
+          },
+          {
+            "bom-ref": "pkg:github/anchore/sbom-action@e8d2a6937ecead383dfe75190d104edd1f9c5751?package-id=a4db30436449dadf#download-syft",
+            "cpe": "cpe:2.3:a:anchore\\/sbom-action\\/download-syft:anchore\\/sbom-action\\/download-syft:e8d2a6937ecead383dfe75190d104edd1f9c5751:*:*:*:*:*:*:*",
+            "name": "anchore/sbom-action/download-syft",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "github-actions-usage-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "github-action"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:anchore\\/sbom-action\\/download-syft:anchore\\/sbom_action\\/download_syft:e8d2a6937ecead383dfe75190d104edd1f9c5751:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:anchore\\/sbom_action\\/download_syft:anchore\\/sbom-action\\/download-syft:e8d2a6937ecead383dfe75190d104edd1f9c5751:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:anchore\\/sbom_action\\/download_syft:anchore\\/sbom_action\\/download_syft:e8d2a6937ecead383dfe75190d104edd1f9c5751:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:anchore\\/sbom-action\\/download:anchore\\/sbom-action\\/download-syft:e8d2a6937ecead383dfe75190d104edd1f9c5751:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:anchore\\/sbom-action\\/download:anchore\\/sbom_action\\/download_syft:e8d2a6937ecead383dfe75190d104edd1f9c5751:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:anchore\\/sbom_action\\/download:anchore\\/sbom-action\\/download-syft:e8d2a6937ecead383dfe75190d104edd1f9c5751:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:anchore\\/sbom_action\\/download:anchore\\/sbom_action\\/download_syft:e8d2a6937ecead383dfe75190d104edd1f9c5751:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:anchore\\/sbom:anchore\\/sbom-action\\/download-syft:e8d2a6937ecead383dfe75190d104edd1f9c5751:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:anchore\\/sbom:anchore\\/sbom_action\\/download_syft:e8d2a6937ecead383dfe75190d104edd1f9c5751:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/.github/workflows/release.yaml"
+              }
+            ],
+            "purl": "pkg:github/anchore/sbom-action@e8d2a6937ecead383dfe75190d104edd1f9c5751#download-syft",
+            "type": "library",
+            "version": "e8d2a6937ecead383dfe75190d104edd1f9c5751"
+          },
+          {
+            "bom-ref": "pkg:rpm/rhel/basesystem@11-13.el9?arch=noarch&upstream=basesystem-11-13.el9.src.rpm&distro=rhel-9.4&package-id=fcabd006cb3bfe7d",
+            "cpe": "cpe:2.3:a:basesystem:basesystem:11-13.el9:*:*:*:*:*:*:*",
+            "licenses": [
+              {
+                "license": {
+                  "name": "Public Domain"
+                }
+              }
+            ],
+            "name": "basesystem",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "rpm-db-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "rpm"
+              },
+              {
+                "name": "syft:package:metadataType",
+                "value": "rpm-db-entry"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat:basesystem:11-13.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/var/lib/rpm/rpmdb.sqlite"
+              },
+              {
+                "name": "syft:metadata:release",
+                "value": "13.el9"
+              },
+              {
+                "name": "syft:metadata:size",
+                "value": "0"
+              },
+              {
+                "name": "syft:metadata:sourceRpm",
+                "value": "basesystem-11-13.el9.src.rpm"
+              }
+            ],
+            "publisher": "Red Hat, Inc.",
+            "purl": "pkg:rpm/rhel/basesystem@11-13.el9?arch=noarch&upstream=basesystem-11-13.el9.src.rpm&distro=rhel-9.4",
+            "type": "library",
+            "version": "11-13.el9"
+          },
+          {
+            "bom-ref": "pkg:rpm/rhel/bash@5.1.8-9.el9?arch=aarch64&upstream=bash-5.1.8-9.el9.src.rpm&distro=rhel-9.4&package-id=42968379d5d62fd1",
+            "cpe": "cpe:2.3:a:redhat:bash:5.1.8-9.el9:*:*:*:*:*:*:*",
+            "licenses": [
+              {
+                "license": {
+                  "name": "GPLv3+"
+                }
+              }
+            ],
+            "name": "bash",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "rpm-db-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "rpm"
+              },
+              {
+                "name": "syft:package:metadataType",
+                "value": "rpm-db-entry"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:bash:bash:5.1.8-9.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/var/lib/rpm/rpmdb.sqlite"
+              },
+              {
+                "name": "syft:metadata:release",
+                "value": "9.el9"
+              },
+              {
+                "name": "syft:metadata:size",
+                "value": "7716607"
+              },
+              {
+                "name": "syft:metadata:sourceRpm",
+                "value": "bash-5.1.8-9.el9.src.rpm"
+              }
+            ],
+            "publisher": "Red Hat, Inc.",
+            "purl": "pkg:rpm/rhel/bash@5.1.8-9.el9?arch=aarch64&upstream=bash-5.1.8-9.el9.src.rpm&distro=rhel-9.4",
+            "type": "library",
+            "version": "5.1.8-9.el9"
+          },
+          {
+            "bom-ref": "pkg:rpm/rhel/coreutils-single@8.32-35.el9?arch=aarch64&upstream=coreutils-8.32-35.el9.src.rpm&distro=rhel-9.4&package-id=af22a007b5604913",
+            "cpe": "cpe:2.3:a:coreutils-single:coreutils-single:8.32-35.el9:*:*:*:*:*:*:*",
+            "licenses": [
+              {
+                "license": {
+                  "name": "GPLv3+"
+                }
+              }
+            ],
+            "name": "coreutils-single",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "rpm-db-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "rpm"
+              },
+              {
+                "name": "syft:package:metadataType",
+                "value": "rpm-db-entry"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:coreutils-single:coreutils_single:8.32-35.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:coreutils_single:coreutils-single:8.32-35.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:coreutils_single:coreutils_single:8.32-35.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:coreutils:coreutils-single:8.32-35.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:coreutils:coreutils_single:8.32-35.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat:coreutils-single:8.32-35.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat:coreutils_single:8.32-35.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/var/lib/rpm/rpmdb.sqlite"
+              },
+              {
+                "name": "syft:metadata:release",
+                "value": "35.el9"
+              },
+              {
+                "name": "syft:metadata:size",
+                "value": "1515473"
+              },
+              {
+                "name": "syft:metadata:sourceRpm",
+                "value": "coreutils-8.32-35.el9.src.rpm"
+              }
+            ],
+            "publisher": "Red Hat, Inc.",
+            "purl": "pkg:rpm/rhel/coreutils-single@8.32-35.el9?arch=aarch64&upstream=coreutils-8.32-35.el9.src.rpm&distro=rhel-9.4",
+            "type": "library",
+            "version": "8.32-35.el9"
+          },
+          {
+            "bom-ref": "pkg:github/enterprise-contract/action-validate-image@v1.0.200?package-id=a0bd43f54cd11d2a",
+            "cpe": "cpe:2.3:a:enterprise-contract\\/action-validate-image:enterprise-contract\\/action-validate-image:v1.0.200:*:*:*:*:*:*:*",
+            "name": "enterprise-contract/action-validate-image",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "github-actions-usage-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "github-action"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:enterprise-contract\\/action-validate-image:enterprise_contract\\/action_validate_image:v1.0.200:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:enterprise_contract\\/action_validate_image:enterprise-contract\\/action-validate-image:v1.0.200:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:enterprise_contract\\/action_validate_image:enterprise_contract\\/action_validate_image:v1.0.200:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:enterprise-contract\\/action-validate:enterprise-contract\\/action-validate-image:v1.0.200:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:enterprise-contract\\/action-validate:enterprise_contract\\/action_validate_image:v1.0.200:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:enterprise_contract\\/action_validate:enterprise-contract\\/action-validate-image:v1.0.200:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:enterprise_contract\\/action_validate:enterprise_contract\\/action_validate_image:v1.0.200:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:enterprise-contract\\/action:enterprise-contract\\/action-validate-image:v1.0.200:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:enterprise-contract\\/action:enterprise_contract\\/action_validate_image:v1.0.200:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:enterprise_contract\\/action:enterprise-contract\\/action-validate-image:v1.0.200:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:enterprise_contract\\/action:enterprise_contract\\/action_validate_image:v1.0.200:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:enterprise:enterprise-contract\\/action-validate-image:v1.0.200:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:enterprise:enterprise_contract\\/action_validate_image:v1.0.200:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/.github/workflows/release.yaml"
+              }
+            ],
+            "purl": "pkg:github/enterprise-contract/action-validate-image@v1.0.200",
+            "type": "library",
+            "version": "v1.0.200"
+          },
+          {
+            "bom-ref": "pkg:github/enterprise-contract/github-workflows@main?package-id=257cb5773a0994ca#github/workflows/auto-mergeyaml",
+            "cpe": "cpe:2.3:a:enterprise-contract\\/github-workflows\\/.github\\/workflows\\/auto-merge.yaml:enterprise-contract\\/github-workflows\\/.github\\/workflows\\/auto-merge.yaml:main:*:*:*:*:*:*:*",
+            "name": "enterprise-contract/github-workflows/.github/workflows/auto-merge.yaml",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "github-action-workflow-usage-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "github-action-workflow"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:enterprise-contract\\/github-workflows\\/.github\\/workflows\\/auto-merge.yaml:enterprise_contract\\/github_workflows\\/.github\\/workflows\\/auto_merge.yaml:main:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:enterprise_contract\\/github_workflows\\/.github\\/workflows\\/auto_merge.yaml:enterprise-contract\\/github-workflows\\/.github\\/workflows\\/auto-merge.yaml:main:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:enterprise_contract\\/github_workflows\\/.github\\/workflows\\/auto_merge.yaml:enterprise_contract\\/github_workflows\\/.github\\/workflows\\/auto_merge.yaml:main:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:enterprise-contract\\/github-workflows\\/.github\\/workflows\\/auto:enterprise-contract\\/github-workflows\\/.github\\/workflows\\/auto-merge.yaml:main:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:enterprise-contract\\/github-workflows\\/.github\\/workflows\\/auto:enterprise_contract\\/github_workflows\\/.github\\/workflows\\/auto_merge.yaml:main:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:enterprise_contract\\/github_workflows\\/.github\\/workflows\\/auto:enterprise-contract\\/github-workflows\\/.github\\/workflows\\/auto-merge.yaml:main:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:enterprise_contract\\/github_workflows\\/.github\\/workflows\\/auto:enterprise_contract\\/github_workflows\\/.github\\/workflows\\/auto_merge.yaml:main:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:enterprise-contract\\/github:enterprise-contract\\/github-workflows\\/.github\\/workflows\\/auto-merge.yaml:main:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:enterprise-contract\\/github:enterprise_contract\\/github_workflows\\/.github\\/workflows\\/auto_merge.yaml:main:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:enterprise_contract\\/github:enterprise-contract\\/github-workflows\\/.github\\/workflows\\/auto-merge.yaml:main:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:enterprise_contract\\/github:enterprise_contract\\/github_workflows\\/.github\\/workflows\\/auto_merge.yaml:main:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:enterprise:enterprise-contract\\/github-workflows\\/.github\\/workflows\\/auto-merge.yaml:main:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:enterprise:enterprise_contract\\/github_workflows\\/.github\\/workflows\\/auto_merge.yaml:main:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/.github/workflows/auto-merge.yaml"
+              }
+            ],
+            "purl": "pkg:github/enterprise-contract/github-workflows@main#.github/workflows/auto-merge.yaml",
+            "type": "library",
+            "version": "main"
+          },
+          {
+            "bom-ref": "pkg:rpm/rhel/filesystem@3.16-2.el9?arch=aarch64&upstream=filesystem-3.16-2.el9.src.rpm&distro=rhel-9.4&package-id=69a40f8cdb618c80",
+            "cpe": "cpe:2.3:a:filesystem:filesystem:3.16-2.el9:*:*:*:*:*:*:*",
+            "licenses": [
+              {
+                "license": {
+                  "name": "Public Domain"
+                }
+              }
+            ],
+            "name": "filesystem",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "rpm-db-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "rpm"
+              },
+              {
+                "name": "syft:package:metadataType",
+                "value": "rpm-db-entry"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat:filesystem:3.16-2.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/var/lib/rpm/rpmdb.sqlite"
+              },
+              {
+                "name": "syft:metadata:release",
+                "value": "2.el9"
+              },
+              {
+                "name": "syft:metadata:size",
+                "value": "106"
+              },
+              {
+                "name": "syft:metadata:sourceRpm",
+                "value": "filesystem-3.16-2.el9.src.rpm"
+              }
+            ],
+            "publisher": "Red Hat, Inc.",
+            "purl": "pkg:rpm/rhel/filesystem@3.16-2.el9?arch=aarch64&upstream=filesystem-3.16-2.el9.src.rpm&distro=rhel-9.4",
+            "type": "library",
+            "version": "3.16-2.el9"
+          },
+          {
+            "bom-ref": "pkg:github/github/codeql-action@2e230e8fe0ad3a14a340ad0815ddb96d599d2aff?package-id=516eaed5013f515c#upload-sarif",
+            "cpe": "cpe:2.3:a:github\\/codeql-action\\/upload-sarif:github\\/codeql-action\\/upload-sarif:2e230e8fe0ad3a14a340ad0815ddb96d599d2aff:*:*:*:*:*:*:*",
+            "name": "github/codeql-action/upload-sarif",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "github-actions-usage-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "github-action"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:github\\/codeql-action\\/upload-sarif:github\\/codeql_action\\/upload_sarif:2e230e8fe0ad3a14a340ad0815ddb96d599d2aff:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:github\\/codeql_action\\/upload_sarif:github\\/codeql-action\\/upload-sarif:2e230e8fe0ad3a14a340ad0815ddb96d599d2aff:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:github\\/codeql_action\\/upload_sarif:github\\/codeql_action\\/upload_sarif:2e230e8fe0ad3a14a340ad0815ddb96d599d2aff:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:github\\/codeql-action\\/upload:github\\/codeql-action\\/upload-sarif:2e230e8fe0ad3a14a340ad0815ddb96d599d2aff:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:github\\/codeql-action\\/upload:github\\/codeql_action\\/upload_sarif:2e230e8fe0ad3a14a340ad0815ddb96d599d2aff:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:github\\/codeql_action\\/upload:github\\/codeql-action\\/upload-sarif:2e230e8fe0ad3a14a340ad0815ddb96d599d2aff:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:github\\/codeql_action\\/upload:github\\/codeql_action\\/upload_sarif:2e230e8fe0ad3a14a340ad0815ddb96d599d2aff:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:github\\/codeql:github\\/codeql-action\\/upload-sarif:2e230e8fe0ad3a14a340ad0815ddb96d599d2aff:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:github\\/codeql:github\\/codeql_action\\/upload_sarif:2e230e8fe0ad3a14a340ad0815ddb96d599d2aff:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/.github/workflows/scorecards.yml"
+              }
+            ],
+            "purl": "pkg:github/github/codeql-action@2e230e8fe0ad3a14a340ad0815ddb96d599d2aff#upload-sarif",
+            "type": "library",
+            "version": "2e230e8fe0ad3a14a340ad0815ddb96d599d2aff"
+          },
+          {
+            "bom-ref": "pkg:rpm/rhel/glibc-common@2.34-100.el9_4.2?arch=aarch64&upstream=glibc-2.34-100.el9_4.2.src.rpm&distro=rhel-9.4&package-id=1337b83e2f30b6a2",
+            "cpe": "cpe:2.3:a:glibc-common:glibc-common:2.34-100.el9_4.2:*:*:*:*:*:*:*",
+            "licenses": [
+              {
+                "license": {
+                  "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+                }
+              }
+            ],
+            "name": "glibc-common",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "rpm-db-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "rpm"
+              },
+              {
+                "name": "syft:package:metadataType",
+                "value": "rpm-db-entry"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:glibc-common:glibc_common:2.34-100.el9_4.2:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:glibc_common:glibc-common:2.34-100.el9_4.2:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:glibc_common:glibc_common:2.34-100.el9_4.2:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat:glibc-common:2.34-100.el9_4.2:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat:glibc_common:2.34-100.el9_4.2:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:glibc:glibc-common:2.34-100.el9_4.2:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:glibc:glibc_common:2.34-100.el9_4.2:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/var/lib/rpm/rpmdb.sqlite"
+              },
+              {
+                "name": "syft:metadata:release",
+                "value": "100.el9_4.2"
+              },
+              {
+                "name": "syft:metadata:size",
+                "value": "1355781"
+              },
+              {
+                "name": "syft:metadata:sourceRpm",
+                "value": "glibc-2.34-100.el9_4.2.src.rpm"
+              }
+            ],
+            "publisher": "Red Hat, Inc.",
+            "purl": "pkg:rpm/rhel/glibc-common@2.34-100.el9_4.2?arch=aarch64&upstream=glibc-2.34-100.el9_4.2.src.rpm&distro=rhel-9.4",
+            "type": "library",
+            "version": "2.34-100.el9_4.2"
+          },
+          {
+            "bom-ref": "pkg:rpm/rhel/glibc-minimal-langpack@2.34-100.el9_4.2?arch=aarch64&upstream=glibc-2.34-100.el9_4.2.src.rpm&distro=rhel-9.4&package-id=d47b67020a44dba2",
+            "cpe": "cpe:2.3:a:glibc-minimal-langpack:glibc-minimal-langpack:2.34-100.el9_4.2:*:*:*:*:*:*:*",
+            "licenses": [
+              {
+                "license": {
+                  "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+                }
+              }
+            ],
+            "name": "glibc-minimal-langpack",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "rpm-db-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "rpm"
+              },
+              {
+                "name": "syft:package:metadataType",
+                "value": "rpm-db-entry"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:glibc-minimal-langpack:glibc_minimal_langpack:2.34-100.el9_4.2:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:glibc_minimal_langpack:glibc-minimal-langpack:2.34-100.el9_4.2:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:glibc_minimal_langpack:glibc_minimal_langpack:2.34-100.el9_4.2:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:glibc-minimal:glibc-minimal-langpack:2.34-100.el9_4.2:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:glibc-minimal:glibc_minimal_langpack:2.34-100.el9_4.2:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:glibc_minimal:glibc-minimal-langpack:2.34-100.el9_4.2:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:glibc_minimal:glibc_minimal_langpack:2.34-100.el9_4.2:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat:glibc-minimal-langpack:2.34-100.el9_4.2:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat:glibc_minimal_langpack:2.34-100.el9_4.2:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:glibc:glibc-minimal-langpack:2.34-100.el9_4.2:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:glibc:glibc_minimal_langpack:2.34-100.el9_4.2:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/var/lib/rpm/rpmdb.sqlite"
+              },
+              {
+                "name": "syft:metadata:release",
+                "value": "100.el9_4.2"
+              },
+              {
+                "name": "syft:metadata:size",
+                "value": "0"
+              },
+              {
+                "name": "syft:metadata:sourceRpm",
+                "value": "glibc-2.34-100.el9_4.2.src.rpm"
+              }
+            ],
+            "publisher": "Red Hat, Inc.",
+            "purl": "pkg:rpm/rhel/glibc-minimal-langpack@2.34-100.el9_4.2?arch=aarch64&upstream=glibc-2.34-100.el9_4.2.src.rpm&distro=rhel-9.4",
+            "type": "library",
+            "version": "2.34-100.el9_4.2"
+          },
+          {
+            "bom-ref": "pkg:rpm/rhel/glibc@2.34-100.el9_4.2?arch=aarch64&upstream=glibc-2.34-100.el9_4.2.src.rpm&distro=rhel-9.4&package-id=e6a13a45b91a1910",
+            "cpe": "cpe:2.3:a:redhat:glibc:2.34-100.el9_4.2:*:*:*:*:*:*:*",
+            "licenses": [
+              {
+                "license": {
+                  "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+                }
+              }
+            ],
+            "name": "glibc",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "rpm-db-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "rpm"
+              },
+              {
+                "name": "syft:package:metadataType",
+                "value": "rpm-db-entry"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:glibc:glibc:2.34-100.el9_4.2:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/var/lib/rpm/rpmdb.sqlite"
+              },
+              {
+                "name": "syft:metadata:release",
+                "value": "100.el9_4.2"
+              },
+              {
+                "name": "syft:metadata:size",
+                "value": "6471716"
+              },
+              {
+                "name": "syft:metadata:sourceRpm",
+                "value": "glibc-2.34-100.el9_4.2.src.rpm"
+              }
+            ],
+            "publisher": "Red Hat, Inc.",
+            "purl": "pkg:rpm/rhel/glibc@2.34-100.el9_4.2?arch=aarch64&upstream=glibc-2.34-100.el9_4.2.src.rpm&distro=rhel-9.4",
+            "type": "library",
+            "version": "2.34-100.el9_4.2"
+          },
+          {
+            "bom-ref": "pkg:rpm/rhel/libacl@2.3.1-4.el9?arch=aarch64&upstream=acl-2.3.1-4.el9.src.rpm&distro=rhel-9.4&package-id=9b7e976141ddde50",
+            "cpe": "cpe:2.3:a:libacl:libacl:2.3.1-4.el9:*:*:*:*:*:*:*",
+            "licenses": [
+              {
+                "license": {
+                  "name": "LGPLv2+"
+                }
+              }
+            ],
+            "name": "libacl",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "rpm-db-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "rpm"
+              },
+              {
+                "name": "syft:package:metadataType",
+                "value": "rpm-db-entry"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat:libacl:2.3.1-4.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/var/lib/rpm/rpmdb.sqlite"
+              },
+              {
+                "name": "syft:metadata:release",
+                "value": "4.el9"
+              },
+              {
+                "name": "syft:metadata:size",
+                "value": "69018"
+              },
+              {
+                "name": "syft:metadata:sourceRpm",
+                "value": "acl-2.3.1-4.el9.src.rpm"
+              }
+            ],
+            "publisher": "Red Hat, Inc.",
+            "purl": "pkg:rpm/rhel/libacl@2.3.1-4.el9?arch=aarch64&upstream=acl-2.3.1-4.el9.src.rpm&distro=rhel-9.4",
+            "type": "library",
+            "version": "2.3.1-4.el9"
+          },
+          {
+            "bom-ref": "pkg:rpm/rhel/libattr@2.5.1-3.el9?arch=aarch64&upstream=attr-2.5.1-3.el9.src.rpm&distro=rhel-9.4&package-id=b87393776b8b2459",
+            "cpe": "cpe:2.3:a:libattr:libattr:2.5.1-3.el9:*:*:*:*:*:*:*",
+            "licenses": [
+              {
+                "license": {
+                  "name": "LGPLv2+"
+                }
+              }
+            ],
+            "name": "libattr",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "rpm-db-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "rpm"
+              },
+              {
+                "name": "syft:package:metadataType",
+                "value": "rpm-db-entry"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat:libattr:2.5.1-3.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/var/lib/rpm/rpmdb.sqlite"
+              },
+              {
+                "name": "syft:metadata:release",
+                "value": "3.el9"
+              },
+              {
+                "name": "syft:metadata:size",
+                "value": "70229"
+              },
+              {
+                "name": "syft:metadata:sourceRpm",
+                "value": "attr-2.5.1-3.el9.src.rpm"
+              }
+            ],
+            "publisher": "Red Hat, Inc.",
+            "purl": "pkg:rpm/rhel/libattr@2.5.1-3.el9?arch=aarch64&upstream=attr-2.5.1-3.el9.src.rpm&distro=rhel-9.4",
+            "type": "library",
+            "version": "2.5.1-3.el9"
+          },
+          {
+            "bom-ref": "pkg:rpm/rhel/libcap@2.48-9.el9_2?arch=aarch64&upstream=libcap-2.48-9.el9_2.src.rpm&distro=rhel-9.4&package-id=6b382f24930e8c35",
+            "cpe": "cpe:2.3:a:libcap:libcap:2.48-9.el9_2:*:*:*:*:*:*:*",
+            "licenses": [
+              {
+                "license": {
+                  "name": "BSD or GPLv2"
+                }
+              }
+            ],
+            "name": "libcap",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "rpm-db-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "rpm"
+              },
+              {
+                "name": "syft:package:metadataType",
+                "value": "rpm-db-entry"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat:libcap:2.48-9.el9_2:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/var/lib/rpm/rpmdb.sqlite"
+              },
+              {
+                "name": "syft:metadata:release",
+                "value": "9.el9_2"
+              },
+              {
+                "name": "syft:metadata:size",
+                "value": "507663"
+              },
+              {
+                "name": "syft:metadata:sourceRpm",
+                "value": "libcap-2.48-9.el9_2.src.rpm"
+              }
+            ],
+            "publisher": "Red Hat, Inc.",
+            "purl": "pkg:rpm/rhel/libcap@2.48-9.el9_2?arch=aarch64&upstream=libcap-2.48-9.el9_2.src.rpm&distro=rhel-9.4",
+            "type": "library",
+            "version": "2.48-9.el9_2"
+          },
+          {
+            "bom-ref": "pkg:rpm/rhel/libgcc@11.4.1-3.el9?arch=aarch64&upstream=gcc-11.4.1-3.el9.src.rpm&distro=rhel-9.4&package-id=212a1282e46c65e0",
+            "cpe": "cpe:2.3:a:libgcc:libgcc:11.4.1-3.el9:*:*:*:*:*:*:*",
+            "licenses": [
+              {
+                "license": {
+                  "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+                }
+              }
+            ],
+            "name": "libgcc",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "rpm-db-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "rpm"
+              },
+              {
+                "name": "syft:package:metadataType",
+                "value": "rpm-db-entry"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat:libgcc:11.4.1-3.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/var/lib/rpm/rpmdb.sqlite"
+              },
+              {
+                "name": "syft:metadata:release",
+                "value": "3.el9"
+              },
+              {
+                "name": "syft:metadata:size",
+                "value": "226740"
+              },
+              {
+                "name": "syft:metadata:sourceRpm",
+                "value": "gcc-11.4.1-3.el9.src.rpm"
+              }
+            ],
+            "publisher": "Red Hat, Inc.",
+            "purl": "pkg:rpm/rhel/libgcc@11.4.1-3.el9?arch=aarch64&upstream=gcc-11.4.1-3.el9.src.rpm&distro=rhel-9.4",
+            "type": "library",
+            "version": "11.4.1-3.el9"
+          },
+          {
+            "bom-ref": "pkg:rpm/rhel/libselinux@3.6-1.el9?arch=aarch64&upstream=libselinux-3.6-1.el9.src.rpm&distro=rhel-9.4&package-id=201ce574780f6af1",
+            "cpe": "cpe:2.3:a:libselinux:libselinux:3.6-1.el9:*:*:*:*:*:*:*",
+            "licenses": [
+              {
+                "license": {
+                  "name": "Public Domain"
+                }
+              }
+            ],
+            "name": "libselinux",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "rpm-db-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "rpm"
+              },
+              {
+                "name": "syft:package:metadataType",
+                "value": "rpm-db-entry"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat:libselinux:3.6-1.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/var/lib/rpm/rpmdb.sqlite"
+              },
+              {
+                "name": "syft:metadata:release",
+                "value": "1.el9"
+              },
+              {
+                "name": "syft:metadata:size",
+                "value": "205261"
+              },
+              {
+                "name": "syft:metadata:sourceRpm",
+                "value": "libselinux-3.6-1.el9.src.rpm"
+              }
+            ],
+            "publisher": "Red Hat, Inc.",
+            "purl": "pkg:rpm/rhel/libselinux@3.6-1.el9?arch=aarch64&upstream=libselinux-3.6-1.el9.src.rpm&distro=rhel-9.4",
+            "type": "library",
+            "version": "3.6-1.el9"
+          },
+          {
+            "bom-ref": "pkg:rpm/rhel/libsepol@3.6-1.el9?arch=aarch64&upstream=libsepol-3.6-1.el9.src.rpm&distro=rhel-9.4&package-id=b5e77e2bbf4c8e1b",
+            "cpe": "cpe:2.3:a:libsepol:libsepol:3.6-1.el9:*:*:*:*:*:*:*",
+            "licenses": [
+              {
+                "license": {
+                  "name": "LGPLv2+"
+                }
+              }
+            ],
+            "name": "libsepol",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "rpm-db-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "rpm"
+              },
+              {
+                "name": "syft:package:metadataType",
+                "value": "rpm-db-entry"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat:libsepol:3.6-1.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/var/lib/rpm/rpmdb.sqlite"
+              },
+              {
+                "name": "syft:metadata:release",
+                "value": "1.el9"
+              },
+              {
+                "name": "syft:metadata:size",
+                "value": "829147"
+              },
+              {
+                "name": "syft:metadata:sourceRpm",
+                "value": "libsepol-3.6-1.el9.src.rpm"
+              }
+            ],
+            "publisher": "Red Hat, Inc.",
+            "purl": "pkg:rpm/rhel/libsepol@3.6-1.el9?arch=aarch64&upstream=libsepol-3.6-1.el9.src.rpm&distro=rhel-9.4",
+            "type": "library",
+            "version": "3.6-1.el9"
+          },
+          {
+            "bom-ref": "pkg:rpm/rhel/ncurses-base@6.2-10.20210508.el9?arch=noarch&upstream=ncurses-6.2-10.20210508.el9.src.rpm&distro=rhel-9.4&package-id=a0d19211c8c4589b",
+            "cpe": "cpe:2.3:a:ncurses-base:ncurses-base:6.2-10.20210508.el9:*:*:*:*:*:*:*",
+            "licenses": [
+              {
+                "license": {
+                  "id": "MIT"
+                }
+              }
+            ],
+            "name": "ncurses-base",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "rpm-db-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "rpm"
+              },
+              {
+                "name": "syft:package:metadataType",
+                "value": "rpm-db-entry"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:ncurses-base:ncurses_base:6.2-10.20210508.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:ncurses_base:ncurses-base:6.2-10.20210508.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:ncurses_base:ncurses_base:6.2-10.20210508.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:ncurses:ncurses-base:6.2-10.20210508.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:ncurses:ncurses_base:6.2-10.20210508.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat:ncurses-base:6.2-10.20210508.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat:ncurses_base:6.2-10.20210508.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/var/lib/rpm/rpmdb.sqlite"
+              },
+              {
+                "name": "syft:metadata:release",
+                "value": "10.20210508.el9"
+              },
+              {
+                "name": "syft:metadata:size",
+                "value": "307293"
+              },
+              {
+                "name": "syft:metadata:sourceRpm",
+                "value": "ncurses-6.2-10.20210508.el9.src.rpm"
+              }
+            ],
+            "publisher": "Red Hat, Inc.",
+            "purl": "pkg:rpm/rhel/ncurses-base@6.2-10.20210508.el9?arch=noarch&upstream=ncurses-6.2-10.20210508.el9.src.rpm&distro=rhel-9.4",
+            "type": "library",
+            "version": "6.2-10.20210508.el9"
+          },
+          {
+            "bom-ref": "pkg:rpm/rhel/ncurses-libs@6.2-10.20210508.el9?arch=aarch64&upstream=ncurses-6.2-10.20210508.el9.src.rpm&distro=rhel-9.4&package-id=1325f54df276eab7",
+            "cpe": "cpe:2.3:a:ncurses-libs:ncurses-libs:6.2-10.20210508.el9:*:*:*:*:*:*:*",
+            "licenses": [
+              {
+                "license": {
+                  "id": "MIT"
+                }
+              }
+            ],
+            "name": "ncurses-libs",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "rpm-db-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "rpm"
+              },
+              {
+                "name": "syft:package:metadataType",
+                "value": "rpm-db-entry"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:ncurses-libs:ncurses_libs:6.2-10.20210508.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:ncurses_libs:ncurses-libs:6.2-10.20210508.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:ncurses_libs:ncurses_libs:6.2-10.20210508.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:ncurses:ncurses-libs:6.2-10.20210508.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:ncurses:ncurses_libs:6.2-10.20210508.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat:ncurses-libs:6.2-10.20210508.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat:ncurses_libs:6.2-10.20210508.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/var/lib/rpm/rpmdb.sqlite"
+              },
+              {
+                "name": "syft:metadata:release",
+                "value": "10.20210508.el9"
+              },
+              {
+                "name": "syft:metadata:size",
+                "value": "1229839"
+              },
+              {
+                "name": "syft:metadata:sourceRpm",
+                "value": "ncurses-6.2-10.20210508.el9.src.rpm"
+              }
+            ],
+            "publisher": "Red Hat, Inc.",
+            "purl": "pkg:rpm/rhel/ncurses-libs@6.2-10.20210508.el9?arch=aarch64&upstream=ncurses-6.2-10.20210508.el9.src.rpm&distro=rhel-9.4",
+            "type": "library",
+            "version": "6.2-10.20210508.el9"
+          },
+          {
+            "bom-ref": "pkg:github/ossf/scorecard-action@dc50aa9510b46c811795eb24b2f1ba02a914e534?package-id=c490fd917aa5bba3",
+            "cpe": "cpe:2.3:a:ossf\\/scorecard-action:ossf\\/scorecard-action:dc50aa9510b46c811795eb24b2f1ba02a914e534:*:*:*:*:*:*:*",
+            "name": "ossf/scorecard-action",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "github-actions-usage-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "github-action"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:ossf\\/scorecard-action:ossf\\/scorecard_action:dc50aa9510b46c811795eb24b2f1ba02a914e534:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:ossf\\/scorecard_action:ossf\\/scorecard-action:dc50aa9510b46c811795eb24b2f1ba02a914e534:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:ossf\\/scorecard_action:ossf\\/scorecard_action:dc50aa9510b46c811795eb24b2f1ba02a914e534:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:ossf\\/scorecard:ossf\\/scorecard-action:dc50aa9510b46c811795eb24b2f1ba02a914e534:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:ossf\\/scorecard:ossf\\/scorecard_action:dc50aa9510b46c811795eb24b2f1ba02a914e534:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/.github/workflows/scorecards.yml"
+              }
+            ],
+            "purl": "pkg:github/ossf/scorecard-action@dc50aa9510b46c811795eb24b2f1ba02a914e534",
+            "type": "library",
+            "version": "dc50aa9510b46c811795eb24b2f1ba02a914e534"
+          },
+          {
+            "bom-ref": "pkg:rpm/rhel/pcre2-syntax@10.40-5.el9?arch=noarch&upstream=pcre2-10.40-5.el9.src.rpm&distro=rhel-9.4&package-id=a209df8eaf0523c8",
+            "cpe": "cpe:2.3:a:pcre2-syntax:pcre2-syntax:10.40-5.el9:*:*:*:*:*:*:*",
+            "licenses": [
+              {
+                "license": {
+                  "name": "BSD"
+                }
+              }
+            ],
+            "name": "pcre2-syntax",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "rpm-db-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "rpm"
+              },
+              {
+                "name": "syft:package:metadataType",
+                "value": "rpm-db-entry"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:pcre2-syntax:pcre2_syntax:10.40-5.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:pcre2_syntax:pcre2-syntax:10.40-5.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:pcre2_syntax:pcre2_syntax:10.40-5.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat:pcre2-syntax:10.40-5.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat:pcre2_syntax:10.40-5.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:pcre2:pcre2-syntax:10.40-5.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:pcre2:pcre2_syntax:10.40-5.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/var/lib/rpm/rpmdb.sqlite"
+              },
+              {
+                "name": "syft:metadata:release",
+                "value": "5.el9"
+              },
+              {
+                "name": "syft:metadata:size",
+                "value": "234324"
+              },
+              {
+                "name": "syft:metadata:sourceRpm",
+                "value": "pcre2-10.40-5.el9.src.rpm"
+              }
+            ],
+            "publisher": "Red Hat, Inc.",
+            "purl": "pkg:rpm/rhel/pcre2-syntax@10.40-5.el9?arch=noarch&upstream=pcre2-10.40-5.el9.src.rpm&distro=rhel-9.4",
+            "type": "library",
+            "version": "10.40-5.el9"
+          },
+          {
+            "bom-ref": "pkg:rpm/rhel/pcre2@10.40-5.el9?arch=aarch64&upstream=pcre2-10.40-5.el9.src.rpm&distro=rhel-9.4&package-id=de30ae3f4dfcd3a5",
+            "cpe": "cpe:2.3:a:redhat:pcre2:10.40-5.el9:*:*:*:*:*:*:*",
+            "licenses": [
+              {
+                "license": {
+                  "name": "BSD"
+                }
+              }
+            ],
+            "name": "pcre2",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "rpm-db-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "rpm"
+              },
+              {
+                "name": "syft:package:metadataType",
+                "value": "rpm-db-entry"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:pcre2:pcre2:10.40-5.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/var/lib/rpm/rpmdb.sqlite"
+              },
+              {
+                "name": "syft:metadata:release",
+                "value": "5.el9"
+              },
+              {
+                "name": "syft:metadata:size",
+                "value": "664154"
+              },
+              {
+                "name": "syft:metadata:sourceRpm",
+                "value": "pcre2-10.40-5.el9.src.rpm"
+              }
+            ],
+            "publisher": "Red Hat, Inc.",
+            "purl": "pkg:rpm/rhel/pcre2@10.40-5.el9?arch=aarch64&upstream=pcre2-10.40-5.el9.src.rpm&distro=rhel-9.4",
+            "type": "library",
+            "version": "10.40-5.el9"
+          },
+          {
+            "bom-ref": "pkg:github/redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056?package-id=539d8ad910b69c22",
+            "cpe": "cpe:2.3:a:redhat-actions\\/buildah-build:redhat-actions\\/buildah-build:7a95fa7ee0f02d552a32753e7414641a04307056:*:*:*:*:*:*:*",
+            "name": "redhat-actions/buildah-build",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "github-actions-usage-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "github-action"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat-actions\\/buildah-build:redhat_actions\\/buildah_build:7a95fa7ee0f02d552a32753e7414641a04307056:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat_actions\\/buildah_build:redhat-actions\\/buildah-build:7a95fa7ee0f02d552a32753e7414641a04307056:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat_actions\\/buildah_build:redhat_actions\\/buildah_build:7a95fa7ee0f02d552a32753e7414641a04307056:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat-actions\\/buildah:redhat-actions\\/buildah-build:7a95fa7ee0f02d552a32753e7414641a04307056:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat-actions\\/buildah:redhat_actions\\/buildah_build:7a95fa7ee0f02d552a32753e7414641a04307056:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat_actions\\/buildah:redhat-actions\\/buildah-build:7a95fa7ee0f02d552a32753e7414641a04307056:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat_actions\\/buildah:redhat_actions\\/buildah_build:7a95fa7ee0f02d552a32753e7414641a04307056:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat:redhat-actions\\/buildah-build:7a95fa7ee0f02d552a32753e7414641a04307056:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat:redhat_actions\\/buildah_build:7a95fa7ee0f02d552a32753e7414641a04307056:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/.github/workflows/release.yaml"
+              }
+            ],
+            "purl": "pkg:github/redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056",
+            "type": "library",
+            "version": "7a95fa7ee0f02d552a32753e7414641a04307056"
+          },
+          {
+            "bom-ref": "pkg:github/redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603?package-id=a0c3934bf919e60d",
+            "cpe": "cpe:2.3:a:redhat-actions\\/podman-login:redhat-actions\\/podman-login:4934294ad0449894bcd1e9f191899d7292469603:*:*:*:*:*:*:*",
+            "name": "redhat-actions/podman-login",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "github-actions-usage-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "github-action"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat-actions\\/podman-login:redhat_actions\\/podman_login:4934294ad0449894bcd1e9f191899d7292469603:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat_actions\\/podman_login:redhat-actions\\/podman-login:4934294ad0449894bcd1e9f191899d7292469603:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat_actions\\/podman_login:redhat_actions\\/podman_login:4934294ad0449894bcd1e9f191899d7292469603:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat-actions\\/podman:redhat-actions\\/podman-login:4934294ad0449894bcd1e9f191899d7292469603:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat-actions\\/podman:redhat_actions\\/podman_login:4934294ad0449894bcd1e9f191899d7292469603:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat_actions\\/podman:redhat-actions\\/podman-login:4934294ad0449894bcd1e9f191899d7292469603:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat_actions\\/podman:redhat_actions\\/podman_login:4934294ad0449894bcd1e9f191899d7292469603:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat:redhat-actions\\/podman-login:4934294ad0449894bcd1e9f191899d7292469603:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat:redhat_actions\\/podman_login:4934294ad0449894bcd1e9f191899d7292469603:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/.github/workflows/release.yaml"
+              }
+            ],
+            "purl": "pkg:github/redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603",
+            "type": "library",
+            "version": "4934294ad0449894bcd1e9f191899d7292469603"
+          },
+          {
+            "bom-ref": "pkg:github/redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c?package-id=45791652a9fbd508",
+            "cpe": "cpe:2.3:a:redhat-actions\\/push-to-registry:redhat-actions\\/push-to-registry:5ed88d269cf581ea9ef6dd6806d01562096bee9c:*:*:*:*:*:*:*",
+            "name": "redhat-actions/push-to-registry",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "github-actions-usage-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "github-action"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat-actions\\/push-to-registry:redhat_actions\\/push_to_registry:5ed88d269cf581ea9ef6dd6806d01562096bee9c:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat_actions\\/push_to_registry:redhat-actions\\/push-to-registry:5ed88d269cf581ea9ef6dd6806d01562096bee9c:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat_actions\\/push_to_registry:redhat_actions\\/push_to_registry:5ed88d269cf581ea9ef6dd6806d01562096bee9c:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat-actions\\/push-to:redhat-actions\\/push-to-registry:5ed88d269cf581ea9ef6dd6806d01562096bee9c:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat-actions\\/push-to:redhat_actions\\/push_to_registry:5ed88d269cf581ea9ef6dd6806d01562096bee9c:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat_actions\\/push_to:redhat-actions\\/push-to-registry:5ed88d269cf581ea9ef6dd6806d01562096bee9c:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat_actions\\/push_to:redhat_actions\\/push_to_registry:5ed88d269cf581ea9ef6dd6806d01562096bee9c:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat-actions\\/push:redhat-actions\\/push-to-registry:5ed88d269cf581ea9ef6dd6806d01562096bee9c:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat-actions\\/push:redhat_actions\\/push_to_registry:5ed88d269cf581ea9ef6dd6806d01562096bee9c:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat_actions\\/push:redhat-actions\\/push-to-registry:5ed88d269cf581ea9ef6dd6806d01562096bee9c:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat_actions\\/push:redhat_actions\\/push_to_registry:5ed88d269cf581ea9ef6dd6806d01562096bee9c:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat:redhat-actions\\/push-to-registry:5ed88d269cf581ea9ef6dd6806d01562096bee9c:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat:redhat_actions\\/push_to_registry:5ed88d269cf581ea9ef6dd6806d01562096bee9c:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/.github/workflows/release.yaml"
+              }
+            ],
+            "purl": "pkg:github/redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c",
+            "type": "library",
+            "version": "5ed88d269cf581ea9ef6dd6806d01562096bee9c"
+          },
+          {
+            "bom-ref": "pkg:rpm/rhel/redhat-release@9.4-0.4.el9?arch=aarch64&upstream=redhat-release-9.4-0.4.el9.src.rpm&distro=rhel-9.4&package-id=b9ace683dc6b2313",
+            "cpe": "cpe:2.3:a:redhat-release:redhat-release:9.4-0.4.el9:*:*:*:*:*:*:*",
+            "licenses": [
+              {
+                "license": {
+                  "name": "GPLv2"
+                }
+              }
+            ],
+            "name": "redhat-release",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "rpm-db-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "rpm"
+              },
+              {
+                "name": "syft:package:metadataType",
+                "value": "rpm-db-entry"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat-release:redhat_release:9.4-0.4.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat_release:redhat-release:9.4-0.4.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat_release:redhat_release:9.4-0.4.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat:redhat-release:9.4-0.4.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:redhat:redhat_release:9.4-0.4.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/var/lib/rpm/rpmdb.sqlite"
+              },
+              {
+                "name": "syft:metadata:release",
+                "value": "0.4.el9"
+              },
+              {
+                "name": "syft:metadata:size",
+                "value": "58825"
+              },
+              {
+                "name": "syft:metadata:sourceRpm",
+                "value": "redhat-release-9.4-0.4.el9.src.rpm"
+              }
+            ],
+            "publisher": "Red Hat, Inc.",
+            "purl": "pkg:rpm/rhel/redhat-release@9.4-0.4.el9?arch=aarch64&upstream=redhat-release-9.4-0.4.el9.src.rpm&distro=rhel-9.4",
+            "type": "library",
+            "version": "9.4-0.4.el9"
+          },
+          {
+            "bom-ref": "os:rhel@9.4",
+            "cpe": "cpe:2.3:o:redhat:enterprise_linux:9:*:baseos:*:*:*:*:*",
+            "description": "Red Hat Enterprise Linux 9.4 (Plow)",
+            "externalReferences": [
+              {
+                "type": "issue-tracker",
+                "url": "https://bugzilla.redhat.com/"
+              },
+              {
+                "type": "website",
+                "url": "https://www.redhat.com/"
+              }
+            ],
+            "name": "rhel",
+            "properties": [
+              {
+                "name": "syft:distro:id",
+                "value": "rhel"
+              },
+              {
+                "name": "syft:distro:idLike:0",
+                "value": "fedora"
+              },
+              {
+                "name": "syft:distro:prettyName",
+                "value": "Red Hat Enterprise Linux 9.4 (Plow)"
+              },
+              {
+                "name": "syft:distro:versionID",
+                "value": "9.4"
+              }
+            ],
+            "swid": {
+              "name": "rhel",
+              "tagId": "rhel",
+              "version": "9.4"
+            },
+            "type": "operating-system",
+            "version": "9.4"
+          },
+          {
+            "bom-ref": "pkg:rpm/rhel/setup@2.13.7-10.el9?arch=noarch&upstream=setup-2.13.7-10.el9.src.rpm&distro=rhel-9.4&package-id=befa3e6a19701472",
+            "cpe": "cpe:2.3:a:redhat:setup:2.13.7-10.el9:*:*:*:*:*:*:*",
+            "licenses": [
+              {
+                "license": {
+                  "name": "Public Domain"
+                }
+              }
+            ],
+            "name": "setup",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "rpm-db-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "rpm"
+              },
+              {
+                "name": "syft:package:metadataType",
+                "value": "rpm-db-entry"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:setup:setup:2.13.7-10.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/var/lib/rpm/rpmdb.sqlite"
+              },
+              {
+                "name": "syft:metadata:release",
+                "value": "10.el9"
+              },
+              {
+                "name": "syft:metadata:size",
+                "value": "725932"
+              },
+              {
+                "name": "syft:metadata:sourceRpm",
+                "value": "setup-2.13.7-10.el9.src.rpm"
+              }
+            ],
+            "publisher": "Red Hat, Inc.",
+            "purl": "pkg:rpm/rhel/setup@2.13.7-10.el9?arch=noarch&upstream=setup-2.13.7-10.el9.src.rpm&distro=rhel-9.4",
+            "type": "library",
+            "version": "2.13.7-10.el9"
+          },
+          {
+            "bom-ref": "pkg:github/sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20?package-id=473eba8896759814",
+            "cpe": "cpe:2.3:a:sigstore\\/cosign-installer:sigstore\\/cosign-installer:59acb6260d9c0ba8f4a2f9d9b48431a222b68e20:*:*:*:*:*:*:*",
+            "name": "sigstore/cosign-installer",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "github-actions-usage-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "github-action"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:sigstore\\/cosign-installer:sigstore\\/cosign_installer:59acb6260d9c0ba8f4a2f9d9b48431a222b68e20:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:sigstore\\/cosign_installer:sigstore\\/cosign-installer:59acb6260d9c0ba8f4a2f9d9b48431a222b68e20:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:sigstore\\/cosign_installer:sigstore\\/cosign_installer:59acb6260d9c0ba8f4a2f9d9b48431a222b68e20:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:sigstore\\/cosign:sigstore\\/cosign-installer:59acb6260d9c0ba8f4a2f9d9b48431a222b68e20:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:sigstore\\/cosign:sigstore\\/cosign_installer:59acb6260d9c0ba8f4a2f9d9b48431a222b68e20:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/.github/workflows/release.yaml"
+              }
+            ],
+            "purl": "pkg:github/sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20",
+            "type": "library",
+            "version": "59acb6260d9c0ba8f4a2f9d9b48431a222b68e20"
+          },
+          {
+            "bom-ref": "pkg:github/slsa-framework/slsa-github-generator@v2.0.0?package-id=29b4696ada284da1#github/workflows/generator_container_slsa3yml",
+            "cpe": "cpe:2.3:a:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator-container-slsa3.yml:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator-container-slsa3.yml:v2.0.0:*:*:*:*:*:*:*",
+            "name": "slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "github-action-workflow-usage-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "github-action-workflow"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator-container-slsa3.yml:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator_container_slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator-container-slsa3.yml:slsa_framework\\/slsa_github_generator\\/.github\\/workflows\\/generator_container_slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator_container_slsa3.yml:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator-container-slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator_container_slsa3.yml:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator_container_slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator_container_slsa3.yml:slsa_framework\\/slsa_github_generator\\/.github\\/workflows\\/generator_container_slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa_framework\\/slsa_github_generator\\/.github\\/workflows\\/generator_container_slsa3.yml:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator-container-slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa_framework\\/slsa_github_generator\\/.github\\/workflows\\/generator_container_slsa3.yml:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator_container_slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa_framework\\/slsa_github_generator\\/.github\\/workflows\\/generator_container_slsa3.yml:slsa_framework\\/slsa_github_generator\\/.github\\/workflows\\/generator_container_slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator-container:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator-container-slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator-container:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator_container_slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator-container:slsa_framework\\/slsa_github_generator\\/.github\\/workflows\\/generator_container_slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator_container:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator-container-slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator_container:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator_container_slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator_container:slsa_framework\\/slsa_github_generator\\/.github\\/workflows\\/generator_container_slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa_framework\\/slsa_github_generator\\/.github\\/workflows\\/generator_container:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator-container-slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa_framework\\/slsa_github_generator\\/.github\\/workflows\\/generator_container:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator_container_slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa_framework\\/slsa_github_generator\\/.github\\/workflows\\/generator_container:slsa_framework\\/slsa_github_generator\\/.github\\/workflows\\/generator_container_slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator-container-slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator_container_slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator:slsa_framework\\/slsa_github_generator\\/.github\\/workflows\\/generator_container_slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa_framework\\/slsa_github_generator\\/.github\\/workflows\\/generator:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator-container-slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa_framework\\/slsa_github_generator\\/.github\\/workflows\\/generator:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator_container_slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa_framework\\/slsa_github_generator\\/.github\\/workflows\\/generator:slsa_framework\\/slsa_github_generator\\/.github\\/workflows\\/generator_container_slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa-framework\\/slsa-github:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator-container-slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa-framework\\/slsa-github:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator_container_slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa-framework\\/slsa-github:slsa_framework\\/slsa_github_generator\\/.github\\/workflows\\/generator_container_slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa_framework\\/slsa_github:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator-container-slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa_framework\\/slsa_github:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator_container_slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa_framework\\/slsa_github:slsa_framework\\/slsa_github_generator\\/.github\\/workflows\\/generator_container_slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa-framework\\/slsa:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator-container-slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa-framework\\/slsa:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator_container_slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa-framework\\/slsa:slsa_framework\\/slsa_github_generator\\/.github\\/workflows\\/generator_container_slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa_framework\\/slsa:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator-container-slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa_framework\\/slsa:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator_container_slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa_framework\\/slsa:slsa_framework\\/slsa_github_generator\\/.github\\/workflows\\/generator_container_slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator-container-slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa:slsa-framework\\/slsa-github-generator\\/.github\\/workflows\\/generator_container_slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:slsa:slsa_framework\\/slsa_github_generator\\/.github\\/workflows\\/generator_container_slsa3.yml:v2.0.0:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/.github/workflows/release.yaml"
+              }
+            ],
+            "purl": "pkg:github/slsa-framework/slsa-github-generator@v2.0.0#.github/workflows/generator_container_slsa3.yml",
+            "type": "library",
+            "version": "v2.0.0"
+          },
+          {
+            "bom-ref": "pkg:github/step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10?package-id=037a87160468e428",
+            "cpe": "cpe:2.3:a:step-security\\/harden-runner:step-security\\/harden-runner:f086349bfa2bd1361f7909c78558e816508cdc10:*:*:*:*:*:*:*",
+            "name": "step-security/harden-runner",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "github-actions-usage-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "github-action"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:step-security\\/harden-runner:step_security\\/harden_runner:f086349bfa2bd1361f7909c78558e816508cdc10:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:step_security\\/harden_runner:step-security\\/harden-runner:f086349bfa2bd1361f7909c78558e816508cdc10:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:step_security\\/harden_runner:step_security\\/harden_runner:f086349bfa2bd1361f7909c78558e816508cdc10:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:step-security\\/harden:step-security\\/harden-runner:f086349bfa2bd1361f7909c78558e816508cdc10:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:step-security\\/harden:step_security\\/harden_runner:f086349bfa2bd1361f7909c78558e816508cdc10:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:step_security\\/harden:step-security\\/harden-runner:f086349bfa2bd1361f7909c78558e816508cdc10:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:step_security\\/harden:step_security\\/harden_runner:f086349bfa2bd1361f7909c78558e816508cdc10:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:step:step-security\\/harden-runner:f086349bfa2bd1361f7909c78558e816508cdc10:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:step:step_security\\/harden_runner:f086349bfa2bd1361f7909c78558e816508cdc10:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/.github/workflows/scorecards.yml"
+              }
+            ],
+            "purl": "pkg:github/step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10",
+            "type": "library",
+            "version": "f086349bfa2bd1361f7909c78558e816508cdc10"
+          },
+          {
+            "bom-ref": "pkg:rpm/rhel/tzdata@2024a-1.el9?arch=noarch&upstream=tzdata-2024a-1.el9.src.rpm&distro=rhel-9.4&package-id=b4ba3ef7051be978",
+            "cpe": "cpe:2.3:a:redhat:tzdata:2024a-1.el9:*:*:*:*:*:*:*",
+            "licenses": [
+              {
+                "license": {
+                  "name": "Public Domain"
+                }
+              }
+            ],
+            "name": "tzdata",
+            "properties": [
+              {
+                "name": "syft:package:foundBy",
+                "value": "rpm-db-cataloger"
+              },
+              {
+                "name": "syft:package:type",
+                "value": "rpm"
+              },
+              {
+                "name": "syft:package:metadataType",
+                "value": "rpm-db-entry"
+              },
+              {
+                "name": "syft:cpe23",
+                "value": "cpe:2.3:a:tzdata:tzdata:2024a-1.el9:*:*:*:*:*:*:*"
+              },
+              {
+                "name": "syft:location:0:path",
+                "value": "/var/lib/rpm/rpmdb.sqlite"
+              },
+              {
+                "name": "syft:metadata:release",
+                "value": "1.el9"
+              },
+              {
+                "name": "syft:metadata:size",
+                "value": "1707934"
+              },
+              {
+                "name": "syft:metadata:sourceRpm",
+                "value": "tzdata-2024a-1.el9.src.rpm"
+              }
+            ],
+            "publisher": "Red Hat, Inc.",
+            "purl": "pkg:rpm/rhel/tzdata@2024a-1.el9?arch=noarch&upstream=tzdata-2024a-1.el9.src.rpm&distro=rhel-9.4",
+            "type": "library",
+            "version": "2024a-1.el9"
+          }
+        ],
+        "formulation": [
+          {
+            "components": [
+              {
+                "name": "registry.access.redhat.com/ubi9/ubi-micro",
+                "properties": [
+                  {
+                    "name": "konflux:container:is_base_image",
+                    "value": "true"
+                  }
+                ],
+                "purl": "pkg:oci/ubi-micro@sha256:1c8483e0fda0e990175eb9855a5f15e0910d2038dd397d9e2b357630f0321e6d?repository_url=registry.access.redhat.com/ubi9/ubi-micro",
+                "type": "container"
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "component": {
+            "bom-ref": "16bc5cb4c685e7ff",
+            "name": "/var/lib/containers/storage/vfs/dir/4b7821c0b45061e168823e4fb28b9045cda30b7f4c766c0d540f1f1ad0ce7717",
+            "type": "file"
+          },
+          "timestamp": "2024-06-04T15:56:33Z",
+          "tools": {
+            "components": [
+              {
+                "author": "anchore",
+                "name": "syft",
+                "type": "application",
+                "version": "0.105.1"
+              }
+            ]
+          }
+        },
+        "serialNumber": "urn:uuid:3066850c-2a84-4dfb-9b52-3286462f6ec6",
+        "specVersion": "1.5",
+        "version": 1
+      },
+      "root/buildinfo/content_manifests/sbom-purl.json": {
+        "image_contents": {
+          "dependencies": [
+            {
+              "purl": "pkg:github/actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29"
+            },
+            {
+              "purl": "pkg:github/actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808"
+            },
+            {
+              "purl": "pkg:github/anchore/sbom-action@e8d2a6937ecead383dfe75190d104edd1f9c5751#download-syft"
+            },
+            {
+              "purl": "pkg:rpm/rhel/basesystem@11-13.el9?arch=noarch&upstream=basesystem-11-13.el9.src.rpm&distro=rhel-9.4"
+            },
+            {
+              "purl": "pkg:rpm/rhel/bash@5.1.8-9.el9?arch=aarch64&upstream=bash-5.1.8-9.el9.src.rpm&distro=rhel-9.4"
+            },
+            {
+              "purl": "pkg:rpm/rhel/coreutils-single@8.32-35.el9?arch=aarch64&upstream=coreutils-8.32-35.el9.src.rpm&distro=rhel-9.4"
+            },
+            {
+              "purl": "pkg:github/enterprise-contract/action-validate-image@v1.0.200"
+            },
+            {
+              "purl": "pkg:github/enterprise-contract/github-workflows@main#.github/workflows/auto-merge.yaml"
+            },
+            {
+              "purl": "pkg:rpm/rhel/filesystem@3.16-2.el9?arch=aarch64&upstream=filesystem-3.16-2.el9.src.rpm&distro=rhel-9.4"
+            },
+            {
+              "purl": "pkg:github/github/codeql-action@2e230e8fe0ad3a14a340ad0815ddb96d599d2aff#upload-sarif"
+            },
+            {
+              "purl": "pkg:rpm/rhel/glibc-common@2.34-100.el9_4.2?arch=aarch64&upstream=glibc-2.34-100.el9_4.2.src.rpm&distro=rhel-9.4"
+            },
+            {
+              "purl": "pkg:rpm/rhel/glibc-minimal-langpack@2.34-100.el9_4.2?arch=aarch64&upstream=glibc-2.34-100.el9_4.2.src.rpm&distro=rhel-9.4"
+            },
+            {
+              "purl": "pkg:rpm/rhel/glibc@2.34-100.el9_4.2?arch=aarch64&upstream=glibc-2.34-100.el9_4.2.src.rpm&distro=rhel-9.4"
+            },
+            {
+              "purl": "pkg:rpm/rhel/libacl@2.3.1-4.el9?arch=aarch64&upstream=acl-2.3.1-4.el9.src.rpm&distro=rhel-9.4"
+            },
+            {
+              "purl": "pkg:rpm/rhel/libattr@2.5.1-3.el9?arch=aarch64&upstream=attr-2.5.1-3.el9.src.rpm&distro=rhel-9.4"
+            },
+            {
+              "purl": "pkg:rpm/rhel/libcap@2.48-9.el9_2?arch=aarch64&upstream=libcap-2.48-9.el9_2.src.rpm&distro=rhel-9.4"
+            },
+            {
+              "purl": "pkg:rpm/rhel/libgcc@11.4.1-3.el9?arch=aarch64&upstream=gcc-11.4.1-3.el9.src.rpm&distro=rhel-9.4"
+            },
+            {
+              "purl": "pkg:rpm/rhel/libselinux@3.6-1.el9?arch=aarch64&upstream=libselinux-3.6-1.el9.src.rpm&distro=rhel-9.4"
+            },
+            {
+              "purl": "pkg:rpm/rhel/libsepol@3.6-1.el9?arch=aarch64&upstream=libsepol-3.6-1.el9.src.rpm&distro=rhel-9.4"
+            },
+            {
+              "purl": "pkg:rpm/rhel/ncurses-base@6.2-10.20210508.el9?arch=noarch&upstream=ncurses-6.2-10.20210508.el9.src.rpm&distro=rhel-9.4"
+            },
+            {
+              "purl": "pkg:rpm/rhel/ncurses-libs@6.2-10.20210508.el9?arch=aarch64&upstream=ncurses-6.2-10.20210508.el9.src.rpm&distro=rhel-9.4"
+            },
+            {
+              "purl": "pkg:github/ossf/scorecard-action@dc50aa9510b46c811795eb24b2f1ba02a914e534"
+            },
+            {
+              "purl": "pkg:rpm/rhel/pcre2-syntax@10.40-5.el9?arch=noarch&upstream=pcre2-10.40-5.el9.src.rpm&distro=rhel-9.4"
+            },
+            {
+              "purl": "pkg:rpm/rhel/pcre2@10.40-5.el9?arch=aarch64&upstream=pcre2-10.40-5.el9.src.rpm&distro=rhel-9.4"
+            },
+            {
+              "purl": "pkg:github/redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056"
+            },
+            {
+              "purl": "pkg:github/redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603"
+            },
+            {
+              "purl": "pkg:github/redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c"
+            },
+            {
+              "purl": "pkg:rpm/rhel/redhat-release@9.4-0.4.el9?arch=aarch64&upstream=redhat-release-9.4-0.4.el9.src.rpm&distro=rhel-9.4"
+            },
+            {
+              "purl": "pkg:rpm/rhel/setup@2.13.7-10.el9?arch=noarch&upstream=setup-2.13.7-10.el9.src.rpm&distro=rhel-9.4"
+            },
+            {
+              "purl": "pkg:github/sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20"
+            },
+            {
+              "purl": "pkg:github/slsa-framework/slsa-github-generator@v2.0.0#.github/workflows/generator_container_slsa3.yml"
+            },
+            {
+              "purl": "pkg:github/step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10"
+            },
+            {
+              "purl": "pkg:rpm/rhel/tzdata@2024a-1.el9?arch=noarch&upstream=tzdata-2024a-1.el9.src.rpm&distro=rhel-9.4"
+            }
+          ]
+        }
+      },
+      "root/buildinfo/content_manifests/ubi9-micro-container-9.4-6.1716471860.json": {
+        "content_sets": [
+          "rhel-9-for-aarch64-baseos-rpms",
+          "rhel-9-for-aarch64-appstream-rpms"
+        ],
+        "image_contents": [],
+        "metadata": {
+          "icm_spec": "https://raw.githubusercontent.com/containerbuildsystem/atomic-reactor/master/atomic_reactor/schemas/content_manifest.json",
+          "icm_version": 1,
+          "image_layer_index": 0
         }
       }
     },
     "source": {
       "git": {
         "url": "https://github.com/enterprise-contract/golden-container.git",
-        "revision": "68b69547cad3c4ba856fe6b06154012f33dd8b5a"
+        "revision": "b0d7c600114b39f0f14e4e85a7c8aed7c4de316e"
       }
     }
   }

--- a/example/data/trusted_tekton_tasks.yml
+++ b/example/data/trusted_tekton_tasks.yml
@@ -17,66 +17,83 @@
 
 trusted_tasks:
   git+https://github.com/redhat-appstudio/build-definitions.git//task/buildah/0.1/buildah.yaml:
-    - ref: 3672a457e3e89c0591369f609eba727b8e84108f
-      effective_on: 2024-02-16T00:00:00Z
-    - ref: 81185d669f543f5cd9114377f7ee0480e15a7ac1
-      effective_on: 2024-02-10T00:00:00Z
-
+    - effective_on: "2024-02-16T00:00:00Z"
+      ref: 3672a457e3e89c0591369f609eba727b8e84108f
   git+https://github.com/redhat-appstudio/build-definitions.git//task/clair-scan/0.1/clair-scan.yaml:
-    - ref: 28b86c8b94c42995d98f843b0fc854c1cf2ae500
-      effective_on: 2024-02-15T00:00:00Z
-    - ref: 4efdfc8c8da9f78602b5a21bcd2b3cf5667503fc
-      effective_on: 2024-01-31T00:00:00Z
-
+    - effective_on: "2024-02-15T00:00:00Z"
+      ref: 28b86c8b94c42995d98f843b0fc854c1cf2ae500
+  oci://quay.io/redhat-appstudio-tekton-catalog/task-build-image-manifest:0.1:
+    - effective_on: "2024-07-06T00:00:00Z"
+      ref: sha256:e064b63b2311d23d6bf6538347cb4eb18c980d61883f48149bc9c728f76b276c
+  oci://quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.1:
+    - effective_on: "2024-07-06T00:00:00Z"
+      ref: sha256:09ad5680c2b9ed61abb40c2f0071b7e889f799a47e1ece546299617d79e299f1
   oci://quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.1:
-    - ref: sha256:351af2c0e5eeb92a5d6d4083847c1559475b596cda7671f489756d5302a4c847
-      effective_on: "2023-11-06T00:00:00Z"
-    - ref: sha256:97f21661e237735af04b37feeeaedd328424bfa0ebd4cd0f79ac39cde17137f6
-      effective_on: "2023-10-25T00:00:00Z"
-    - ref: sha256:487b82bbdbd361d6ef3cd7a522bb6fe2f163a2d517181f13fe07565a4838f1bb
-      effective_on: "2023-10-21T00:00:00Z"
-
+    - effective_on: "2024-07-06T00:00:00Z"
+      ref: sha256:b8d50716c01160be5deb27dd30f79ae33cc89c72952285cd850323fa0a88b8db
+    - effective_on: "2023-11-06T00:00:00Z"
+      expires_on: "2024-07-06T00:00:00Z"
+      ref: sha256:351af2c0e5eeb92a5d6d4083847c1559475b596cda7671f489756d5302a4c847
   oci://quay.io/redhat-appstudio-tekton-catalog/task-clair-scan:0.1:
-    - ref: sha256:63b42c0fc23d05e26776a0e7c4f0ab00750096ebfe1eed9a7ba96f8b27713fbf
-      effective_on: "2023-11-01T00:00:00Z"
-    - ref: sha256:64203069d09be49e45082ec02588ee0308e693c7777999ed351a78d554657c61
-      effective_on: "2023-10-29T00:00:00Z"
-    - ref: sha256:aa9595966afe40bdc1935c8bec51648e2266500120b02fe336a8f26c58ae7387
-      effective_on: "2023-10-28T00:00:00Z"
-
+    - effective_on: "2024-07-06T00:00:00Z"
+      ref: sha256:44d0df70080e082e72d2694b14130ff512e5e7f2611190161a9b016b4df9fb22
+    - effective_on: "2023-11-01T00:00:00Z"
+      expires_on: "2024-07-06T00:00:00Z"
+      ref: sha256:63b42c0fc23d05e26776a0e7c4f0ab00750096ebfe1eed9a7ba96f8b27713fbf
   oci://quay.io/redhat-appstudio-tekton-catalog/task-clamav-scan:0.1:
-    - ref: sha256:d72cb58db88289559676676c3db43906718028e07279f70ddb12ed8bdc8e2860
-      effective_on: "2023-11-01T00:00:00Z"
-
-  oci://quay.io/redhat-appstudio-tekton-catalog/task-git-clone:0.1:
-    - ref: sha256:b8fddc2d36313a5cde93aba2491205f4a84e6853af6c34ede681f8339b147478
-      effective_on: "2023-11-01T00:00:00Z"
-
+    - effective_on: "2024-07-06T00:00:00Z"
+      ref: sha256:5dbe6c646c3502ddc7fbe6016b8584bed6ce3ab7028b0c405ebaabc7e6e9e64c
+    - effective_on: "2023-11-01T00:00:00Z"
+      expires_on: "2024-07-06T00:00:00Z"
+      ref: sha256:d72cb58db88289559676676c3db43906718028e07279f70ddb12ed8bdc8e2860
   oci://quay.io/redhat-appstudio-tekton-catalog/task-deprecated-image-check:0.3:
-    - ref: sha256:d87f8c50a674f57527a0c4f3df6d9093941a2ae84739b55368b3c11702ce340c
-      effective_on: "2023-11-01T00:00:00Z"
-
+    - effective_on: "2023-11-01T00:00:00Z"
+      ref: sha256:d87f8c50a674f57527a0c4f3df6d9093941a2ae84739b55368b3c11702ce340c
+  oci://quay.io/redhat-appstudio-tekton-catalog/task-deprecated-image-check:0.4:
+    - effective_on: "2024-07-06T00:00:00Z"
+      ref: sha256:3793fbf59e7dadff9d1f7e7ea4cc430c69a2de620b20c7fd69d71bdd5f6c4a60
+  oci://quay.io/redhat-appstudio-tekton-catalog/task-git-clone:0.1:
+    - effective_on: "2024-07-06T00:00:00Z"
+      ref: sha256:ae1249aa49e82da5f99cc23b256172dce8f7c7951ece68ca0419240c4ecb52e2
+    - effective_on: "2023-11-01T00:00:00Z"
+      expires_on: "2024-07-06T00:00:00Z"
+      ref: sha256:b8fddc2d36313a5cde93aba2491205f4a84e6853af6c34ede681f8339b147478
   oci://quay.io/redhat-appstudio-tekton-catalog/task-init:0.2:
-    - ref: sha256:3d8f01fa59596a998d30dc700fcf7377f09d60008337290eebaeaf604512ce2b
-      effective_on: "2023-11-01T00:00:00Z"
-      tag: "0.2"
-
+    - effective_on: "2024-07-06T00:00:00Z"
+      ref: sha256:b23c7a924f303a67b3a00b32a6713ae1a4fccbc5327daa76a6edd250501ea7a3
+    - effective_on: "2023-11-01T00:00:00Z"
+      expires_on: "2024-07-06T00:00:00Z"
+      ref: sha256:3d8f01fa59596a998d30dc700fcf7377f09d60008337290eebaeaf604512ce2b
   oci://quay.io/redhat-appstudio-tekton-catalog/task-prefetch-dependencies:0.1:
-    - ref: sha256:9630dd7d50002fdffb4a406fb0c538703ef98bf2f4318249ac3a2c229938dbea
-      effective_on: "2023-11-01T00:00:00Z"
-
+    - effective_on: "2024-07-06T00:00:00Z"
+      ref: sha256:9aec3ae9f0f50a05abdc739faf4cbc82832cff16c77ac74e1d54072a882c0503
+    - effective_on: "2023-11-01T00:00:00Z"
+      expires_on: "2024-07-06T00:00:00Z"
+      ref: sha256:9630dd7d50002fdffb4a406fb0c538703ef98bf2f4318249ac3a2c229938dbea
   oci://quay.io/redhat-appstudio-tekton-catalog/task-sast-snyk-check:0.1:
-    - ref: sha256:eee508768b14655275fbcc2f42f9da1ab553b872dcbe113b0896aa9bcf7e1adf
-      effective_on: "2023-11-01T00:00:00Z"
-
+    - effective_on: "2024-07-06T00:00:00Z"
+      ref: sha256:242acc527a06a11fac9dd6524467f62f3a086c186c5f885973e5780a04d4289c
+    - effective_on: "2023-11-01T00:00:00Z"
+      expires_on: "2024-07-06T00:00:00Z"
+      ref: sha256:eee508768b14655275fbcc2f42f9da1ab553b872dcbe113b0896aa9bcf7e1adf
   oci://quay.io/redhat-appstudio-tekton-catalog/task-sbom-json-check:0.1:
-    - ref: sha256:717e6e33f02dbe1a28fb743f32699e002c944680c251a50b644f27becb9208e9
-      effective_on: "2023-11-01T00:00:00Z"
-
+    - effective_on: "2024-07-06T00:00:00Z"
+      ref: sha256:f9cc253c3a07594bfb51e09c78b46598591cb353e19b16ef514f8312a8b0bada
+    - effective_on: "2023-11-01T00:00:00Z"
+      expires_on: "2024-07-06T00:00:00Z"
+      ref: sha256:717e6e33f02dbe1a28fb743f32699e002c944680c251a50b644f27becb9208e9
   oci://quay.io/redhat-appstudio-tekton-catalog/task-show-sbom:0.1:
-    - ref: sha256:202d3c3385120ea847d8f0a82bd8d9d5e873d67f981d6f8a51fb1706caaf6bef
-      effective_on: "2023-11-01T00:00:00Z"
-
+    - effective_on: "2024-07-06T00:00:00Z"
+      ref: sha256:1f1504c5d8b135864111a993ac6f9ab1212907fa0c609223714cdd7bd825e2ca
+    - effective_on: "2023-11-01T00:00:00Z"
+      expires_on: "2024-07-06T00:00:00Z"
+      ref: sha256:202d3c3385120ea847d8f0a82bd8d9d5e873d67f981d6f8a51fb1706caaf6bef
+  oci://quay.io/redhat-appstudio-tekton-catalog/task-source-build:0.1:
+    - effective_on: "2024-07-06T00:00:00Z"
+      ref: sha256:1a976a35adee9163e455d0c5aee5d9bf9cb3c6a770656ae347558f8c54977709
   oci://quay.io/redhat-appstudio-tekton-catalog/task-summary:0.1:
-    - ref: sha256:f65a69aaf71cbab382eff685eee522ad35068a4d91d233e76cef7d42ff15a686
-      effective_on: "2023-11-01T00:00:00Z"
+    - effective_on: "2023-11-01T00:00:00Z"
+      ref: sha256:f65a69aaf71cbab382eff685eee522ad35068a4d91d233e76cef7d42ff15a686
+  oci://quay.io/redhat-appstudio-tekton-catalog/task-summary:0.2:
+    - effective_on: "2024-07-06T00:00:00Z"
+      ref: sha256:c718319bd57c4f0ab1843cf98d813d0a26a73e0c8ce66218079c3c865508b0fb

--- a/policy/lib/tekton/task_results.rego
+++ b/policy/lib/tekton/task_results.rego
@@ -7,87 +7,71 @@ import rego.v1
 
 # returns the value of a task result with name IMAGE_URL
 task_result_artifact_url(task) := value if {
-	value := [url |
-		some url in task_result_endswith(task, "IMAGE_URL")
-
-		# don't allow empty results
-		count(url) > 0
-	]
+	value := _non_empty_strings(task_result_endswith(task, "IMAGE_URL"))
 	count(value) > 0
 }
 
 # returns the value of a task result with name ARTIFACT_URI
 task_result_artifact_url(task) := value if {
-	value := [url |
-		some url in task_result_endswith(task, "ARTIFACT_URI")
-
-		# don't allow empty results
-		count(url) > 0
-	]
+	value := _non_empty_strings(task_result_endswith(task, "ARTIFACT_URI"))
 	count(value) > 0
 }
 
 # returns the image url from the task result IMAGES
 task_result_artifact_url(task) := value if {
-	value := [v |
+	value := _non_empty_strings([v |
 		some result in task_result_endswith(task, "IMAGES")
 		some image in split(result, ",")
 		split_item := split(image, "@")
-		v := trim_space(split_item[0])
-	]
+		v := split_item[0]
+	])
 	count(value) > 0
 }
 
 # returns the image url from the task result ARTIFACT_OUTPUTS
 task_result_artifact_url(task) := value if {
-	value := [url |
+	value := _non_empty_strings([result.uri |
 		some result in task_result_endswith(task, "ARTIFACT_OUTPUTS")
-		url := trim_space(result.uri)
-	]
+	])
 	count(value) > 0
 }
 
 # returns the value of a task result with name IMAGE_DIGEST
 task_result_artifact_digest(task) := value if {
-	value := [digest |
-		some digest in task_result_endswith(task, "IMAGE_DIGEST")
-
-		# don't allow empty results
-		count(digest) > 0
-	]
+	value := _non_empty_strings(task_result_endswith(task, "IMAGE_DIGEST"))
 	count(value) > 0
 }
 
 # returns the value of a task result with name ARTIFACT_DIGEST
 task_result_artifact_digest(task) := value if {
-	value := [digest |
-		some digest in task_result_endswith(task, "ARTIFACT_DIGEST")
-
-		# don't allow empty results
-		count(digest) > 0
-	]
+	value := _non_empty_strings(task_result_endswith(task, "ARTIFACT_DIGEST"))
 	count(value) > 0
 }
 
 # returns the image digest from the task result IMAGES
 task_result_artifact_digest(task) := value if {
-	value := [v |
+	value := _non_empty_strings([v |
 		some result in task_result_endswith(task, "IMAGES")
 		some image in split(result, ",")
 		split_item := split(image, "@")
-		v := trim_space(split_item[1])
-	]
+		v := split_item[1]
+	])
 	count(value) > 0
 }
 
 # returns the image digest from the task result ARTIFACT_OUTPUTS
 task_result_artifact_digest(task) := value if {
-	value := [url |
+	value := _non_empty_strings([result.digest |
 		some result in task_result_endswith(task, "ARTIFACT_OUTPUTS")
-		url := trim_space(result.digest)
-	]
+	])
 	count(value) > 0
 }
+
+_non_empty_strings(values) := [trimmed_value |
+	some value in values
+	trimmed_value := trim_space(value)
+	count(trimmed_value) > 0
+]
 
 images_with_digests(tasks) := [sprintf("%v@%v", [i, d]) |
 	some y

--- a/policy/lib/tekton/task_results_test.rego
+++ b/policy/lib/tekton/task_results_test.rego
@@ -15,9 +15,17 @@ test_image_result if {
 			"name": "IMAGE_DIGEST",
 			"value": "1234",
 		},
+		{
+			"name": "OTHER_IMAGE_URL",
+			"value": "image2\n",
+		},
+		{
+			"name": "OTHER_IMAGE_DIGEST",
+			"value": "4321\n",
+		},
 	]
-	lib.assert_equal(["image1"], tkn.task_result_artifact_url(slsav1_task_result("task1", results)))
-	lib.assert_equal(["1234"], tkn.task_result_artifact_digest(slsav1_task_result("task1", results)))
+	lib.assert_equal(["image1", "image2"], tkn.task_result_artifact_url(slsav1_task_result("task1", results)))
+	lib.assert_equal(["1234", "4321"], tkn.task_result_artifact_digest(slsav1_task_result("task1", results)))
 }
 
 test_artifact_result if {
@@ -30,15 +38,23 @@ test_artifact_result if {
 			"name": "ARTIFACT_DIGEST",
 			"value": "1234",
 		},
+		{
+			"name": "OTEHR_ARTIFACT_URI",
+			"value": "image2\n",
+		},
+		{
+			"name": "OTHER_ARTIFACT_DIGEST",
+			"value": "4321\n",
+		},
 	]
-	lib.assert_equal(["image1"], tkn.task_result_artifact_url(slsav1_task_result("task1", results)))
-	lib.assert_equal(["1234"], tkn.task_result_artifact_digest(slsav1_task_result("task1", results)))
+	lib.assert_equal(["image1", "image2"], tkn.task_result_artifact_url(slsav1_task_result("task1", results)))
+	lib.assert_equal(["1234", "4321"], tkn.task_result_artifact_digest(slsav1_task_result("task1", results)))
 }
 
 test_images_result if {
 	results := [{
 		"name": "IMAGES",
-		"value": "img1@sha256:digest1, img2@sha256:digest2",
+		"value": "img1@sha256:digest1, img2@sha256:digest2\n",
 	}]
 	lib.assert_equal(["img1", "img2"], tkn.task_result_artifact_url(slsav1_task_result("task1", results)))
 	lib.assert_equal(
@@ -48,12 +64,18 @@ test_images_result if {
 }
 
 test_artifact_outputs_result if {
-	results := [{
-		"name": "ARTIFACT_OUTPUTS",
-		"value": {"uri": "img1", "digest": "1234"},
-	}]
-	lib.assert_equal(["img1"], tkn.task_result_artifact_url(slsav1_task_result("task1", results)))
-	lib.assert_equal(["1234"], tkn.task_result_artifact_digest(slsav1_task_result("task1", results)))
+	results := [
+		{
+			"name": "ARTIFACT_OUTPUTS",
+			"value": {"uri": "img1", "digest": "1234"},
+		},
+		{
+			"name": "OTHER_ARTIFACT_OUTPUTS",
+			"value": {"uri": "img2\n", "digest": "4321\n"},
+		},
+	]
+	lib.assert_equal(["img1", "img2"], tkn.task_result_artifact_url(slsav1_task_result("task1", results)))
+	lib.assert_equal(["1234", "4321"], tkn.task_result_artifact_digest(slsav1_task_result("task1", results)))
 }
 
 test_invalid_result_name if {
@@ -68,34 +90,34 @@ test_invalid_result_name if {
 test_images_with_digests if {
 	results_artifact_outputs := [{
 		"name": "ARTIFACT_OUTPUTS",
-		"value": {"uri": "img1", "digest": "1234"},
+		"value": {"uri": "img1\n", "digest": "1234\n"},
 	}]
 	results_images := [
 		{
 			"name": "image1_IMAGE_URL",
-			"value": "img1",
+			"value": "img1\n",
 		},
 		{
 			"name": "image1_IMAGE_DIGEST",
-			"value": "1234",
+			"value": "1234\n",
 		},
 	]
 	results_images_unordered := [
 		{
 			"name": "image1_IMAGE_URL",
-			"value": "img1",
+			"value": "img1\n",
 		},
 		{
 			"name": "image2_IMAGE_DIGEST",
-			"value": "5678",
+			"value": "5678\n",
 		},
 		{
 			"name": "image2_IMAGE_URL",
-			"value": "img2",
+			"value": "img2\n",
 		},
 		{
 			"name": "image1_IMAGE_DIGEST",
-			"value": "1234",
+			"value": "1234\n",
 		},
 	]
 	tasks_artifacts := [


### PR DESCRIPTION
The type-hinting results that Chains expects, e.g. IMAGE_URL, sometimes contain a trailing slash. Chains allows for this behavior by always trimming the spaces around such values. The same should be done by the policy rules.

These changes also use the policy input extracted from the latest golden-container image in the acceptance tests. This now contains a Task that builds the source container image which highlights the bug fixed in this PR.