### PR TITLE
SBOM loading optimization

### DIFF
--- a/policy/lib/sbom/sbom.rego
+++ b/policy/lib/sbom/sbom.rego
@@ -39,18 +39,15 @@ _cyclonedx_sboms_from_oci := [sbom |
 	sbom.bomFormat == "CycloneDX"
 ]
 
-default spdx_sboms := []
-
 spdx_sboms := sboms if {
 	sboms := array.concat(_spdx_sboms_from_attestations, _spdx_sboms_from_oci)
 	count(sboms) > 0
 } else := _spdx_sboms_from_image
 
+default _spdx_sboms_from_image := []
+
 _spdx_sboms_from_image := [sbom] if {
 	sbom := input.image.files[_sbom_spdx_image_path]
-} else := [sbom] if {
-	input.image.config.Labels.vendor == "Red Hat, Inc."
-	sbom := ec.oci.image_files(input.image.ref, [_sbom_spdx_image_path])[_sbom_spdx_image_path]
 }
 
 _spdx_sboms_from_attestations := [statement.predicate |

--- a/policy/lib/sbom/sbom_test.rego
+++ b/policy/lib/sbom/sbom_test.rego
@@ -118,9 +118,9 @@ test_cyclonedx_sboms_fallback_live_fetch if {
 		with ec.oci.image_files as mock_ec_oci_image_files(sbom._sbom_cyclonedx_image_path)
 }
 
-test_spdx_sboms_fallback_live_fetch if {
+test_spdx_sboms_fallback__no_live_fetch if {
 	image := json.remove(_spdx_image, ["files"])
-	expected := [{"sbom": "from live image"}]
+	expected := []
 	lib.assert_equal(sbom.spdx_sboms, expected) with input.attestations as []
 		with input.image as image
 		with ec.oci.blob as mock_ec_oci_spdx_blob


### PR DESCRIPTION
When we added support for SPDX SBOMs we added the same fallback as we have done for CycloneDX, i.e. if the SBOM attestation or the `SBOM_BLOB_URL` don't yield SBOM data, we extract the image under test and look for the SBOM data in the image's file system.

Given that the SPDX SBOMs are not produced currently, the fallback of loading from the extracted image file system is always taken, and the potentially expensive operation of downloading the image layers and extracting the files is performed.

With this change we don't look for SPDX SBOMs in the image under test at all, there is no need to add this functionality, we're expecting that the version of the Task that will produce SPDX SBOMs will do so by uploading to the registry and emit the `SBOM_BLOB_URL`.

Reference: https://issues.redhat.com/browse/EC-931