### PR TITLE
Redefine DOCKERFILE parameter check

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -102,7 +102,6 @@ Rules included:
 * xref:release_policy.adoc#base_image_registries__allowed_registries_provided[Base image checks: Allowed base image registry prefixes list was provided]
 * xref:release_policy.adoc#base_image_registries__base_image_permitted[Base image checks: Base image comes from permitted registry]
 * xref:release_policy.adoc#base_image_registries__base_image_info_found[Base image checks: Base images provided]
-* xref:release_policy.adoc#buildah_build_task__buildah_task_has_dockerfile_param[Buildah build task: Buildah task has Dockerfile param defined]
 * xref:release_policy.adoc#buildah_build_task__buildah_uses_local_dockerfile[Buildah build task: Buildah task uses a local Dockerfile]
 * xref:release_policy.adoc#cve__cve_blockers[CVE checks: Blocking CVE check]
 * xref:release_policy.adoc#cve__unpatched_cve_blockers[CVE checks: Blocking unpatched CVE check]
@@ -323,18 +322,6 @@ This package is responsible for verifying the buildah build task
 * Package name: `buildah_build_task`
 * Package full path: `policy.release.buildah_build_task`
 
-[#buildah_build_task__buildah_task_has_dockerfile_param]
-=== link:#buildah_build_task__buildah_task_has_dockerfile_param[Buildah task has Dockerfile param defined]
-
-Verify that a DOCKERFILE parameter was provided to the buildah task.
-
-*Solution*: Make sure the buildah task has a parameter named 'DOCKERFILE'.
-
-* Rule type: [rule-type-indicator failure]#FAILURE#
-* FAILURE message: `The pipeline task %q does not contain the DOCKERFILE param. This is a requirement for the underlying task %q`
-* Code: `buildah_build_task.buildah_task_has_dockerfile_param`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/buildah_build_task.rego#L13[Source, window="_blank"]
-
 [#buildah_build_task__buildah_uses_local_dockerfile]
 === link:#buildah_build_task__buildah_uses_local_dockerfile[Buildah task uses a local Dockerfile]
 
@@ -345,7 +332,7 @@ Verify the Dockerfile used in the buildah task was not fetched from an external 
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `DOCKERFILE param value (%s) is an external source`
 * Code: `buildah_build_task.buildah_uses_local_dockerfile`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/buildah_build_task.rego#L40[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/buildah_build_task.rego#L14[Source, window="_blank"]
 
 [#attestation_package]
 == link:#attestation_package[Builtin attestation policies]

--- a/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
+++ b/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
@@ -17,7 +17,6 @@
 **** xref:release_policy.adoc#base_image_registries__base_image_permitted[Base image comes from permitted registry]
 **** xref:release_policy.adoc#base_image_registries__base_image_info_found[Base images provided]
 *** xref:release_policy.adoc#buildah_build_task_package[Buildah build task]
-**** xref:release_policy.adoc#buildah_build_task__buildah_task_has_dockerfile_param[Buildah task has Dockerfile param defined]
 **** xref:release_policy.adoc#buildah_build_task__buildah_uses_local_dockerfile[Buildah task uses a local Dockerfile]
 *** xref:release_policy.adoc#attestation_package[Builtin attestation policies]
 **** xref:release_policy.adoc#attestation__signature_check[Attestation signature]

--- a/policy/lib/tekton/task_test.rego
+++ b/policy/lib/tekton/task_test.rego
@@ -49,74 +49,45 @@ test_tasks_from_slsav1_tekton_attestation if {
 			"resolvedDependencies": [task],
 		}},
 	}}
-	expected := {{
-		"params": [
-			{
-				"name": "IMAGE",
-				"value": "quay.io/jstuart/hacbs-docker-build",
-			},
-			{
-				"name": "DOCKERFILE",
-				"value": "./image_with_labels/Dockerfile",
-			},
-		],
-		"podTemplate": {
-			"imagePullSecrets": [{"name": "docker-chains"}],
-			"securityContext": {"fsGroup": 65532},
-		},
-		"serviceAccountName": "default", "taskRef": {
-			"kind": "Task",
-			"name": "buildah",
-		},
-		"timeout": "1h0m0s", "workspaces": [
-			{
-				"name": "source",
-				"persistentVolumeClaim": {"claimName": "pvc-bf2ed289ae"},
-			},
-			{
-				"name": "dockerconfig",
-				"secret": {"secretName": "docker-credentials"},
-			},
-		],
-	}}
+	expected := {slsav1_attestation_local_spec}
 	lib.assert_equal(expected, tkn.tasks(attestation))
 }
 
 # regal ignore:rule-length
 test_tasks_from_slsav1_tekton_mixture_attestation if {
-	task1 := base64.encode(json.marshal(json.patch(slsav1_attestation_local_spec, [{
+	task1 := json.patch(slsav1_attestation_local_spec, [{
 		"op": "add",
 		"path": "/taskRef/name",
 		"value": "task1",
-	}])))
-	task2 := base64.encode(json.marshal(json.patch(slsav1_attestation_local_spec, [{
+	}])
+	task2 := json.patch(slsav1_attestation_local_spec, [{
 		"op": "add",
 		"path": "/taskRef/name",
 		"value": "task2",
-	}])))
-	task3 := base64.encode(json.marshal(json.patch(slsav1_attestation_local_spec, [{
+	}])
+	task3 := json.patch(slsav1_attestation_local_spec, [{
 		"op": "add",
 		"path": "/taskRef/name",
 		"value": "task3",
-	}])))
+	}])
 
 	git_init := {
 		"name": "task",
 		"uri": "oci://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
 		"digest": {"sha256": "28ff94e63e4058afc3f15b4c11c08cf3b54fa91faa646a4bbac90380cd7158df"},
-		"content": task1,
+		"content": base64.encode(json.marshal(task1)),
 	}
 	git_init_pipeline := {
 		"name": "pipelineTask",
 		"uri": "oci://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
 		"digest": {"sha256": "28ff94e63e4058afc3f15b4c11c08cf3b54fa91faa646a4bbac90380cd7158df"},
-		"content": task2,
+		"content": base64.encode(json.marshal(task2)),
 	}
 	git_init_bad := {
 		"name": "pipeline",
 		"uri": "oci://gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
 		"digest": {"sha256": "28ff94e63e4058afc3f15b4c11c08cf3b54fa91faa646a4bbac90380cd7158df"},
-		"content": task3,
+		"content": base64.encode(json.marshal(task3)),
 	}
 
 	attestation := {"statement": {"predicate": {"buildDefinition": {
@@ -128,48 +99,8 @@ test_tasks_from_slsav1_tekton_mixture_attestation if {
 		],
 	}}}}
 	expected := {
-		{
-			"params": [
-				{
-					"name": "IMAGE",
-					"value": "quay.io/jstuart/hacbs-docker-build",
-				},
-				{
-					"name": "DOCKERFILE",
-					"value": "./image_with_labels/Dockerfile",
-				},
-			],
-			"podTemplate": {
-				"imagePullSecrets": [{"name": "docker-chains"}],
-				"securityContext": {"fsGroup": 65532},
-			},
-			"serviceAccountName": "default", "taskRef": {
-				"kind": "Task",
-				"name": "task1",
-			},
-			"timeout": "1h0m0s", "workspaces": [
-				{"name": "source", "persistentVolumeClaim": {"claimName": "pvc-bf2ed289ae"}},
-				{"name": "dockerconfig", "secret": {"secretName": "docker-credentials"}},
-			],
-		},
-		{
-			"params": [
-				{
-					"name": "IMAGE",
-					"value": "quay.io/jstuart/hacbs-docker-build",
-				},
-				{"name": "DOCKERFILE", "value": "./image_with_labels/Dockerfile"},
-			],
-			"podTemplate": {
-				"imagePullSecrets": [{"name": "docker-chains"}],
-				"securityContext": {"fsGroup": 65532},
-			},
-			"serviceAccountName": "default",
-			"taskRef": {"kind": "Task", "name": "task2"}, "timeout": "1h0m0s", "workspaces": [
-				{"name": "source", "persistentVolumeClaim": {"claimName": "pvc-bf2ed289ae"}},
-				{"name": "dockerconfig", "secret": {"secretName": "docker-credentials"}},
-			],
-		},
+		task1,
+		task2,
 	}
 	lib.assert_equal(expected, tkn.tasks(attestation))
 }

--- a/policy/lib/tekton/task_test.rego
+++ b/policy/lib/tekton/task_test.rego
@@ -695,6 +695,18 @@ slsav1_attestation_local_spec := {
 		"securityContext": {"fsGroup": 65532},
 		"imagePullSecrets": [{"name": "docker-chains"}],
 	},
+	"results": [
+		{
+			"name": "IMAGE_DIGEST",
+			"type": "string",
+			"value": "sha256:hash",
+		},
+		{
+			"name": "IMAGE_URL",
+			"type": "string",
+			"value": "quay.io/jstuart/hacbs-docker-build:tag@sha256:hash",
+		},
+	],
 	"workspaces": [
 		{
 			"name": "source",


### PR DESCRIPTION
The policy no longer requires that the buildah Task is named "buildah", but rather looks at the Tasks that build images and selects those that have the `DOCKERFILE` parameter instead. With that the rule `buildah_task_has_dockerfile_param` doesn't make much sense any more and it has been removed.

Resolves: #1027