### PR TITLE
Verify operator CSV images are from allowed registries

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -123,6 +123,7 @@ Rules included:
 * xref:release_policy.adoc#labels__rule_data_provided[Labels: Rule data provided]
 * xref:release_policy.adoc#olm__csv_semver_format[OLM: ClusterServiceVersion semver format]
 * xref:release_policy.adoc#olm__feature_annotations_format[OLM: Feature annotations have expected value]
+* xref:release_policy.adoc#olm__allowed_registries[OLM: Images referenced by OLM bundle are from allowed registries]
 * xref:release_policy.adoc#olm__required_olm_features_annotations_provided[OLM: Required OLM feature annotations list provided]
 * xref:release_policy.adoc#olm__subscriptions_annotation_format[OLM: Subscription annotation has expected value]
 * xref:release_policy.adoc#olm__inaccessible_snapshot_references[OLM: Unable to access images in the input snapshot]
@@ -805,6 +806,19 @@ Check the feature annotations in the ClusterServiceVersion manifest of the OLM b
 * FAILURE message: `The annotation %q is either missing or has an unexpected value`
 * Code: `olm.feature_annotations_format`
 * https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm.rego#L63[Source, window="_blank"]
+
+[#olm__allowed_registries]
+=== link:#olm__allowed_registries[Images referenced by OLM bundle are from allowed registries]
+
+Each image referenced by the OLM bundle should match an entry in the list of prefixes defined by the rule data key `allowed_registry_prefixes` in your policy configuration.
+
+*Solution*: Use image from an allowed registry, or modify your xref:ec-cli:ROOT:configuration.adoc#_data_sources[policy configuration] to include additional registry prefixes.
+
+* Rule type: [rule-type-indicator failure]#FAILURE#
+* FAILURE message: `The %q CSV image reference is not from an allowed registry.`
+* Code: `olm.allowed_registries`
+* Effective from: `2024-09-01T00:00:00Z`
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm.rego#L218[Source, window="_blank"]
 
 [#olm__required_olm_features_annotations_provided]
 === link:#olm__required_olm_features_annotations_provided[Required OLM feature annotations list provided]

--- a/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
+++ b/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
@@ -62,6 +62,7 @@
 *** xref:release_policy.adoc#olm_package[OLM]
 **** xref:release_policy.adoc#olm__csv_semver_format[ClusterServiceVersion semver format]
 **** xref:release_policy.adoc#olm__feature_annotations_format[Feature annotations have expected value]
+**** xref:release_policy.adoc#olm__allowed_registries[Images referenced by OLM bundle are from allowed registries]
 **** xref:release_policy.adoc#olm__required_olm_features_annotations_provided[Required OLM feature annotations list provided]
 **** xref:release_policy.adoc#olm__subscriptions_annotation_format[Subscription annotation has expected value]
 **** xref:release_policy.adoc#olm__inaccessible_snapshot_references[Unable to access images in the input snapshot]

--- a/policy/release/olm_test.rego
+++ b/policy/release/olm_test.rego
@@ -114,11 +114,13 @@ test_all_image_ref if {
 test_all_good if {
 	lib.assert_empty(olm.deny) with input.image.files as {"manifests/csv.yaml": manifest}
 		with input.image.config.Labels as {olm.manifestv1: "manifests/"}
+		with data.rule_data.allowed_registry_prefixes as ["registry.io"]
 }
 
 test_all_good_custom_dir if {
 	lib.assert_empty(olm.deny) with input.image.files as {"other/csv.yaml": manifest}
 		with input.image.config.Labels as {olm.manifestv1: "other/"}
+		with data.rule_data.allowed_registry_prefixes as ["registry.io"]
 }
 
 test_related_img_unpinned if {
@@ -137,6 +139,7 @@ test_related_img_unpinned if {
 
 	lib.assert_equal_results(olm.deny, expected) with input.image.files as {"manifests/csv.yaml": unpinned_manifest}
 		with input.image.config.Labels as {olm.manifestv1: "manifests/"}
+		with data.rule_data.allowed_registry_prefixes as ["registry.io"]
 }
 
 test_feature_annotations_format if {
@@ -187,6 +190,7 @@ test_feature_annotations_format if {
 
 	lib.assert_equal_results(olm.deny, expected) with input.image.files as {"manifests/csv.yaml": bad_manifest}
 		with input.image.config.Labels as {olm.manifestv1: "manifests/"}
+		with data.rule_data.allowed_registry_prefixes as ["registry.io"]
 }
 
 test_feature_annotations_format_custom_rule_data if {
@@ -203,6 +207,7 @@ test_feature_annotations_format_custom_rule_data if {
 	lib.assert_equal_results(olm.deny, expected) with input.image.files as {"manifests/csv.yaml": bad_manifest}
 		with input.image.config.Labels as {olm.manifestv1: "manifests/"}
 		with data.rule_data.required_olm_features_annotations as ["foo", "spam"]
+		with data.rule_data.allowed_registry_prefixes as ["registry.io"]
 }
 
 test_required_olm_features_annotations_provided if {
@@ -213,15 +218,16 @@ test_required_olm_features_annotations_provided if {
 	}}
 	lib.assert_equal_results(olm.deny, expected_empty) with input.image.files as {"manifests/csv.yaml": manifest}
 		with input.image.config.Labels as {olm.manifestv1: "manifests/"}
+		with data.rule_data.allowed_registry_prefixes as ["registry.io"]
 		with data.rule_data.required_olm_features_annotations as []
 
-	d := {"required_olm_features_annotations": [
+	d := [
 		# Wrong type
 		1,
 		# Duplicated items
 		"foo",
 		"foo",
-	]}
+	]
 
 	expected := {
 		{
@@ -247,7 +253,8 @@ test_required_olm_features_annotations_provided if {
 
 	lib.assert_equal_results(olm.deny, expected) with input.image.files as {"manifests/csv.yaml": manifest}
 		with input.image.config.Labels as {olm.manifestv1: "manifests/"}
-		with data.rule_data as d
+		with data.rule_data.allowed_registry_prefixes as ["registry.io"]
+		with data.rule_data.required_olm_features_annotations as d
 }
 
 test_csv_semver_format_bad_semver if {
@@ -260,6 +267,7 @@ test_csv_semver_format_bad_semver if {
 
 	lib.assert_equal_results(olm.deny, expected) with input.image.files as {"manifests/csv.yaml": csv}
 		with input.image.config.Labels as {olm.manifestv1: "manifests/"}
+		with data.rule_data.allowed_registry_prefixes as ["registry.io"]
 }
 
 test_csv_semver_format_missing if {
@@ -272,6 +280,7 @@ test_csv_semver_format_missing if {
 
 	lib.assert_equal_results(olm.deny, expected) with input.image.files as {"manifests/csv.yaml": csv}
 		with input.image.config.Labels as {olm.manifestv1: "manifests/"}
+		with data.rule_data.allowed_registry_prefixes as ["registry.io"]
 }
 
 test_subscriptions_annotation_format if {
@@ -312,6 +321,7 @@ test_subscriptions_annotation_format if {
 
 	lib.assert_equal_results(olm.deny, expected) with input.image.files as files
 		with input.image.config.Labels as {olm.manifestv1: "m/"}
+		with data.rule_data.allowed_registry_prefixes as ["registry.io"]
 }
 
 test_unpinned_snapshot_references_operator if {
@@ -321,14 +331,16 @@ test_unpinned_snapshot_references_operator if {
 		"term": "registry.io/repo/msd:no_digest",
 	}}
 	lib.assert_equal_results(olm.deny, expected) with input.snapshot.components as [unpinned_component, component1]
-		with data.rule_data as {"pipeline_intention": "release"}
+		with data.rule_data.pipeline_intention as "release"
+		with data.rule_data.allowed_registry_prefixes as ["registry.io"]
 		with ec.oci.image_manifest as `{"config": {"digest": "sha256:goat"}}`
 		with input.image.ref as unpinned_component.containerImage
 }
 
 test_unpinned_snapshot_references_different_input if {
 	lib.assert_empty(olm.deny) with input.snapshot.components as [unpinned_component]
-		with data.rule_data as {"pipeline_intention": "release"}
+		with data.rule_data.pipeline_intention as "release"
+		with data.rule_data.allowed_registry_prefixes as ["registry.io"]
 		with ec.oci.image_manifest as `{"config": {"digest": "sha256:goat"}}`
 		with input.image.ref as pinned2
 }
@@ -341,7 +353,8 @@ test_inaccessible_snapshot_references if {
 	}}
 
 	lib.assert_equal_results(olm.deny, expected) with input.snapshot.components as [component1]
-		with data.rule_data as {"pipeline_intention": "release"}
+		with data.rule_data.pipeline_intention as "release"
+		with data.rule_data.allowed_registry_prefixes as ["registry.io"]
 		with ec.oci.image_manifest as false
 }
 
@@ -354,7 +367,7 @@ test_unmapped_references_in_operator if {
 
 	lib.assert_equal_results(olm.deny, expected) with input.snapshot.components as [component1]
 		with input.image.files as {"manifests/csv.yaml": manifest}
-		with data.rule_data as {"pipeline_intention": "release"}
+		with data.rule_data as {"pipeline_intention": "release", "allowed_registry_prefixes": ["registry.io"]}
 		with ec.oci.image_manifest as mock_ec_oci_image_manifest
 		with input.image.config.Labels as {olm.manifestv1: "manifests/"}
 }
@@ -372,4 +385,36 @@ test_unmapped_references_none_found if {
 	lib.assert_empty(olm.deny) with input.snapshot.components as [component1, component2]
 		with input.image.files as {"manifests/csv.yaml": manifest}
 		with input.image.config.Labels as {olm.manifestv1: "manifests/"}
+		with data.rule_data.allowed_registry_prefixes as ["registry.io"]
+}
+
+test_allowed_registries if {
+	# This should pass since registry.io is a member of allowed_registry_prefixes
+	lib.assert_empty(olm.deny) with data.rule_data.pipeline_intention as "release"
+		with data.rule_data.allowed_registry_prefixes as ["registry.io", "registry.redhat.io"]
+		with input.image.config.Labels as {olm.manifestv1: "manifests/"}
+		with input.image.files as {"manifests/csv.yaml": manifest}
+}
+
+test_unallowed_registries if {
+	expected := {
+		{
+			"code": "olm.allowed_registries",
+			# regal ignore:line-length
+			"msg": "The \"registry.io/repository/image@sha256:cafe\" CSV image reference is not from an allowed registry.",
+			"term": "registry.io/repository/image",
+		},
+		{
+			"code": "olm.allowed_registries",
+			# regal ignore:line-length
+			"msg": "The \"registry.io/repository/image2@sha256:tea\" CSV image reference is not from an allowed registry.",
+			"term": "registry.io/repository/image2",
+		},
+	}
+
+	# This expects failure as registry.io is not a member of allowed_registry_prefixes
+	lib.assert_equal_results(olm.deny, expected) with data.rule_data.pipeline_intention as "release"
+		with data.rule_data.allowed_registry_prefixes as ["registry.access.redhat.com", "registry.redhat.io"]
+		with input.image.config.Labels as {olm.manifestv1: "manifests/"}
+		with input.image.files as {"manifests/csv.yaml": manifest}
 }


### PR DESCRIPTION
This commit adds a rule that verifies that images from operator bundle CSVs are hosted on approved registries. 

resolves: CVP-4149