### PR TITLE
Fixup for last PR: Actually remove the version

### DIFF
--- a/antora/docs/modules/ROOT/pages/index.adoc
+++ b/antora/docs/modules/ROOT/pages/index.adoc
@@ -14,7 +14,7 @@ xref:pipeline_policy.adoc[Pipeline Policy].
 == Additional Documentation
 
 * https://konflux-ci.dev/docs/[Konflux Documentation]
-* xref:_@ec-cli::index.adoc[EC CLI Documentation]
+* xref:ec-cli::index.adoc[EC CLI Documentation]
 
 == Code
 

--- a/antora/docs/modules/ROOT/pages/policy_bundles.adoc
+++ b/antora/docs/modules/ROOT/pages/policy_bundles.adoc
@@ -28,7 +28,7 @@ The bundles mentioned above are also listed in https://artifacthub.io/packages/s
 
 == Example usage
 
-The bundles are designed to be used with the xref:_@ec-cli::index.adoc[ec-cli], but you
+The bundles are designed to be used with the xref:ec-cli::index.adoc[ec-cli], but you
 can also use them with conftest directly. The input should include a top level key called `attestations` which contains a list of
 attestations for the image being validated. For example:
 


### PR DESCRIPTION
I think this is better since there should be no need to specify a version at all.

Ref: https://issues.redhat.com/browse/EC-86