### PR TITLE
Remove deprecated_cve_result_name from collections

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -47,7 +47,6 @@ Rules included:
 * xref:release_policy.adoc#cve__cve_blockers[CVE checks: Blocking CVE check]
 * xref:release_policy.adoc#cve__unpatched_cve_blockers[CVE checks: Blocking unpatched CVE check]
 * xref:release_policy.adoc#cve__cve_results_found[CVE checks: CVE scan results found]
-* xref:release_policy.adoc#cve__deprecated_cve_result_name[CVE checks: Deprecated CVE result name]
 * xref:release_policy.adoc#cve__cve_warnings[CVE checks: Non-blocking CVE check]
 * xref:release_policy.adoc#cve__unpatched_cve_warnings[CVE checks: Non-blocking unpatched CVE check]
 * xref:release_policy.adoc#cve__rule_data_provided[CVE checks: Rule data provided]
@@ -106,7 +105,6 @@ Rules included:
 * xref:release_policy.adoc#cve__cve_blockers[CVE checks: Blocking CVE check]
 * xref:release_policy.adoc#cve__unpatched_cve_blockers[CVE checks: Blocking unpatched CVE check]
 * xref:release_policy.adoc#cve__cve_results_found[CVE checks: CVE scan results found]
-* xref:release_policy.adoc#cve__deprecated_cve_result_name[CVE checks: Deprecated CVE result name]
 * xref:release_policy.adoc#cve__cve_warnings[CVE checks: Non-blocking CVE check]
 * xref:release_policy.adoc#cve__unpatched_cve_warnings[CVE checks: Non-blocking unpatched CVE check]
 * xref:release_policy.adoc#cve__rule_data_provided[CVE checks: Rule data provided]
@@ -402,7 +400,7 @@ The SLSA Provenance attestation for the image is inspected to ensure CVEs that h
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Found %d CVE vulnerabilities of %s security level`
 * Code: `cve.cve_blockers`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/cve.rego#L89[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/cve.rego#L88[Source, window="_blank"]
 
 [#cve__unpatched_cve_blockers]
 === link:#cve__unpatched_cve_blockers[Blocking unpatched CVE check]
@@ -414,7 +412,7 @@ The SLSA Provenance attestation for the image is inspected to ensure CVEs that d
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Found %d unpatched CVE vulnerabilities of %s security level`
 * Code: `cve.unpatched_cve_blockers`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/cve.rego#L114[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/cve.rego#L113[Source, window="_blank"]
 
 [#cve__cve_results_found]
 === link:#cve__cve_results_found[CVE scan results found]
@@ -426,7 +424,7 @@ Confirm that clair-scan task results are present in the SLSA Provenance attestat
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Clair CVE scan results were not found`
 * Code: `cve.cve_results_found`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/cve.rego#L140[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/cve.rego#L139[Source, window="_blank"]
 
 [#cve__deprecated_cve_result_name]
 === link:#cve__deprecated_cve_result_name[Deprecated CVE result name]
@@ -474,7 +472,7 @@ Confirm the expected rule data keys have been provided in the expected format. T
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `cve.rule_data_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/cve.rego#L165[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/cve.rego#L164[Source, window="_blank"]
 
 [#external_parameters_package]
 == link:#external_parameters_package[External parameters]

--- a/policy/release/cve.rego
+++ b/policy/release/cve.rego
@@ -74,13 +74,12 @@ warn contains result if {
 #   failure_msg: CVE scan uses deprecated result name
 #   solution: >-
 #     Use the newer `SCAN_OUTPUT` result name.
-#   collections:
-#   - minimal
-#   - redhat
 #   depends_on:
 #   - attestation_type.known_attestation_type
 #
 warn contains result if {
+	# NOTE: This policy rule is purposely not added to any collection because the new result name
+	# has not been widely adopted yet. See https://issues.redhat.com/browse/STONEINTG-660
 	count(lib.results_named(_result_name)) == 0
 	count(lib.results_named(_deprecated_result_name)) > 0
 	result := lib.result_helper(rego.metadata.chain(), [])


### PR DESCRIPTION
The policy rule `cve.deprecated_cve_result_name` has been removed from any collection since the new result name has not yet been widely adopted. Without this change, users a faced with a warning they cannot act on. This change is about reducing the noise for users.

Ref: EC-751