### PR TITLE
Add trusted_artifacts.workspaces rule to task ns

### DIFF
--- a/antora/docs/modules/ROOT/pages/task_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/task_policy.adoc
@@ -109,3 +109,14 @@ Trusted Artifact results follow the expected naming convention.
 * FAILURE message: `The result %q of the Task %q does not use the _ARTIFACT suffix`
 * Code: `trusted_artifacts.result`
 * https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/task/trusted_artifacts.rego#L28[Source, window="_blank"]
+
+[#trusted_artifacts__workspace]
+=== link:#trusted_artifacts__workspace[Workspace]
+
+Tasks that implement the Trusted Artifacts pattern should not allow general purpose workspaces to share data. Instead, data should be passed around via Trusted Artifacts. Workspaces used for other purposes, e.g. provide auth credentials, are allowed. Use the rule data key `allowed_trusted_artifacts_workspaces` to specify which workspace names are allowed. By default this value is empty which effectively disallows any workspace.
+
+* Rule type: [rule-type-indicator failure]#FAILURE#
+* FAILURE message: `General purpose workspace %q is not allowed`
+* Code: `trusted_artifacts.workspace`
+* Effective from: `2024-07-07T00:00:00Z`
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/task/trusted_artifacts.rego#L41[Source, window="_blank"]

--- a/antora/docs/modules/ROOT/partials/task_policy_nav.adoc
+++ b/antora/docs/modules/ROOT/partials/task_policy_nav.adoc
@@ -10,3 +10,4 @@
 ** xref:task_policy.adoc#trusted_artifacts_package[Trusted Artifacts Conventions]
 *** xref:task_policy.adoc#trusted_artifacts__parameter[Parameter]
 *** xref:task_policy.adoc#trusted_artifacts__result[Result]
+*** xref:task_policy.adoc#trusted_artifacts__workspace[Workspace]


### PR DESCRIPTION
This commit adds a new policy rule, `trusted_artifacts.workspaces`, under the `task` namespace. Its purpose is to disallow general purpose workspaces from being used by Tasks that implement the Trusted Artifacts pattern.

Ref: EC-658