### PR TITLE
Allow mixed type-hinting of images

### DIFF
--- a/policy/lib/tekton/task.rego
+++ b/policy/lib/tekton/task.rego
@@ -154,7 +154,6 @@ task_result_endswith(task, suffix) := values if {
 		endswith(result_name, suffix)
 	])
 	values := [result.value | some result in results]
-	count(values) > 0
 }
 
 # slsa v0.2 step image

--- a/policy/lib/tekton/task_results.rego
+++ b/policy/lib/tekton/task_results.rego
@@ -5,67 +5,65 @@ import rego.v1
 # handle the output artifacts from Tekton Chains
 # https://tekton.dev/docs/chains/slsa-provenance/#output-artifacts
 
+task_result_artifact_url(task) := array.concat(
+	_task_result_image_urls(task),
+	array.concat(
+		_task_result_artifact_uris(task),
+		array.concat(
+			_task_result_images_urls(task),
+			_task_result_artifact_outputs_urls(task),
+		),
+	),
+)
+
 # returns the value of a task result with name IMAGE_URL
-task_result_artifact_url(task) := value if {
-	value := _non_empty_strings(task_result_endswith(task, "IMAGE_URL"))
-	count(value) > 0
-}
+_task_result_image_urls(task) := _non_empty_strings(task_result_endswith(task, "IMAGE_URL"))
 
 # returns the value of a task result with name ARTIFACT_URI
-task_result_artifact_url(task) := value if {
-	value := _non_empty_strings(task_result_endswith(task, "ARTIFACT_URI"))
-	count(value) > 0
-}
+_task_result_artifact_uris(task) := _non_empty_strings(task_result_endswith(task, "ARTIFACT_URI"))
 
 # returns the image url from the task result IMAGES
-task_result_artifact_url(task) := value if {
-	value := _non_empty_strings([v |
-		some result in task_result_endswith(task, "IMAGES")
-		some image in split(result, ",")
-		split_item := split(image, "@")
-		v := split_item[0]
-	])
-	count(value) > 0
-}
+_task_result_images_urls(task) := _non_empty_strings([v |
+	some result in task_result_endswith(task, "IMAGES")
+	some image in split(result, ",")
+	split_item := split(image, "@")
+	v := split_item[0]
+])
 
 # returns the image url from the task result ARTIFACT_OUTPUTS
-task_result_artifact_url(task) := value if {
-	value := _non_empty_strings([result.uri |
-		some result in task_result_endswith(task, "ARTIFACT_OUTPUTS")
-	])
-	count(value) > 0
-}
+_task_result_artifact_outputs_urls(task) := _non_empty_strings([result.uri |
+	some result in task_result_endswith(task, "ARTIFACT_OUTPUTS")
+])
+
+task_result_artifact_digest(task) := array.concat(
+	_task_result_image_digests(task),
+	array.concat(
+		_task_result_artifact_digests(task),
+		array.concat(
+			_task_result_images_digests(task),
+			_task_result_artifact_outputs_digests(task),
+		),
+	),
+)
 
 # returns the value of a task result with name IMAGE_DIGEST
-task_result_artifact_digest(task) := value if {
-	value := _non_empty_strings(task_result_endswith(task, "IMAGE_DIGEST"))
-	count(value) > 0
-}
+_task_result_image_digests(task) := _non_empty_strings(task_result_endswith(task, "IMAGE_DIGEST"))
 
 # returns the value of a task result with name ARTIFACT_DIGEST
-task_result_artifact_digest(task) := value if {
-	value := _non_empty_strings(task_result_endswith(task, "ARTIFACT_DIGEST"))
-	count(value) > 0
-}
+_task_result_artifact_digests(task) := _non_empty_strings(task_result_endswith(task, "ARTIFACT_DIGEST"))
 
 # returns the image digest from the task result IMAGES
-task_result_artifact_digest(task) := value if {
-	value := _non_empty_strings([v |
-		some result in task_result_endswith(task, "IMAGES")
-		some image in split(result, ",")
-		split_item := split(image, "@")
-		v := split_item[1]
-	])
-	count(value) > 0
-}
+_task_result_images_digests(task) := _non_empty_strings([v |
+	some result in task_result_endswith(task, "IMAGES")
+	some image in split(result, ",")
+	split_item := split(image, "@")
+	v := split_item[1]
+])
 
 # returns the image digest from the task result ARTIFACT_OUTPUTS
-task_result_artifact_digest(task) := value if {
-	value := _non_empty_strings([result.digest |
-		some result in task_result_endswith(task, "ARTIFACT_OUTPUTS")
-	])
-	count(value) > 0
-}
+_task_result_artifact_outputs_digests(task) := _non_empty_strings([result.digest |
+	some result in task_result_endswith(task, "ARTIFACT_OUTPUTS")
+])
 
 _non_empty_strings(values) := [trimmed_value |
 	some value in values

--- a/policy/lib/tekton/task_results_test.rego
+++ b/policy/lib/tekton/task_results_test.rego
@@ -83,8 +83,8 @@ test_invalid_result_name if {
 		"name": "INVALID_OUTPUTS",
 		"value": {"uri": "img1", "digest": "1234"},
 	}]
-	not tkn.task_result_artifact_url(slsav1_task_result("task1", results))
-	not tkn.task_result_artifact_digest(slsav1_task_result("task1", results))
+	lib.assert_empty(tkn.task_result_artifact_url(slsav1_task_result("task1", results)))
+	lib.assert_empty(tkn.task_result_artifact_digest(slsav1_task_result("task1", results)))
 }
 
 test_images_with_digests if {
@@ -131,4 +131,70 @@ test_images_with_digests if {
 
 	tasks_ordered := [slsav1_task_result("task1", results_images_unordered)]
 	lib.assert_equal(["img1@1234", "img2@5678"], tkn.images_with_digests(tasks_ordered))
+}
+
+test_mixed_results if {
+	results := [
+		{
+			"name": "image1_IMAGE_URL",
+			"value": "image-url-img1",
+		},
+		{
+			"name": "image1_IMAGE_DIGEST",
+			"value": "2345",
+		},
+		{
+			"name": "image2_IMAGE_URL",
+			"value": "image-url-img2",
+		},
+		{
+			"name": "image2_IMAGE_DIGEST",
+			"value": "3456",
+		},
+		{
+			"name": "IMAGES",
+			"value": "images-1@sha256:4567,images-2@sha256:5678",
+		},
+		{
+			"name": "image1_ARTIFACT_URI",
+			"value": "image-artifact-1",
+		},
+		{
+			"name": "image1_ARTIFACT_DIGEST",
+			"value": "sha256:6789",
+		},
+		{
+			"name": "image2_ARTIFACT_URI",
+			"value": "image-artifact-1",
+		},
+		{
+			"name": "image2_ARTIFACT_DIGEST",
+			"value": "sha256:7890",
+		},
+		{
+			"name": "image1_ARTIFACT_OUTPUTS",
+			"value": {"uri": "artifact-outputs-img1", "digest": "sha256:1234"},
+		},
+		{
+			"name": "image2_ARTIFACT_OUTPUTS",
+			"value": {"uri": "artifact-outputs-img2", "digest": "sha256:9801"},
+		},
+	]
+
+	expected := [
+		"image-url-img1@2345",
+		"image-url-img2@3456",
+		"image-artifact-1@sha256:6789",
+		"image-artifact-1@sha256:7890",
+		"images-1@sha256:4567",
+		"images-2@sha256:5678",
+		"artifact-outputs-img1@sha256:1234",
+		"artifact-outputs-img2@sha256:9801",
+	]
+
+	lib.assert_equal(expected, tkn.images_with_digests([slsav1_task_result("task1", results)]))
+}
+
+test_no_results if {
+	lib.assert_empty(tkn.images_with_digests([slsav1_task_result("task1", [])]))
 }


### PR DESCRIPTION
It is perfectly valid of a Task to emit various results which may conform to different type-hinting formats accepted by Chains.

Prior to this commit, if a Task did this, EC would crash with the generic error:

    functions must not produce multiple outputs for same inputs

This commit adds support for such use cases.