### PR TITLE
Run tests offline on Linux

### DIFF
--- a/.github/workflows/pre-merge-ci.yaml
+++ b/.github/workflows/pre-merge-ci.yaml
@@ -51,7 +51,10 @@ jobs:
           cache: true
 
       - name: Run checks
-        run: make ci
+        run: |
+          # allows us to use unshare to restrict network access
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          make ci
 
       - name: Check for uncommitted changes
         run: |


### PR DESCRIPTION
Uses `unshare` to run the Rego tests on Linux without network access. This makes sure that the tests are not depending on outside service and that all network access is mocked.