### PR TITLE
Expect pinned references in input snapshot for operators

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -130,6 +130,7 @@ Rules included:
 * xref:release_policy.adoc#olm__inaccessible_snapshot_references[OLM: Unable to access images in the input snapshot]
 * xref:release_policy.adoc#olm__unmapped_references[OLM: Unmapped images in OLM bundle]
 * xref:release_policy.adoc#olm__unpinned_references[OLM: Unpinned images in OLM bundle]
+* xref:release_policy.adoc#olm__unpinned_snapshot_references[OLM: Unpinned images in input snapshot]
 * xref:release_policy.adoc#provenance_materials__git_clone_source_matches_provenance[Provenance Materials: Git clone source matches materials provenance]
 * xref:release_policy.adoc#provenance_materials__git_clone_task_found[Provenance Materials: Git clone task found]
 * xref:release_policy.adoc#quay_expiration__expires_label[Quay expiration: Expires label]
@@ -831,8 +832,8 @@ Check the input snapshot and make sure all the images are accessible.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `The %q image reference is not accessible in the input snapshot.`
 * Code: `olm.inaccessible_snapshot_references`
-* Effective from: `2024-08-01T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm.rego#L125[Source, window="_blank"]
+* Effective from: `2024-08-15T00:00:00Z`
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm.rego#L155[Source, window="_blank"]
 
 [#olm__unmapped_references]
 === link:#olm__unmapped_references[Unmapped images in OLM bundle]
@@ -844,8 +845,8 @@ Check the OLM bundle image for the presence of unmapped image references. Unmapp
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `The %q CSV image reference is not in the snapshot or accessible.`
 * Code: `olm.unmapped_references`
-* Effective from: `2024-08-01T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm.rego#L147[Source, window="_blank"]
+* Effective from: `2024-08-15T00:00:00Z`
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm.rego#L177[Source, window="_blank"]
 
 [#olm__unpinned_references]
 === link:#olm__unpinned_references[Unpinned images in OLM bundle]
@@ -858,6 +859,19 @@ Check the OLM bundle image for the presence of unpinned image references. Unpinn
 * FAILURE message: `The %q image reference is not pinned at %s.`
 * Code: `olm.unpinned_references`
 * https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm.rego#L37[Source, window="_blank"]
+
+[#olm__unpinned_snapshot_references]
+=== link:#olm__unpinned_snapshot_references[Unpinned images in input snapshot]
+
+Check the input snapshot for the presence of unpinned image references. Unpinned image pull references are references to images that do not contain a digest -- uniquely identifying the version of the image being pulled.
+
+*Solution*: Update the input snapshot replacing the unpinned image reference with pinned image reference. Pinned image reference contains the image digest.
+
+* Rule type: [rule-type-indicator failure]#FAILURE#
+* FAILURE message: `The %q image reference is not pinned in the input snapshot.`
+* Code: `olm.unpinned_snapshot_references`
+* Effective from: `2024-08-15T00:00:00Z`
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm.rego#L125[Source, window="_blank"]
 
 [#provenance_materials_package]
 == link:#provenance_materials_package[Provenance Materials]

--- a/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
+++ b/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
@@ -66,6 +66,7 @@
 **** xref:release_policy.adoc#olm__inaccessible_snapshot_references[Unable to access images in the input snapshot]
 **** xref:release_policy.adoc#olm__unmapped_references[Unmapped images in OLM bundle]
 **** xref:release_policy.adoc#olm__unpinned_references[Unpinned images in OLM bundle]
+**** xref:release_policy.adoc#olm__unpinned_snapshot_references[Unpinned images in input snapshot]
 *** xref:release_policy.adoc#provenance_materials_package[Provenance Materials]
 **** xref:release_policy.adoc#provenance_materials__git_clone_source_matches_provenance[Git clone source matches materials provenance]
 **** xref:release_policy.adoc#provenance_materials__git_clone_task_found[Git clone task found]


### PR DESCRIPTION
Instead of trying to resolve the input components, expect pinned references.