### PR TITLE
Merge rule_data.trusted_tasks into trusted_tasks

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -1632,7 +1632,7 @@ Each test result is expected to have a `results` key. Verify that the `results` 
 [#trusted_task_package]
 == link:#trusted_task_package[Trusted Task checks]
 
-This package is used to verify all the Tekton Tasks involved in building the image are trusted. Trust is established by comparing the Task references found in the SLSA Provenance with the pre-defined list of trusted Tasks. The list is customized via the `trusted_tasks` rule data key.
+This package is used to verify all the Tekton Tasks involved in building the image are trusted. Trust is established by comparing the Task references found in the SLSA Provenance with a pre-defined list of trusted Tasks, which is expected to be provided as a data source that creates the `data.trusted_tasks` in the format demonstrated at https://github.com/enterprise-contract/ec-policies/blob/main/example/data/trusted_tekton_tasks.yml. The list can be extended or customized using the `trusted_tasks` rule data key which is merged into the `trusted_tasks` data.
 
 * Package name: `trusted_task`
 * Package full path: `policy.release.trusted_task`
@@ -1648,7 +1648,7 @@ Check if all Tekton Tasks use a Task definition by a pinned reference. When usin
 * WARNING message: `Pipeline task %q uses an unpinned task reference, %s`
 * Code: `trusted_task.pinned`
 * Effective from: `2024-05-07T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task.rego#L21[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task.rego#L25[Source, window="_blank"]
 
 [#trusted_task__data]
 === link:#trusted_task__data[Task tracking data was provided]
@@ -1661,7 +1661,7 @@ Confirm the `trusted_tasks` rule data was provided, since it's required by the p
 * FAILURE message: `Missing required trusted_tasks data`
 * Code: `trusted_task.data`
 * Effective from: `2024-05-07T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task.rego#L131[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task.rego#L135[Source, window="_blank"]
 
 [#trusted_task__trusted]
 === link:#trusted_task__trusted[Tasks are trusted]
@@ -1674,7 +1674,7 @@ Check the trust of the Tekton Tasks used in the build Pipeline. There are two mo
 * FAILURE message: `%s`
 * Code: `trusted_task.trusted`
 * Effective from: `2024-05-07T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task.rego#L68[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task.rego#L72[Source, window="_blank"]
 
 [#trusted_task__current]
 === link:#trusted_task__current[Tasks using the latest versions]
@@ -1687,7 +1687,7 @@ Check if all Tekton Tasks use the latest known Task reference.
 * WARNING message: `Pipeline task %q uses an out of date task reference, %s`
 * Code: `trusted_task.current`
 * Effective from: `2024-05-07T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task.rego#L46[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task.rego#L50[Source, window="_blank"]
 
 [#trusted_task__valid_trusted_artifact_inputs]
 === link:#trusted_task__valid_trusted_artifact_inputs[Trusted Artifact produced in pipeline]
@@ -1699,7 +1699,7 @@ All input trusted artifacts must be produced on the pipeline. If they are not th
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Code tampering detected, input %q for task %q was not produced by the pipeline as attested.`
 * Code: `trusted_task.valid_trusted_artifact_inputs`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task.rego#L94[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task.rego#L98[Source, window="_blank"]
 
 [#trusted_task__trusted_parameters]
 === link:#trusted_task__trusted_parameters[Trusted parameters]
@@ -1712,7 +1712,7 @@ Confirm certain parameters provided to each builder Task have come from trusted 
 * FAILURE message: `The %q parameter of the %q PipelineTask includes an untrusted digest: %s`
 * Code: `trusted_task.trusted_parameters`
 * Effective from: `2021-07-04T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task.rego#L150[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task.rego#L154[Source, window="_blank"]
 
 [#rpm_ostree_task_package]
 == link:#rpm_ostree_task_package[rpm-ostree Task]

--- a/policy/lib/rule_data.rego
+++ b/policy/lib/rule_data.rego
@@ -85,6 +85,11 @@ rule_data_defaults := {
 	# Some checks are influenced by this value. Let's use null as a default instead
 	# of the usual empty list.
 	"pipeline_intention": null,
+	# The big list of trusted_tasks (from the acceptable tasks bundle) is at
+	# data.trusted_tasks but we want to allow people to add their own trusted_tasks
+	# using the ruleData key. Make this default to an empty dict so we can conveniently
+	# merge it with with `data.trusted_tasks`
+	"trusted_tasks": {},
 }
 
 # Returns the "first found" of the following:

--- a/policy/lib/tekton/trusted.rego
+++ b/policy/lib/tekton/trusted.rego
@@ -5,6 +5,9 @@ import rego.v1
 import data.lib.refs
 import data.lib.time as time_lib
 
+# regal ignore:prefer-package-imports
+import data.lib.rule_data as lib_rule_data
+
 # Returns a subset of tasks that use unpinned Task references.
 unpinned_task_references(tasks) := {task |
 	some task in tasks
@@ -62,6 +65,9 @@ _newer_record_exists(task) if {
 # _trusted_tasks provides a safe way to access the list of trusted tasks. It prevents a policy rule
 # from incorrectly not evaluating due to missing data. It also removes stale records.
 _trusted_tasks[key] := pruned_records if {
-	some key, records in data.trusted_tasks
+	some key, records in _trusted_tasks_data
 	pruned_records := time_lib.acceptable_items(records)
 }
+
+# Merging in the trusted_tasks rule data makes it easier for users to customize their trusted tasks
+_trusted_tasks_data := object.union(data.trusted_tasks, lib_rule_data("trusted_tasks"))

--- a/policy/lib/tekton/trusted_test.rego
+++ b/policy/lib/tekton/trusted_test.rego
@@ -64,6 +64,13 @@ test_is_trusted_task if {
 	tkn.is_trusted_task(newest_trusted_git_task) with data.trusted_tasks as future_trusted_tasks
 }
 
+test_rule_data_merging if {
+	lib.assert_equal(tkn._trusted_tasks_data.foo, "baz") with data.trusted_tasks as {"foo": "baz"}
+
+	lib.assert_equal(tkn._trusted_tasks_data.foo, "bar") with data.trusted_tasks as {"foo": "baz"}
+		with data.rule_data.trusted_tasks as {"foo": "bar"}
+}
+
 trusted_bundle_task := {"spec": {"taskRef": {"resolver": "bundles", "params": [
 	{"name": "bundle", "value": "registry.local/trusty:1.0@sha256:digest"},
 	{"name": "name", "value": "trusty"},

--- a/policy/release/trusted_task.rego
+++ b/policy/release/trusted_task.rego
@@ -3,8 +3,12 @@
 # title: Trusted Task checks
 # description: >-
 #   This package is used to verify all the Tekton Tasks involved in building the image are trusted.
-#   Trust is established by comparing the Task references found in the SLSA Provenance with the
-#   pre-defined list of trusted Tasks. The list is customized via the `trusted_tasks` rule data key.
+#   Trust is established by comparing the Task references found in the SLSA Provenance with a
+#   pre-defined list of trusted Tasks, which is expected to be provided as a data source that
+#   creates the `data.trusted_tasks` in the format demonstrated at
+#   https://github.com/enterprise-contract/ec-policies/blob/main/example/data/trusted_tekton_tasks.yml.
+#   The list can be extended or customized using the `trusted_tasks` rule data key which is merged
+#   into the `trusted_tasks` data.
 #
 package policy.release.trusted_task
 


### PR DESCRIPTION
Ernesto (reasonably IMO) assumed that this would work and I can't think of a good reason that it shouldn't, especially since it's such a small change.

It's true that we're moving towards the "trusted artifacts", aka "-oci-ta" tasks which mean we can permit custom tasks without requiring they they are trusted. But still, it's reasonable for teams to want to ensure their custom tasks are trusted, so I like the idea of make it more convenient.

Ref: [EC-709](https://issues.redhat.com/browse/EC-709)