### PR TITLE
Add terms to rpm_repos.ids_known

### DIFF
--- a/acceptance/features/release.feature
+++ b/acceptance/features/release.feature
@@ -30,3 +30,36 @@ Feature: Golden Container Image
         When input is validated
         Then there should be no violations in the result
         Then there should be no warnings in the result
+
+    Scenario: Various excludes
+        Given a sample policy input "golden-container"
+         And a policy config:
+            """
+            {
+                "sources": [
+                    {
+                        "policy": [
+                            "$GITROOT/policy/lib",
+                            "$GITROOT/policy/release"
+                        ],
+                        "data": [
+                            "$GITROOT/example/data"
+                        ],
+                        "config": {
+                            "include": ["*"],
+                            "exclude": [
+                                "@rhtap-jenkins",
+                                "source_image",
+                                "github_certificate",
+                                "rpm_repos.ids_known:pkg:rpm/rhel/basesystem@11-13.el9?arch=noarch&upstream=basesystem-11-13.el9.src.rpm&distro=rhel-9.4"
+                            ]
+                        }
+                    }
+                ]
+            }
+            """
+        When input is validated
+        Then there should be no violations with "rhtap-jenkins" collection in the result
+         And there should be no violations with "source_image" package in the result
+         And there should be no violations with "rpm_repos.ids_known" code and "pkg:rpm/rhel/basesystem@11-13.el9?arch=noarch&upstream=basesystem-11-13.el9.src.rpm&distro=rhel-9.4" term in the result
+         And there should be no warnings with "github_certificate" package in the result

--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -80,6 +80,7 @@ Rules included:
 * xref:release_policy.adoc#java__trusted_dependencies_source_list_provided[Java dependency checks: Trusted Java dependency source list was provided]
 * xref:release_policy.adoc#labels__rule_data_provided[Labels: Rule data provided]
 * xref:release_policy.adoc#olm__required_olm_features_annotations_provided[OLM: Required OLM feature annotations list provided]
+* xref:release_policy.adoc#rpm_repos__rule_data_provided[RPM Repos: Known repo id list provided]
 * xref:release_policy.adoc#rpm_signature__rule_data_provided[RPM Signature: Rule data provided]
 * xref:release_policy.adoc#sbom_cyclonedx__allowed_package_external_references[SBOM CycloneDX: Allowed package external references]
 * xref:release_policy.adoc#sbom_cyclonedx__disallowed_package_attributes[SBOM CycloneDX: Disallowed package attributes]
@@ -1028,7 +1029,7 @@ Each RPM package listed in an SBOM must specify the repository id that it comes 
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `RPM repo id check failed: %s`
 * Code: `rpm_repos.ids_known`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/rpm_repos.rego#L32[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/rpm_repos.rego#L33[Source, window="_blank"]
 
 [#rpm_repos__rule_data_provided]
 === link:#rpm_repos__rule_data_provided[Known repo id list provided]

--- a/policy/release/rpm_repos.rego
+++ b/policy/release/rpm_repos.rego
@@ -23,6 +23,7 @@ import data.lib
 #     'known_rpm_repositories' key under the top level 'rule_data' key.
 #   collections:
 #   - redhat
+#   - policy_data
 #
 deny contains result if {
 	some error in _rule_data_errors

--- a/policy/release/rpm_repos.rego
+++ b/policy/release/rpm_repos.rego
@@ -50,8 +50,8 @@ deny contains result if {
 	# Don't bother with this unless we have valid rule data
 	count(_rule_data_errors) == 0
 
-	some error in _repo_id_errors
-	result := lib.result_helper(rego.metadata.chain(), [error])
+	some bad_purl, msg in _repo_id_errors
+	result := lib.result_helper_with_term(rego.metadata.chain(), [msg], bad_purl)
 }
 
 _rule_data_errors contains msg if {
@@ -71,20 +71,28 @@ _rule_data_errors contains msg if {
 	msg := violation.error
 }
 
-_repo_id_errors contains msg if {
+_repo_id_errors[bad_purl] := msg if {
 	bad_purls := all_rpm_purls - _plain_purls(all_purls_with_repo_ids)
 	count(bad_purls) > 0
 
-	some bad_purl in _truncated_msg_list(bad_purls)
-	msg := sprintf("An RPM component in the SBOM did not specify a repository_id value in its purl: %s", [bad_purl])
+	truncated := _truncate(bad_purls)
+	some bad_purl in truncated.values
+	msg := sprintf("An RPM component in the SBOM did not specify a repository_id value in its purl: %s%s", [
+		bad_purl,
+		_truncated_msg(truncated.remainder),
+	])
 }
 
-_repo_id_errors contains msg if {
+_repo_id_errors[bad_purl] := msg if {
 	bad_purls := all_purls_with_repo_ids - all_purls_with_known_repo_ids
 	count(bad_purls) > 0
 
-	some bad_purl in _truncated_msg_list(_plain_purls(bad_purls))
-	msg := sprintf("An RPM component in the SBOM specified an unknown or disallowed repository_id: %s", [bad_purl])
+	truncated := _truncate(_plain_purls(bad_purls))
+	some bad_purl in truncated.values
+	msg := sprintf("An RPM component in the SBOM specified an unknown or disallowed repository_id: %s%s", [
+		bad_purl,
+		_truncated_msg(truncated.remainder),
+	])
 }
 
 all_purls_with_known_repo_ids contains purl_obj if {
@@ -146,11 +154,13 @@ _truncate_threshold := 10
 # ...but not if the N in the "N more" is less than this
 _min_remainder_count := 4
 
-_truncated_msg_list(all_msgs) := truncated_msgs if {
-	remainder_count := count(all_msgs) - _truncate_threshold
+_truncate(collection) := {"values": truncated, "remainder": remainder_count} if {
+	remainder_count := count(collection) - _truncate_threshold
 	remainder_count >= _min_remainder_count
-	truncated_msgs := array.concat(
-		array.slice(lib.to_array(all_msgs), 0, _truncate_threshold),
-		[sprintf("%d additional similar violations not separately listed", [remainder_count])],
-	)
-} else := all_msgs
+	truncated := array.slice(lib.to_array(collection), 0, _truncate_threshold)
+} else := {"values": collection, "remainder": 0}
+
+_truncated_msg(remainder) := msg if {
+	remainder > 0
+	msg := sprintf(" (%d additional similar violations not separately listed)", [remainder])
+} else := ""


### PR DESCRIPTION
The term is the whole purl found to be in violation. In addition the main difference is that the rule doesn't emit +1 violation when the list is truncated, a notice is added to the message about remaining similar violations instead.

Reference: EC-877

Also, adds `rpm_repos.rule_data_provided` to the `policy_data` collection.