### PR TITLE
Consider finding counts in addition to status

### DIFF
--- a/policy/release/test.rego
+++ b/policy/release/test.rego
@@ -32,7 +32,7 @@ import data.lib.image
 #   - test.test_data_found
 #
 warn contains result if {
-	some test in resulted_in(lib.rule_data("failed_tests_results"))
+	some test in _resulted_in(lib.rule_data("failed_tests_results"), "failures")
 	test in lib.rule_data("informative_tests")
 	result := lib.result_helper_with_term(rego.metadata.chain(), [test], test)
 }
@@ -56,7 +56,7 @@ warn contains result if {
 #   - test.test_data_found
 #
 warn contains result if {
-	some test in resulted_in(lib.rule_data("warned_tests_results"))
+	some test in _resulted_in(lib.rule_data("warned_tests_results"), "warnings")
 	result := lib.result_helper_with_term(rego.metadata.chain(), [test], test)
 }
 
@@ -157,7 +157,7 @@ deny contains result if {
 #   - test.test_data_found
 #
 deny contains result if {
-	some test in resulted_in(lib.rule_data("failed_tests_results"))
+	some test in _resulted_in(lib.rule_data("failed_tests_results"), "failures")
 	not test in lib.rule_data("informative_tests")
 	result := lib.result_helper_with_term(rego.metadata.chain(), [test], test)
 }
@@ -180,7 +180,7 @@ deny contains result if {
 #   - test.test_data_found
 #
 deny contains result if {
-	some test in resulted_in(lib.rule_data("erred_tests_results"))
+	some test in _resulted_in(lib.rule_data("erred_tests_results"), "n/a")
 	result := lib.result_helper_with_term(rego.metadata.chain(), [test], test)
 }
 
@@ -206,7 +206,7 @@ deny contains result if {
 #   effective_on: 2023-12-08T00:00:00Z
 #
 deny contains result if {
-	some test in resulted_in(lib.rule_data("skipped_tests_results"))
+	some test in _resulted_in(lib.rule_data("skipped_tests_results"), "n/a")
 	result := lib.result_helper_with_term(rego.metadata.chain(), [test], test)
 }
 
@@ -258,12 +258,20 @@ deny contains result if {
 	)
 }
 
+_did_result(test, results, _) if {
+	test.result in results
+}
+
+_did_result(test, _, key) if {
+	test[key] > 0
+}
+
 # Collect all tests that have resulted with one of the given
 # results and convert their name to "test:<name>" format
-resulted_in(results) := {r |
+_resulted_in(results, key) := {r |
 	some result in lib.results_from_tests
 	test := result.value
-	test.result in results
+	_did_result(test, results, key)
 	r := result.name
 }
 

--- a/policy/release/test_test.rego
+++ b/policy/release/test_test.rego
@@ -536,4 +536,52 @@ test_rule_data_provided if {
 	lib.assert_equal_results(test.deny, expected) with data.rule_data as d
 }
 
+test_results_and_counts if {
+	task1 := tkn_test.slsav1_task_result_ref("task1", [{
+		"name": lib.task_test_result_name,
+		"type": "string",
+		"value": {"result": "ERROR", "failures": 1, "warnings": 2, "successes": 3},
+	}])
+	task2 := tkn_test.slsav1_task_result_ref("task2", [{
+		"name": lib.task_test_result_name,
+		"type": "string",
+		"value": {"result": "FAILURE", "failures": 1, "warnings": 0, "successes": 3},
+	}])
+	task3 := tkn_test.slsav1_task_result_ref("task3", [{
+		"name": lib.task_test_result_name,
+		"type": "string",
+		"value": {"result": "SUCCESS", "failures": 0, "warnings": 2, "successes": 3},
+	}])
+	attestations := [lib_test.mock_slsav1_attestation_with_tasks([task1, task2, task3])]
+	lib.assert_equal_results(test.deny, {
+		{
+			"code": "test.no_erred_tests",
+			"msg": `The Task "task1" from the build Pipeline reports a test erred`,
+			"term": "task1",
+		},
+		{
+			"code": "test.no_failed_tests",
+			"msg": `The Task "task1" from the build Pipeline reports a failed test`,
+			"term": "task1",
+		},
+		{
+			"code": "test.no_failed_tests",
+			"msg": `The Task "task2" from the build Pipeline reports a failed test`,
+			"term": "task2",
+		},
+	}) with input.attestations as attestations
+	lib.assert_equal_results(test.warn, {
+		{
+			"code": "test.no_test_warnings",
+			"msg": `The Task "task1" from the build Pipeline reports a test contains warnings`,
+			"term": "task1",
+		},
+		{
+			"code": "test.no_test_warnings",
+			"msg": `The Task "task3" from the build Pipeline reports a test contains warnings`,
+			"term": "task3",
+		},
+	}) with input.attestations as attestations
+}
+
 _bundle := "registry.img/spam@sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb"


### PR DESCRIPTION
The status held in the `result` field of the test output is what was solely considered, so when a test resulted in ERROR (`"result": "ERROR"`) but in addition to that also had failures, e.g. `"result": "ERROR", "failures": 3` the failures were not reported.

This changes the logic so that the individual finding counts are reported as well as the outcome held in `result` field.

Reference: https://issues.redhat.com/browse/EC-620