### PR TITLE
Enable rpm repo id check in redhat collection effective in 30 days

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -144,6 +144,7 @@ Rules included:
 * xref:release_policy.adoc#provenance_materials__git_clone_source_matches_provenance[Provenance Materials: Git clone source matches materials provenance]
 * xref:release_policy.adoc#provenance_materials__git_clone_task_found[Provenance Materials: Git clone task found]
 * xref:release_policy.adoc#quay_expiration__expires_label[Quay expiration: Expires label]
+* xref:release_policy.adoc#rpm_repos__ids_known[RPM Repos: All rpms have known repo ids]
 * xref:release_policy.adoc#rpm_repos__rule_data_provided[RPM Repos: Known repo id list provided]
 * xref:release_policy.adoc#rpm_signature__allowed[RPM Signature: Allowed RPM signature key]
 * xref:release_policy.adoc#rpm_signature__result_format[RPM Signature: Result format]
@@ -1040,6 +1041,7 @@ Each RPM package listed in an SBOM must specify the repository id that it comes 
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `RPM repo id check failed: %s`
 * Code: `rpm_repos.ids_known`
+* Effective from: `2024-11-10T00:00:00Z`
 * https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/rpm_repos.rego#L33[Source, window="_blank"]
 
 [#rpm_repos__rule_data_provided]

--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -1034,7 +1034,7 @@ This package defines rules to confirm that all RPM packages listed in SBOMs spec
 [#rpm_repos__ids_known]
 === link:#rpm_repos__ids_known[All rpms have known repo ids]
 
-Each RPM package listed in an SBOM must specify the repository id that it comes from, and that repository id must be present in the list of known and permitted repository ids.
+Each RPM package listed in an SBOM must specify the repository id that it comes from, and that repository id must be present in the list of known and permitted repository ids. Currently this is rule enforced only for SBOM components created by cachi2.
 
 *Solution*: Ensure every rpm comes from a known and permitted repository, and that the data in the SBOM correctly records that.
 

--- a/policy/release/rpm_repos.rego
+++ b/policy/release/rpm_repos.rego
@@ -35,6 +35,7 @@ deny contains result if {
 # description: >-
 #   Each RPM package listed in an SBOM must specify the repository id that it comes from,
 #   and that repository id must be present in the list of known and permitted repository ids.
+#   Currently this is rule enforced only for SBOM components created by cachi2.
 # custom:
 #   short_name: ids_known
 #   failure_msg: 'RPM repo id check failed: %s'

--- a/policy/release/rpm_repos.rego
+++ b/policy/release/rpm_repos.rego
@@ -41,10 +41,9 @@ deny contains result if {
 #   solution: >-
 #     Ensure every rpm comes from a known and permitted repository, and that the data in the
 #     SBOM correctly records that.
-#   # Todo: Until the sbom generation is upated this will always fail, so don't include it
-#   # in the redhat collection yet. See https://issues.redhat.com/browse/STONEBLD-2638
-#   #collections:
-#   #- redhat
+#   collections:
+#   - redhat
+#   effective_on: "2024-11-10T00:00:00Z"
 #
 deny contains result if {
 	# Don't bother with this unless we have valid rule data


### PR DESCRIPTION
Because this check will fail for a image that was not built with the latest version of cachi2, the effective on date was set 30 days out. Hopefully most people would have their Konflux tekton task bundle refs updated by then.
    
See also:
* https://github.com/containerbuildsystem/cachi2/releases/tag/0.11.0
* https://github.com/konflux-ci/build-definitions/commit/ef11db2b8f47b8bd1c2f7c0ab93fca93ef12b41d

Ref: [EC-876](https://issues.redhat.com/browse/EC-876)