### PR TITLE
Switch to "unversioned" in antora.yml

### DIFF
--- a/antora/docs/antora.yml
+++ b/antora/docs/antora.yml
@@ -17,6 +17,6 @@
 
 name: ec-policies
 title: Enterprise Contract Policies
-version: master
+version: ~
 nav:
 - modules/ROOT/nav.adoc


### PR DESCRIPTION
See https://docs.antora.org/antora/latest/component-with-no-version/

We don't actually have a master branch, so it should have been main to begin with. Likely a copy/paste snafu made in
93b0e925ed36e7f8fa64249c007d7f08c95910bc.

But actually, because we don't build docs for different branches, switching to unversioned should be is better, and by chance it preserves the url path for the policies. I guess since "master" exist the antora build was skipping the url prefix entirely.

(And now we know why ec-policies is the only component without the 'main/' in its url path.)

Drive-by fix while working on...

Ref: https://issues.redhat.com/browse/EC-903