### PR TITLE
Use PURL's subpath when matching disallowed pkgs

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -1096,7 +1096,7 @@ Checks different properties of the CycloneDX SBOMs associated with the image bei
 [#sbom_cyclonedx__allowed]
 === link:#sbom_cyclonedx__allowed[Allowed]
 
-Confirm the CycloneDX SBOM contains only allowed packages. By default all packages are allowed. Use the "disallowed_packages" rule data key to provide a list of disallowed packages.
+Confirm the CycloneDX SBOM contains only allowed packages. By default all packages are allowed. Use the "disallowed_packages" rule data key to provide a list of disallowed packages. The subpath attribute of the PURL must be an exact match. Use the special value of "*" as a matcher for all subpaths, e.g. `pkg:golang/my-pakcage#*`.
 
 *Solution*: Update the image to not use a disallowed package.
 
@@ -1115,7 +1115,7 @@ Confirm the CycloneDX SBOM contains only packages with explicitly allowed extern
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Package %s has reference %q of type %q which is not explicitly allowed%s`
 * Code: `sbom_cyclonedx.allowed_package_external_references`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx.rego#L125[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx.rego#L127[Source, window="_blank"]
 
 [#sbom_cyclonedx__disallowed_package_attributes]
 === link:#sbom_cyclonedx__disallowed_package_attributes[Disallowed package attributes]
@@ -1128,7 +1128,7 @@ Confirm the CycloneDX SBOM contains only packages without disallowed attributes.
 * FAILURE message: `Package %s has the attribute %q set%s`
 * Code: `sbom_cyclonedx.disallowed_package_attributes`
 * Effective from: `2024-07-31T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx.rego#L93[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx.rego#L95[Source, window="_blank"]
 
 [#sbom_cyclonedx__disallowed_package_external_references]
 === link:#sbom_cyclonedx__disallowed_package_external_references[Disallowed package external references]
@@ -1141,7 +1141,7 @@ Confirm the CycloneDX SBOM contains only packages without disallowed external re
 * FAILURE message: `Package %s has reference %q of type %q which is disallowed%s`
 * Code: `sbom_cyclonedx.disallowed_package_external_references`
 * Effective from: `2024-07-31T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx.rego#L155[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx.rego#L157[Source, window="_blank"]
 
 [#sbom_cyclonedx__disallowed_packages_provided]
 === link:#sbom_cyclonedx__disallowed_packages_provided[Disallowed packages list is provided]
@@ -1153,7 +1153,7 @@ Confirm the `disallowed_packages` and `disallowed_attributes` rule data were pro
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `sbom_cyclonedx.disallowed_packages_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx.rego#L73[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx.rego#L75[Source, window="_blank"]
 
 [#sbom_cyclonedx__found]
 === link:#sbom_cyclonedx__found[Found]

--- a/policy/release/sbom_cyclonedx.rego
+++ b/policy/release/sbom_cyclonedx.rego
@@ -54,7 +54,9 @@ deny contains result if {
 # title: Allowed
 # description: >-
 #   Confirm the CycloneDX SBOM contains only allowed packages. By default all packages are allowed.
-#   Use the "disallowed_packages" rule data key to provide a list of disallowed packages.
+#   Use the "disallowed_packages" rule data key to provide a list of disallowed packages. The
+#   subpath attribute of the PURL must be an exact match. Use the special value of "*" as a matcher
+#   for all subpaths, e.g. `pkg:golang/my-pakcage#*`.
 # custom:
 #   short_name: allowed
 #   failure_msg: "Package is not allowed: %s"
@@ -191,6 +193,7 @@ _contains(needle, haystack) if {
 	needle_purl.type == hay_purl.type
 	needle_purl.namespace == hay_purl.namespace
 	needle_purl.name == hay_purl.name
+	hay_purl.subpath in {"*", needle_purl.subpath}
 	_matches_version(needle_purl.version, hay)
 } else := false
 

--- a/policy/release/sbom_cyclonedx_test.rego
+++ b/policy/release/sbom_cyclonedx_test.rego
@@ -228,6 +228,39 @@ test_not_allowed_with_min_max if {
 	assert_allowed("pkg:golang/k8s.io/client-go@v99.99.99", disallowed_packages)
 }
 
+test_not_allowed_with_subpath if {
+	disallowed_packages := [{
+		"purl": "pkg:golang/github.com/hashicorp/consul#api",
+		"format": "semverv",
+		"min": "v1.29.2",
+	}]
+
+	# Subpath matches
+	assert_not_allowed("pkg:golang/github.com/hashicorp/consul@v1.29.2#api", disallowed_packages)
+
+	# Subpath does not match
+	assert_allowed("pkg:golang/github.com/hashicorp/consul@v1.29.2#spam", disallowed_packages)
+
+	# Missing subpath does not match - (top level case)
+	assert_allowed("pkg:golang/github.com/hashicorp/consul@v1.29.2", disallowed_packages)
+	assert_allowed("pkg:golang/github.com/hashicorp/consul@v1.29.2#", disallowed_packages)
+}
+
+test_not_allowed_with_universal_subpath if {
+	disallowed_packages := [{
+		"purl": "pkg:golang/github.com/hashicorp/consul#*",
+		"format": "semverv",
+		"min": "v1.29.2",
+	}]
+
+	# Any subpath matches
+	assert_not_allowed("pkg:golang/github.com/hashicorp/consul@v1.29.2#spam", disallowed_packages)
+
+	# Missing subpath matches
+	assert_not_allowed("pkg:golang/github.com/hashicorp/consul@v1.29.2", disallowed_packages)
+	assert_not_allowed("pkg:golang/github.com/hashicorp/consul@v1.29.2#", disallowed_packages)
+}
+
 assert_allowed(purl, disallowed_packages) if {
 	att := json.patch(_sbom_attestation, [{
 		"op": "add",


### PR DESCRIPTION
There are certain repositories that defined multiple packages. These packages may have different attributes, e.g. different licenses. As such, it is desirable to disallow certain packages from those repos while still allowing others.

A good example of this is the github.com/hashicorp/consul repo. The top-level license is quite restritive, but the one under the `/api` subpath is not.

This commit changes the sbom_cyclonedx.allowed policy rule to take into account the subpath attribute. The subpaths defined in the items of the disallowed_packages list must be an exact match to the subpath of components defined in the SBOM.

To more easily handle the case where all the subpaths must be disallowed, the special `"*"` subpath value can be used.

Ref: EC-870