### PR TITLE
Make the task expiry message customizable

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -1758,10 +1758,8 @@ Ensure that all of the Tasks in the Pipeline completed successfully. Note that s
 
 The Tekton Task used is or will be unsupported. The Task is annotated with `build.appstudio.redhat.com/expires-on` annotation marking it as unsupported after a certain date.
 
-*Solution*: Upgrade to a newer version of the Task.
-
 * Rule type: [rule-type-indicator failure]#FAILURE#
-* FAILURE message: `Task %q is used by pipeline task %q is or will be unsupported as of %s.`
+* FAILURE message: `Task %q is used by pipeline task %q is or will be unsupported as of %s. %s`
 * Code: `tasks.unsupported`
 * https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/tasks.rego#L240[Source, window="_blank"]
 

--- a/antora/docs/modules/ROOT/pages/tasks.adoc
+++ b/antora/docs/modules/ROOT/pages/tasks.adoc
@@ -19,6 +19,10 @@ A Task can be set to expire by setting the
 annotation means that the task is or will be unsupported by a certain date/time
 provided in the value of the annotation in the RFC3339 format.
 
+By default, the rule will prompt the user to `Update to a newer version of the Task.`.
+The message can be customized by setting the `build.appstudio.redhat.com/expiry-message`
+annotation.
+
 For example, this will set the Task to be unsupported after 2025-01-01 at
 midnight UTC; prior to that a warning will be emited by the
 xref:release_policy.adoc#tasks__unsupported[Task version unsupported] rule and

--- a/policy/release/tasks.rego
+++ b/policy/release/tasks.rego
@@ -246,9 +246,7 @@ deny contains result if {
 # custom:
 #   short_name: unsupported
 #   failure_msg: >-
-#     Task %q is used by pipeline task %q is or will be unsupported as of %s.
-#   solution: >-
-#     Upgrade to a newer version of the Task.
+#     Task %q is used by pipeline task %q is or will be unsupported as of %s. %s
 #   collections:
 #   - redhat
 #   depends_on:
@@ -261,11 +259,16 @@ deny contains result if {
 	annotations := tkn.task_annotations(task)
 
 	expires_on := annotations[_expires_on_annotation]
+	expiry_message := object.get(
+		annotations,
+		_expiry_msg_annotation,
+		"Upgrade to a newer version of the Task.",
+	)
 
 	result := object.union(
 		lib.result_helper_with_term(
 			rego.metadata.chain(),
-			[tkn.task_name(task), tkn.pipeline_task_name(task), expires_on],
+			[tkn.task_name(task), tkn.pipeline_task_name(task), expires_on, expiry_message],
 			tkn.task_name(task),
 		),
 		{"effective_on": expires_on},
@@ -385,3 +388,5 @@ _format_missing(o, opt) := desc if {
 } else := sprintf("Required task %q", [o])
 
 _expires_on_annotation := "build.appstudio.redhat.com/expires-on"
+
+_expiry_msg_annotation := "build.appstudio.redhat.com/expiry-message"

--- a/policy/release/tasks_test.rego
+++ b/policy/release/tasks_test.rego
@@ -588,7 +588,8 @@ test_deprecated_slsa_v0_2 if {
 
 	expected := {{
 		"code": "tasks.unsupported",
-		"msg": `Task "task" is used by pipeline task "task" is or will be unsupported as of 2200-01-01T00:00:00Z.`,
+		# regal ignore:line-length
+		"msg": `Task "task" is used by pipeline task "task" is or will be unsupported as of 2200-01-01T00:00:00Z. Upgrade to a newer version of the Task.`,
 		"term": "task",
 	}}
 
@@ -605,7 +606,8 @@ test_expired_slsa_v0_2 if {
 
 	expected := {{
 		"code": "tasks.unsupported",
-		"msg": `Task "task" is used by pipeline task "task" is or will be unsupported as of 2000-01-01T00:00:00Z.`,
+		# regal ignore:line-length
+		"msg": `Task "task" is used by pipeline task "task" is or will be unsupported as of 2000-01-01T00:00:00Z. Upgrade to a newer version of the Task.`,
 		"term": "task",
 	}}
 
@@ -622,7 +624,8 @@ test_deprecated_slsa_v1 if {
 
 	expected := {{
 		"code": "tasks.unsupported",
-		"msg": `Task "task" is used by pipeline task "task" is or will be unsupported as of 2200-01-01T00:00:00Z.`,
+		# regal ignore:line-length
+		"msg": `Task "task" is used by pipeline task "task" is or will be unsupported as of 2200-01-01T00:00:00Z. Upgrade to a newer version of the Task.`,
 		"term": "task",
 	}}
 
@@ -639,7 +642,29 @@ test_expired_slsa_v1 if {
 
 	expected := {{
 		"code": "tasks.unsupported",
-		"msg": `Task "task" is used by pipeline task "task" is or will be unsupported as of 2000-01-01T00:00:00Z.`,
+		# regal ignore:line-length
+		"msg": `Task "task" is used by pipeline task "task" is or will be unsupported as of 2000-01-01T00:00:00Z. Upgrade to a newer version of the Task.`,
+		"term": "task",
+	}}
+
+	lib.assert_equal_results(tasks.deny, expected) with input.attestations as attestation
+		with data["pipeline-required-tasks"] as {"generic": []}
+		with data["task-bundles"] as _trusted_tasks
+}
+
+test_expired_with_custom_message if {
+	attestation := _slsav1_attestations_with_tasks({}, [object.union(
+		_task("task"),
+		{"invocation": {"environment": {"annotations": {
+			tasks._expires_on_annotation: "2000-01-01T00:00:00Z",
+			tasks._expiry_msg_annotation: "The Task has been discontinued.",
+		}}}},
+	)])
+
+	expected := {{
+		"code": "tasks.unsupported",
+		# regal ignore:line-length
+		"msg": `Task "task" is used by pipeline task "task" is or will be unsupported as of 2000-01-01T00:00:00Z. The Task has been discontinued.`,
 		"term": "task",
 	}}
 


### PR DESCRIPTION
Note: this came from an internal Slack conversation about how to distinguish between "task is deprecated because we only maintain the newer version" and "task is discontinued". Somewhat related to https://github.com/konflux-ci/build-definitions/pull/1471#discussion_r1776637740

Along with the expires-on annotation, Task authors can optionally define the expiry-message annotation to override the default expiry message. The default is still "Upgrade to a newer version of the Task."

This required moving the 'solution' part of the rule into the 'failure_msg' instead, because 'solution' does not support templating.