### PR TITLE
Make slsa_source_correlated generic 

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -1127,12 +1127,12 @@ Confirm the expected rule data keys have been provided in the expected format. T
 [#slsa_source_correlated__source_code_reference_provided]
 === link:#slsa_source_correlated__source_code_reference_provided[Source code reference provided]
 
-Warn if the expected source code reference is not provided.
+Check if the expected source code reference is provided.
 
 *Solution*: Provide the expected source code reference in inputs.
 
-* Rule type: [rule-type-indicator warning]#WARNING#
-* WARNING message: `Expected source code reference was not provided for verification`
+* Rule type: [rule-type-indicator failure]#FAILURE#
+* FAILURE message: `Expected source code reference was not provided for verification`
 * Code: `slsa_source_correlated.source_code_reference_provided`
 * https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/slsa_source_correlated.rego#L23[Source, window="_blank"]
 

--- a/policy/release/lib/attestations.rego
+++ b/policy/release/lib/attestations.rego
@@ -4,6 +4,10 @@ import rego.v1
 
 import data.lib.tkn
 
+slsa_provenance_predicate_type_v1 := "https://slsa.dev/provenance/v1"
+
+slsa_provenance_predicate_type_v02 := "https://slsa.dev/provenance/v0.2"
+
 tekton_pipeline_run := "tekton.dev/v1beta1/PipelineRun"
 
 pipelinerun_att_build_types := {
@@ -37,6 +41,11 @@ java_sbom_component_count_result_name := "SBOM_JAVA_COMPONENTS_COUNT"
 
 build_base_images_digests_result_name := "BASE_IMAGES_DIGESTS"
 
+slsa_provenance_attestations := [att |
+	some att in input.attestations
+	att.statement.predicateType in {slsa_provenance_predicate_type_v1, slsa_provenance_predicate_type_v02}
+]
+
 # These are the ones we're interested in
 pipelinerun_attestations := att if {
 	v1_0 := [a |
@@ -58,7 +67,7 @@ pipelinerun_slsa_provenance02 := [att |
 # written for either.
 pipelinerun_slsa_provenance_v1 := [att |
 	some att in input.attestations
-	att.statement.predicateType == "https://slsa.dev/provenance/v1"
+	att.statement.predicateType == slsa_provenance_predicate_type_v1
 
 	att.statement.predicate.buildDefinition.buildType in slsav1_pipelinerun_att_build_types
 

--- a/policy/release/lib/attestations_test.rego
+++ b/policy/release/lib/attestations_test.rego
@@ -13,15 +13,30 @@ tr_build_type := "tekton.dev/v1beta1/TaskRun"
 
 tr_build_type_legacy := "https://tekton.dev/attestations/chains@v2"
 
-mock_pr_att := {"statement": {"predicate": {"buildType": pr_build_type}}}
+mock_pr_att := {"statement": {
+	"predicateType": "https://slsa.dev/provenance/v1",
+	"predicate": {"buildType": pr_build_type},
+}}
 
-mock_pr_att_legacy := {"statement": {"predicate": {"buildType": pr_build_type_legacy}}}
+mock_pr_att_legacy := {"statement": {
+	"predicateType": "https://slsa.dev/provenance/v0.2",
+	"predicate": {"buildType": pr_build_type_legacy},
+}}
 
-mock_tr_att := {"statement": {"predicate": {"buildType": tr_build_type}}}
+mock_tr_att := {"statement": {
+	"predicateType": "https://slsa.dev/provenance/v1",
+	"predicate": {"buildType": tr_build_type},
+}}
 
-mock_tr_att_legacy := {"statement": {"predicate": {"buildType": tr_build_type_legacy}}}
+mock_tr_att_legacy := {"statement": {
+	"predicateType": "https://slsa.dev/provenance/v0.2",
+	"predicate": {"buildType": tr_build_type_legacy},
+}}
 
-garbage_att := {"statement": {"predicate": {"buildType": "garbage"}}}
+garbage_att := {"statement": {
+	"predicateType": "https://oscar.sesame/v1",
+	"predicate": {"buildType": "garbage"},
+}}
 
 valid_slsav1_att := {"statement": {
 	"predicateType": "https://slsa.dev/provenance/v1",
@@ -139,6 +154,25 @@ test_tasks_from_pipelinerun if {
 	slsa02_task := {"name": "my-task", "ref": {"kind": "task"}}
 	slsa02_att := att_mock_task_helper(slsa02_task)
 	lib.assert_equal([slsa02_task], lib.tasks_from_pipelinerun) with input.attestations as slsa02_att
+}
+
+test_slsa_provenance_attestations if {
+	lib.assert_equal(lib.slsa_provenance_attestations, []) with input.attestations as []
+
+	attestations := [
+		mock_pr_att,
+		mock_pr_att_legacy,
+		mock_tr_att,
+		mock_tr_att_legacy,
+		garbage_att,
+	]
+	expected := [
+		mock_pr_att,
+		mock_pr_att_legacy,
+		mock_tr_att,
+		mock_tr_att_legacy,
+	]
+	lib.assert_equal(lib.slsa_provenance_attestations, expected) with input.attestations as attestations
 }
 
 test_pr_attestations if {

--- a/policy/release/slsa_source_correlated.rego
+++ b/policy/release/slsa_source_correlated.rego
@@ -23,7 +23,7 @@ nul := base64.decode("AA==")
 # METADATA
 # title: Source code reference provided
 # description: >-
-#   Warn if the expected source code reference is not provided.
+#   Check if the expected source code reference is provided.
 # custom:
 #   short_name: source_code_reference_provided
 #   failure_msg: Expected source code reference was not provided for verification
@@ -33,7 +33,7 @@ nul := base64.decode("AA==")
 #   - minimal
 #   - slsa3
 #   - redhat
-warn contains result if {
+deny contains result if {
 	source := object.get(input, ["image", "source"], {})
 	count(source) == 0
 

--- a/policy/release/slsa_source_correlated.rego
+++ b/policy/release/slsa_source_correlated.rego
@@ -173,7 +173,7 @@ _expected_sources contains expected_source if {
 
 # SLSA Provenance v0.2
 _source_references contains ref if {
-	some att in lib.pipelinerun_attestations
+	some att in lib.slsa_provenance_attestations
 	some material in att.statement.predicate.materials
 	some digest_alg in object.keys(material.digest)
 	some supported_vcs_type in lib.rule_data("supported_vcs")
@@ -191,7 +191,7 @@ _source_references contains ref if {
 
 # SLSA Provenance v1.0
 _source_references contains ref if {
-	some att in lib.pipelinerun_slsa_provenance_v1
+	some att in lib.slsa_provenance_attestations
 
 	# regal ignore:prefer-snake-case
 	some dep in att.statement.predicate.buildDefinition.resolvedDependencies

--- a/policy/release/slsa_source_correlated_test.rego
+++ b/policy/release/slsa_source_correlated_test.rego
@@ -383,6 +383,20 @@ test_slsa_v10_source_references if {
 	]
 }
 
+test_slsa_v02_ignore_irrelevant_attestations if {
+	good_att := _source_material_attestation("git+https://git.repository", "ref")
+	irrelevant_att := _material_attestation([])
+	lib.assert_empty(slsa_source_correlated.deny) with input.image as expected
+		with input.attestations as [good_att, irrelevant_att]
+}
+
+test_slsa_v10_ignore_irrelevant_attestations if {
+	good_att := _source_resolved_dependencies_attestation("git+https://git.repository", "ref")
+	irrelevant_att := _resolved_dependencies_attestation([])
+	lib.assert_empty(slsa_source_correlated.deny) with input.image as expected
+		with input.attestations as [good_att, irrelevant_att]
+}
+
 test_rule_data_provided if {
 	d := {
 		"supported_digests": [
@@ -453,10 +467,13 @@ test_refs if {
 expected := {"source": {"git": {"url": "https://git.repository", "revision": "ref"}}}
 
 # SLSA Provenance v0.2
-_material_attestation(materials) := {"statement": {"predicate": {
-	"buildType": lib.tekton_pipeline_run,
-	"materials": materials,
-}}}
+_material_attestation(materials) := {"statement": {
+	"predicateType": "https://slsa.dev/provenance/v0.2",
+	"predicate": {
+		"buildType": lib.tekton_pipeline_run,
+		"materials": materials,
+	},
+}}
 
 # SLSA Provenance v0.2
 _source_material_attestation(uri, sha1) := _material_attestation([{

--- a/policy/release/slsa_source_correlated_test.rego
+++ b/policy/release/slsa_source_correlated_test.rego
@@ -5,18 +5,23 @@ import rego.v1
 import data.lib
 import data.policy.release.slsa_source_correlated
 
-test_warn_missing_source_code_happy_day if {
-	lib.assert_empty(slsa_source_correlated.warn) with input.image as {"source": {"something": "here"}}
+test_deny_missing_source_code_happy_day if {
+	lib.assert_empty(slsa_source_correlated.deny) with input.image as {"source": {"something": "here"}}
+		with input.attestations as [_source_material_attestation("git+https://git.repository", "ref")]
 }
 
-test_warn_missing_expected_source_code_reference if {
+test_deny_missing_expected_source_code_reference if {
+	attestations := [_source_material_attestation("git+https://git.repository", "ref")]
 	expected := {{
 		"code": "slsa_source_correlated.source_code_reference_provided",
 		"msg": "Expected source code reference was not provided for verification",
 	}}
-	lib.assert_equal_results(slsa_source_correlated.warn, expected) with input as {}
-	lib.assert_equal_results(slsa_source_correlated.warn, expected) with input.image as {}
-	lib.assert_equal_results(slsa_source_correlated.warn, expected) with input.image as {"source": {}}
+	lib.assert_equal_results(slsa_source_correlated.deny, expected) with input as {}
+		with input.attestations as attestations
+	lib.assert_equal_results(slsa_source_correlated.deny, expected) with input.image as {}
+		with input.attestations as attestations
+	lib.assert_equal_results(slsa_source_correlated.deny, expected) with input.image as {"source": {}}
+		with input.attestations as attestations
 }
 
 test_deny_material_code_reference if {


### PR DESCRIPTION
This PR includes two related changes:

```
Make slsa_source_correlated generic 

This commit modifies the rules in the `slsa_source_correlated` package
so they work with any SLSA Provenance attestation regardless of the
producer. Prior to this change, only attestations generated by Tekton
Chains were taken into account.
```

```
Make source_code_reference_provided a failure 

Prior to this commit, the
`slsa_source_correlated.source_code_reference_provided` policy rule
generated a warning if the expected source code reference was not
provided in the input. When that information is not available, the other
policy rules in the package will pass because there is nothing to match
against. Given that it's easy to ignore errors in different contexts,
this behavior may give users a false sense of security.

This commit changes the policy rule to emit a violation instead of a
warning, making it obvious when an incorrect validation call needs to be
corrected.
```

These essentially bring in the validations provided by [this](https://gitlab.com/lucarval/simple-ec-policies/-/blob/main/policies/gitlab_slsa_provenance.rego?ref_type=heads) sample policy package. 

Ref: EC-679
