### PR TITLE
Add helper for extracting a repo id from a purl

### DIFF
--- a/policy/lib/purl.rego
+++ b/policy/lib/purl.rego
@@ -1,0 +1,16 @@
+package lib.purl
+
+import rego.v1
+
+# Extract a repository id from a purl. These are often
+# called "repoids" so we'll follow that convention.
+repoid(purl) := _named_qualifier("repository_id", purl)
+
+# (Qualifiers are similar to url params)
+_named_qualifier(key, purl) := result if {
+	ec.purl.is_valid(purl)
+	parsed_purl := ec.purl.parse(purl)
+	some qualifier in parsed_purl.qualifiers
+	qualifier.key == key
+	result := qualifier.value
+}

--- a/policy/lib/purl_test.rego
+++ b/policy/lib/purl_test.rego
@@ -1,0 +1,35 @@
+package lib.purl_test
+
+import rego.v1
+
+import data.lib
+import data.lib.purl
+
+# regal ignore:line-length
+_good := "pkg:rpm/rhel/bash@5.1.8-9.el9?arch=aarch64&upstream=bash-5.1.8-9.el9.src.rpm&distro=rhel-9.4&repository_id=some-repo-id"
+
+_bad := [
+	# regal ignore:line-length
+	"pkg:rpm/rhel/bash@5.1.8-9.el9?arch=aarch64&upstream=bash-5.1.8-9.el9.src.rpm&distro=rhel-9.4&repostory_id=some-repo-id",
+	"pkg:rpm/rhel/bash@5.1.8-9.el9?arch=aarch64&upstream=bash-5.1.8-9.el9.src.rpm&distro=rhel-9.4",
+	"pkg:golang/k8s.io/client-go@v0.29.4",
+	"this-is-not-a-valid-purl",
+]
+
+test_purl_repoid if {
+	lib.assert_equal("some-repo-id", purl.repoid(_good))
+	lib.assert_empty([purl.repoid(p) | some p in _bad])
+}
+
+# This behavior has test coverage in the ec-cli repo already but let's
+# exercise it here anyway since it's low cost and serves as a handy demo
+test_purl_parse if {
+	parsed := ec.purl.parse(_good)
+	lib.assert_equal("rpm", parsed.type)
+	lib.assert_equal("rhel", parsed.namespace)
+	lib.assert_equal("bash", parsed.name)
+	lib.assert_equal("", parsed.subpath)
+	lib.assert_equal("5.1.8-9.el9", parsed.version)
+	lib.assert_equal("arch", parsed.qualifiers[0].key)
+	lib.assert_equal("aarch64", parsed.qualifiers[0].value)
+}


### PR DESCRIPTION
Not sure how this will fit in to the higher level rule, but let's take a bottom-up approach and figure it out as we go.

Ref: https://issues.redhat.com/browse/EC-847