### PR TITLE
Flatten package names

### DIFF
--- a/antora/docs/modules/ROOT/pages/build_task_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/build_task_policy.adoc
@@ -4,30 +4,29 @@
 
 These rules are applied to Tekton build task definitions.
 
-[#labels_package]
-== link:#labels_package[Tekton task build type label checks]
+[#build_labels_package]
+== link:#build_labels_package[Tekton task build type label checks]
 
 Policies to verify that a Tekton build task definition has the required build type label.
 
-* Package name: `labels`
-* Package full path: `build_task.labels`
+* Package name: `build_labels`
 
-[#labels__build_type_label_set]
-=== link:#labels__build_type_label_set[Build task has build type label]
+[#build_labels__build_type_label_set]
+=== link:#build_labels__build_type_label_set[Build task has build type label]
 
 Confirm the build task definition has the required build type label.
 
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `The required build label '%s' is missing`
-* Code: `labels.build_type_label_set`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/build_task/labels/labels.rego#L17[Source, window="_blank"]
+* Code: `build_labels.build_type_label_set`
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/build_task/build_labels/build_labels.rego#L17[Source, window="_blank"]
 
-[#labels__build_task_has_label]
-=== link:#labels__build_task_has_label[Build task has label]
+[#build_labels__build_task_has_label]
+=== link:#build_labels__build_task_has_label[Build task has label]
 
 Confirm that the build task definition includes at least one label.
 
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `The task definition does not include any labels`
-* Code: `labels.build_task_has_label`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/build_task/labels/labels.rego#L30[Source, window="_blank"]
+* Code: `build_labels.build_task_has_label`
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/build_task/build_labels/build_labels.rego#L30[Source, window="_blank"]

--- a/antora/docs/modules/ROOT/pages/pipeline_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/pipeline_policy.adoc
@@ -10,7 +10,6 @@ These rules are applied to Tekton pipeline definitions.
 To be able to reproduce and audit builds accurately it's important to know exactly what happens during the build. To do this Enterprise Contract requires that all tasks are defined in a set of known and trusted task bundles. This package includes rules to confirm that the tasks in a Pipeline definition are defined in task bundles, and that the task bundles are from the list of known and trusted bundles.
 
 * Package name: `task_bundle`
-* Package full path: `pipeline.task_bundle`
 
 [#task_bundle__missing_required_data]
 === link:#task_bundle__missing_required_data[Missing required data]
@@ -78,7 +77,6 @@ Check if the Tekton Bundle used for the Tasks in the Pipeline definition is pinn
 Policies to confirm the Tekton Pipeline definition has the expected kind.
 
 * Package name: `basic`
-* Package full path: `pipeline.basic`
 
 [#basic__expected_kind]
 === link:#basic__expected_kind[Pipeline definition has expected kind]
@@ -96,7 +94,6 @@ Confirm that the pipeline definition has the kind "Pipeline".
 Konflux expects that certain Tekton tasks are executed during image builds. This package includes policy rules to confirm that the pipeline definition includes those required tasks.
 
 * Package name: `required_tasks`
-* Package full path: `pipeline.required_tasks`
 
 [#required_tasks__missing_future_required_task]
 === link:#required_tasks__missing_future_required_task[Missing future required task]

--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -203,6 +203,14 @@ Rules included:
 * xref:release_policy.adoc#rpm_ostree_task__builder_image_param[rpm-ostree Task: Builder image parameter]
 * xref:release_policy.adoc#rpm_ostree_task__rule_data[rpm-ostree Task: Rule data]
 
+| [#rhtap-jenkins]`rhtap-jenkins`
+a| A set of policy rules to validate artifacts built using RHTAP Jenkins pipelines.
+
+Rules included:
+
+* xref:release_policy.adoc#rhtap_jenkins__invocation_id_found[RHTAP Jenkins: RHTAP Jenkins SLSA Invocation ID present]
+* xref:release_policy.adoc#rhtap_jenkins__attestation_found[RHTAP Jenkins: RHTAP Jenkins SLSA Provenance Attestation Found]
+
 | [#slsa3]`slsa3`
 a| Includes policy rules required to meet SLSA Level 3.
 
@@ -233,7 +241,6 @@ Rules included:
 Sanity checks related to the format of the image build's attestation.
 
 * Package name: `attestation_type`
-* Package full path: `release.attestation_type`
 
 [#attestation_type__deprecated_policy_attestation_format]
 === link:#attestation_type__deprecated_policy_attestation_format[Deprecated policy attestation format]
@@ -290,7 +297,6 @@ Confirm at least one PipelineRun attestation is present.
 This package is responsible for verifying the base (parent) images reported in the SLSA Provenace or the SBOM are allowed.
 
 * Package name: `base_image_registries`
-* Package full path: `release.base_image_registries`
 
 [#base_image_registries__allowed_registries_provided]
 === link:#base_image_registries__allowed_registries_provided[Allowed base image registry prefixes list was provided]
@@ -334,7 +340,6 @@ Verify the expected information was provided about which base images were used d
 This package is responsible for verifying the buildah build task
 
 * Package name: `buildah_build_task`
-* Package full path: `release.buildah_build_task`
 
 [#buildah_build_task__add_capabilities_param]
 === link:#buildah_build_task__add_capabilities_param[ADD_CAPABILITIES parameter]
@@ -390,7 +395,6 @@ Confirm the `disallowed_platform_patterns` rule data, if provided matches the ex
 This package is responsible for verifying a CVE scan was performed during the build pipeline, and that the image under test does not contain CVEs of certain security levels.
 
 * Package name: `cve`
-* Package full path: `release.cve`
 
 [#cve__cve_blockers]
 === link:#cve__cve_blockers[Blocking CVE check]
@@ -482,7 +486,6 @@ Confirm the expected rule data keys have been provided in the expected format. T
 Verify the attribute .predicate.buildDefinition.externalParameters of a SLSA Provenance v1.0 matches the expectation.
 
 * Package name: `external_parameters`
-* Package full path: `release.external_parameters`
 
 [#external_parameters__pipeline_run_params]
 === link:#external_parameters__pipeline_run_params[Pipeline run params]
@@ -522,7 +525,6 @@ Verify the PipelineRun did not use any pre-existing PersistentVolumeClaim worksp
 Verify attributes on the certificate involved in the image signature when using slsa-github-generator on GitHub Actions with Sigstore Fulcio
 
 * Package name: `github_certificate`
-* Package full path: `release.github_certificate`
 
 [#github_certificate__gh_workflow_extensions]
 === link:#github_certificate__gh_workflow_extensions[GitHub Workflow Certificate Extensions]
@@ -592,7 +594,6 @@ Confirm the expected rule data keys have been provided in the expected format. T
 This package verifies the build task in the attestation was invoked with the expected parameters to perform a hermetic build.
 
 * Package name: `hermetic_build_task`
-* Package full path: `release.hermetic_build_task`
 
 [#hermetic_build_task__build_task_hermetic]
 === link:#hermetic_build_task__build_task_hermetic[Build task called with hermetic param set]
@@ -612,7 +613,6 @@ Verify the build task in the PipelineRun attestation was invoked with the proper
 This package contains a rule to confirm that all Java dependencies were rebuilt in house rather than imported directly from potentially untrusted respositories. If the result is missing no violation is reported. The rules depend on the configuration under the key 'allowed_java_component_sources', the key lists all component sources that are allowed by the policy. The values of the list can be 'rebuilt' for dependencies that have been explicitly built from sources, or the name of the Maven repository names where the dependency artifact was retrieved from. The Maven repositories are configured using the 'JBSConfig' custom resources. Default configuration in Konflux currently includes Maven repositories with names : 'jboss', 'confluent', 'redhat', 'jitpack' and 'gradle'.
 
 * Package name: `java`
-* Package full path: `release.java`
 
 [#java__no_foreign_dependencies]
 === link:#java__no_foreign_dependencies[Java builds have no foreign dependencies]
@@ -644,7 +644,6 @@ Confirm the `allowed_java_component_sources` rule data was provided, since it's 
 Check if the image has the expected labels set. The rules in this package distinguish file-based catalog (FBC) images from all other images. When checking an FBC image, a policy rule may use a different set of rule data. An FBC image is detected by the presence of the operators.operatorframework.io.index.configs.v1 label.
 
 * Package name: `labels`
-* Package full path: `release.labels`
 
 [#labels__deprecated_labels]
 === link:#labels__deprecated_labels[Deprecated labels]
@@ -760,7 +759,6 @@ Confirm the expected rule data keys have been provided in the expected format. T
 Checks for Operator Lifecycle Manager (OLM) bundles.
 
 * Package name: `olm`
-* Package full path: `release.olm`
 
 [#olm__csv_semver_format]
 === link:#olm__csv_semver_format[ClusterServiceVersion semver format]
@@ -879,7 +877,6 @@ Check the input snapshot for the presence of unpinned image references. Unpinned
 This package provides rules for verifying the contents of the materials section of the SLSA Provenance attestation.
 
 * Package name: `provenance_materials`
-* Package full path: `release.provenance_materials`
 
 [#provenance_materials__git_clone_source_matches_provenance]
 === link:#provenance_materials__git_clone_source_matches_provenance[Git clone source matches materials provenance]
@@ -911,7 +908,6 @@ Confirm that the attestation contains a git-clone task with `commit` and `url` t
 Policies to prevent releasing an image to quay that has a quay expiration date. In Konflux images with an expiration date are produced by "on-pr" build pipelines, i.e. pre-merge CI builds, so this is intended to prevent accidentally releasing a CI build.
 
 * Package name: `quay_expiration`
-* Package full path: `release.quay_expiration`
 
 [#quay_expiration__expires_label]
 === link:#quay_expiration__expires_label[Expires label]
@@ -931,7 +927,6 @@ Check the image metadata for the presence of a "quay.expires-after" label. If it
 Some initial checks for images built using an RHTAP Jenkins build pipeline. Note that the RHTAP Jenkins pipeline is WIP currently, but will be shipped in an upcoming release of RHTAP. It's expected more useful checks will be added in future. RHTAP Jenkins pipelines are defined under https://github.com/redhat-appstudio/tssc-sample-templates/tree/main/skeleton/ci
 
 * Package name: `rhtap_jenkins`
-* Package full path: `release.rhtap_jenkins`
 
 [#rhtap_jenkins__invocation_id_found]
 === link:#rhtap_jenkins__invocation_id_found[RHTAP Jenkins SLSA Invocation ID present]
@@ -963,7 +958,6 @@ Verify an attestation created by the RHTAP Jenkins build pipeline is present.
 This package defines rules to confirm that all RPM packages listed in SBOMs specify a known and permitted repository id.
 
 * Package name: `rpm_repos`
-* Package full path: `release.rpm_repos`
 
 [#rpm_repos__ids_known]
 === link:#rpm_repos__ids_known[All rpms have known repo ids]
@@ -996,7 +990,6 @@ A list of known and permitted repository ids should be available in the rule dat
 This package provides rules for verifying the signatures of RPMs identified in the the SLSA Provenance attestation.
 
 * Package name: `rpm_signature`
-* Package full path: `release.rpm_signature`
 
 [#rpm_signature__allowed]
 === link:#rpm_signature__allowed[Allowed RPM signature key]
@@ -1039,7 +1032,6 @@ Confirm the expected `allowed_rpm_signature_keys` rule data key has been provide
 Checks general properties of the SBOMs associated with the image being validated. More specific rules for SPDX and CycloneDX SBOMs are in separate packages.
 
 * Package name: `sbom`
-* Package full path: `release.sbom`
 
 [#sbom__disallowed_packages_provided]
 === link:#sbom__disallowed_packages_provided[Disallowed packages list is provided]
@@ -1071,7 +1063,6 @@ Confirm an SBOM attestation exists.
 Checks different properties of the CycloneDX SBOMs associated with the image being validated. The SBOMs are read from multiple locations: a file within the image, and a CycloneDX SBOM attestation.
 
 * Package name: `sbom_cyclonedx`
-* Package full path: `release.sbom_cyclonedx`
 
 [#sbom_cyclonedx__allowed]
 === link:#sbom_cyclonedx__allowed[Allowed]
@@ -1143,7 +1134,6 @@ The SLSA requirement states the following:
 This package verifies the requirement by asserting the image was built by Tekton Pipelines.
 
 * Package name: `slsa_build_build_service`
-* Package full path: `release.slsa_build_build_service`
 
 [#slsa_build_build_service__allowed_builder_ids_provided]
 === link:#slsa_build_build_service__allowed_builder_ids_provided[Allowed builder IDs provided]
@@ -1187,7 +1177,6 @@ The SLSA requirement states the following:
 This package verifies the requirement by asserting the image was built by Tekton Pipelines.
 
 * Package name: `slsa_build_scripted_build`
-* Package full path: `release.slsa_build_scripted_build`
 
 [#slsa_build_scripted_build__build_script_used]
 === link:#slsa_build_scripted_build__build_script_used[Build task contains steps]
@@ -1245,7 +1234,6 @@ The SLSA Provenance Available requirement states the following:
 This package only accepts the in-toto SLSA Provenance format.
 
 * Package name: `slsa_provenance_available`
-* Package full path: `release.slsa_provenance_available`
 
 [#slsa_provenance_available__allowed_predicate_types_provided]
 === link:#slsa_provenance_available__allowed_predicate_types_provided[Allowed predicate types provided]
@@ -1290,7 +1278,6 @@ Most popular version control system meet this requirement, such as git, Mercuria
 This package verifies the requirement by asserting the image was built from a git repository.
 
 * Package name: `slsa_source_version_controlled`
-* Package full path: `release.slsa_source_version_controlled`
 
 [#slsa_source_version_controlled__materials_uri_is_git_repo]
 === link:#slsa_source_version_controlled__materials_uri_is_git_repo[Material uri is a git repo]
@@ -1336,7 +1323,6 @@ SLSA v1 verification model states:
 This package correlates the provided source code reference with the source code referenced in the attestation.
 
 * Package name: `slsa_source_correlated`
-* Package full path: `release.slsa_source_correlated`
 
 [#slsa_source_correlated__expected_source_code_reference]
 === link:#slsa_source_correlated__expected_source_code_reference[Expected source code reference]
@@ -1390,7 +1376,6 @@ Attestation contains source reference.
 Checks different properties of the CycloneDX SBOMs associated with the image being validated. The SBOMs are read from multiple locations: a file within the image, and a CycloneDX SBOM attestation.
 
 * Package name: `sbom_spdx`
-* Package full path: `release.sbom_spdx`
 
 [#sbom_spdx__allowed]
 === link:#sbom_spdx__allowed[Allowed]
@@ -1483,7 +1468,6 @@ Check the SPDX SBOM has the expected format. It verifies the SPDX SBOM matches t
 Rules that verify the current date conform to a given schedule.
 
 * Package name: `schedule`
-* Package full path: `release.schedule`
 
 [#schedule__date_restriction]
 === link:#schedule__date_restriction[Date Restriction]
@@ -1527,7 +1511,6 @@ Check if the current weekday is allowed based on the rule data value from the ke
 This package is reponsible for verifying the source container image associated with the image being validated.
 
 * Package name: `source_image`
-* Package full path: `release.source_image`
 
 [#source_image__exists]
 === link:#source_image__exists[Exists]
@@ -1557,7 +1540,6 @@ Verify the source container image is signed.
 To be able to reproduce and audit builds accurately it's important to know exactly what happened during the build. To do this Enterprise Contract requires that all tasks are defined in a set of known and trusted task bundles. This package includes rules to confirm that the tasks that built the image were defined in task bundles, and that the task bundles used are from the list of known and trusted bundles.
 
 * Package name: `attestation_task_bundle`
-* Package full path: `release.attestation_task_bundle`
 
 [#attestation_task_bundle__trusted_bundles_provided]
 === link:#attestation_task_bundle__trusted_bundles_provided[A trusted Tekton bundles list was provided]
@@ -1635,7 +1617,6 @@ Check for the existence of a task bundle. This rule will fail if the task is not
 Enterprise Contract expects that a set of tasks were included in the pipeline build for each image to be released. This package includes a set of rules to verify that the expected tasks ran in the pipeline when the image was built. Required tasks for a pipeline are specified in a data source provided at runtime. This data source features two primary rule data keys: pipeline-required-tasks and required-tasks. The pipeline-required-tasks key lists all required tasks broken down by pipeline name, while required-tasks details a default or baseline set of tasks. If your pipeline corresponds to an entry under pipeline-required-tasks, those tasks will be prioritized; otherwise, the system will default to the tasks listed under required-tasks. Required tasks are listed by the names given to them within the task definition. Optionally invocation parameter of a Task can be also mandated by including the name and the value in square brackets following the name of the task. For example: name[PARAM=val]. Only single parameter is supported, to assert multiple parameters repeat the required task definition for each parameter seperately.
 
 * Package name: `tasks`
-* Package full path: `release.tasks`
 
 [#tasks__required_untrusted_task_found]
 === link:#tasks__required_untrusted_task_found[All required tasks are from trusted tasks]
@@ -1761,7 +1742,6 @@ The Tekton Task used is or will be unsupported. The Task is annotated with `buil
 Enterprise Contract requires that each build was subjected to a set of tests and that those tests all passed. This package includes a set of rules to verify that.
 
 * Package name: `test`
-* Package full path: `release.test`
 
 [#test__test_all_images]
 === link:#test__test_all_images[Image digest is present in IMAGES_PROCESSED result]
@@ -1891,7 +1871,6 @@ Each test result is expected to have a `results` key. Verify that the `results` 
 This package is used to verify all the Tekton Tasks involved in building the image are trusted. Trust is established by comparing the Task references found in the SLSA Provenance with a pre-defined list of trusted Tasks, which is expected to be provided as a data source that creates the `data.trusted_tasks` in the format demonstrated at https://github.com/enterprise-contract/ec-policies/blob/main/example/data/trusted_tekton_tasks.yml. The list can be extended or customized using the `trusted_tasks` rule data key which is merged into the `trusted_tasks` data.
 
 * Package name: `trusted_task`
-* Package full path: `release.trusted_task`
 
 [#trusted_task__data_format]
 === link:#trusted_task__data_format[Data format]
@@ -1988,7 +1967,6 @@ Confirm certain parameters provided to each builder Task have come from trusted 
 This package is responsible for verifying the rpm-ostree Tekton Task was executed with the expected parameters.
 
 * Package name: `rpm_ostree_task`
-* Package full path: `release.rpm_ostree_task`
 
 [#rpm_ostree_task__builder_image_param]
 === link:#rpm_ostree_task__builder_image_param[Builder image parameter]

--- a/antora/docs/modules/ROOT/pages/task_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/task_policy.adoc
@@ -10,7 +10,6 @@ These rules are applied to Tekton task definitions.
 This package ensures that a Task definition contains expected values for the image references used by the Task's steps.
 
 * Package name: `step_image_registries`
-* Package full path: `task.step_image_registries`
 
 [#step_image_registries__step_image_registry_prefix_list_provided]
 === link:#step_image_registries__step_image_registry_prefix_list_provided[Permitted step image registry prefix list provided]
@@ -42,7 +41,6 @@ Confirm that each step in the Task uses a container image with a URL that matche
 Policies to verify that a Tekton Task definition uses well formed expected annotations .
 
 * Package name: `annotations`
-* Package full path: `task.annotations`
 
 [#annotations__expires_on_format]
 === link:#annotations__expires_on_format[Task definition uses expires-on annotation in RFC3339 format]
@@ -60,7 +58,6 @@ Make sure to use the date format in RFC3339 format in the "build.appstudio.redha
 Verify Tekton Task definitions provide expected results.
 
 * Package name: `results`
-* Package full path: `task.results`
 
 [#results__required]
 === link:#results__required[Required result defined]
@@ -90,7 +87,6 @@ Confirm the expected `required_task_results` rule data key has been provided in 
 Policies to verify that a Tekton task definition has the expected value for kind.
 
 * Package name: `kind`
-* Package full path: `task.kind`
 
 [#kind__kind_present]
 === link:#kind__kind_present[Kind field is present in task definition]
@@ -118,7 +114,6 @@ Confirm the task definition has the kind "Task".
 Policies to verify that a Tekton task definition conforms to the expected conventions required for using Trusted Artifacts.
 
 * Package name: `trusted_artifacts`
-* Package full path: `task.trusted_artifacts`
 
 [#trusted_artifacts__parameter]
 === link:#trusted_artifacts__parameter[Parameter]

--- a/antora/docs/modules/ROOT/partials/build_task_policy_nav.adoc
+++ b/antora/docs/modules/ROOT/partials/build_task_policy_nav.adoc
@@ -1,4 +1,4 @@
 * xref:build_task_policy.adoc[Build Task Policy]
-** xref:build_task_policy.adoc#labels_package[Tekton task build type label checks]
-*** xref:build_task_policy.adoc#labels__build_type_label_set[Build task has build type label]
-*** xref:build_task_policy.adoc#labels__build_task_has_label[Build task has label]
+** xref:build_task_policy.adoc#build_labels_package[Tekton task build type label checks]
+*** xref:build_task_policy.adoc#build_labels__build_type_label_set[Build task has build type label]
+*** xref:build_task_policy.adoc#build_labels__build_task_has_label[Build task has label]

--- a/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
+++ b/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
@@ -4,6 +4,7 @@
 *** xref:release_policy.adoc#minimal[minimal]
 *** xref:release_policy.adoc#policy_data[policy_data]
 *** xref:release_policy.adoc#redhat[redhat]
+*** xref:release_policy.adoc#rhtap-jenkins[rhtap-jenkins]
 *** xref:release_policy.adoc#slsa3[slsa3]
 ** Release Rules
 *** xref:release_policy.adoc#attestation_type_package[Attestation type]

--- a/docs/asciidoc/asciidoc.go
+++ b/docs/asciidoc/asciidoc.go
@@ -45,9 +45,10 @@ func (d *doc) SetAnnotations(a []ast.FlatAnnotationsRefSet) {
 	for _, set := range a {
 		rules := make([]*ast.Annotations, 0, 5)
 		for _, ref := range set {
-			path := ref.GetPackage().Path.String()
-			if strings.HasPrefix(path, fmt.Sprintf("data.%s.", d.Qualifier)) {
-				if strings.Contains(path, ".collection.") {
+			pkgPath := ref.GetPackage().Path.String()
+			locationPrefix := filepath.Join("policy", d.Qualifier)
+			if strings.HasPrefix(ref.Location.File, locationPrefix) {
+				if strings.Contains(pkgPath, ".collection.") {
 					c := col{ref.Annotations, nil}
 					c.SetAnnotations(a)
 					collections = append(collections, c)
@@ -192,7 +193,6 @@ func init() {
 	funcs := template.FuncMap{
 		"anchor":           anchor,
 		"packageName":      packageName,
-		"packageFullPath":  packageFullPath,
 		"warningOrFailure": warningOrFailure,
 		"toUpper":          strings.ToUpper,
 		"toTitle":          strings.ToTitle,
@@ -207,10 +207,6 @@ func init() {
 func packageName(p *pkg) string {
 	path := p.path()
 	return path[len(path)-1]
-}
-
-func packageFullPath(p *pkg) string {
-	return strings.Join(p.path()[1:], ".")
 }
 
 func anchor(a *ast.Annotations) string {

--- a/docs/asciidoc/policy.template
+++ b/docs/asciidoc/policy.template
@@ -34,7 +34,6 @@ Rules included:{{ "\n" }}
 {{ .Description }}
 
 * Package name: `{{ packageName . }}`
-* Package full path: `{{ packageFullPath . }}`
 
 {{- range .Rules }}
 

--- a/policy/build_task/build_labels/build_labels.rego
+++ b/policy/build_task/build_labels/build_labels.rego
@@ -5,7 +5,7 @@
 #   Policies to verify that a Tekton build task definition has the
 #   required build type label.
 #
-package build_task.labels
+package build_labels
 
 import rego.v1
 

--- a/policy/build_task/build_labels/build_labels_test.rego
+++ b/policy/build_task/build_labels/build_labels_test.rego
@@ -1,25 +1,25 @@
-package build_task.labels_test
+package build_labels_test
 
 import rego.v1
 
-import data.build_task.labels
+import data.build_labels
 import data.lib
 
 test_build_label_found if {
 	# regal ignore:line-length
-	lib.assert_empty(labels.deny) with input as {"metadata": {"labels": {"build.appstudio.redhat.com/build_type": "docker"}}}
+	lib.assert_empty(build_labels.deny) with input as {"metadata": {"labels": {"build.appstudio.redhat.com/build_type": "docker"}}}
 }
 
 test_build_label_not_found if {
-	lib.assert_equal_results(labels.deny, {{
-		"code": "labels.build_type_label_set",
+	lib.assert_equal_results(build_labels.deny, {{
+		"code": "build_labels.build_type_label_set",
 		"msg": "The required build label 'build.appstudio.redhat.com/build_type' is missing",
 	}}) with input as {"metadata": {"labels": {"bad": "docker"}}}
 }
 
 test_no_labels if {
-	lib.assert_equal_results(labels.deny, {{
-		"code": "labels.build_task_has_label",
+	lib.assert_equal_results(build_labels.deny, {{
+		"code": "build_labels.build_task_has_label",
 		"msg": "The task definition does not include any labels",
 	}}) with input as {"metadata": {"name": "no_labels"}}
 }

--- a/policy/lib/result_helper.rego
+++ b/policy/lib/result_helper.rego
@@ -40,36 +40,15 @@ _code(chain) := code if {
 # custom.short_name must be present.
 _rule_annotations(chain) := chain[0].annotations
 
-# This is meant to match the special handling done in ec-cli, see here:
-# https://github.com/enterprise-contract/ec-cli/blob/014a488a4/internal/opa/rule/rule.go#L161-L186
 _pkg_name(rule_path) := name if {
-	# Seems to not work if I keep assigning to a single var, so
-	# that's why the many different pN vars.
-
-	# Strip off the first element which is always "data"
+	# "data" is automatically added by rego.
 	p1 := _left_strip_elements(["data"], rule_path)
 
-	# Strip off policy.release or policy.pipeline to match what ec-cli
-	# does. (There are some edge cases where the behavior is not exactly
-	# the same, but I think this version is better.)
-	p2 := _left_strip_elements(["release"], p1)
-	p3 := _left_strip_elements(["pipeline"], p2)
+	# Remove the actual rule name as that is not part of the package.
+	p2 := _right_strip_elements(["deny"], p1)
+	p3 := _right_strip_elements(["warn"], p2)
 
-	# Actually ec-cli doesn't remove these, but lots of tests in this repo
-	# assume it will be removed, so let's go with the flow for now.
-	# (We might want to revist this behavior in future.)
-	p4 := _left_strip_elements(["task"], p3)
-	p5 := _left_strip_elements(["build_task"], p4)
-
-	# Strip off "policy" no matter what
-	p6 := _left_strip_elements(["policy"], p5)
-
-	# Remove the "deny" or "warn" element
-	p7 := _right_strip_elements(["deny"], p6)
-	p8 := _right_strip_elements(["warn"], p7)
-
-	# Put it all together with dots in between
-	name := concat(".", p8)
+	name := concat(".", p3)
 }
 
 _left_strip_elements(items_to_strip, list) := new_list if {

--- a/policy/lib/result_helper_test.rego
+++ b/policy/lib/result_helper_test.rego
@@ -17,7 +17,7 @@ test_result_helper if {
 	}}
 
 	chain := [
-		{"annotations": rule_annotations, "path": ["data", "policy", "oh", "deny"]},
+		{"annotations": rule_annotations, "path": ["data", "oh", "deny"]},
 		{"annotations": {}, "path": ["ignored", "ignored"]}, # Actually not needed any more
 	]
 
@@ -36,7 +36,7 @@ test_result_helper_without_package_annotation if {
 		"failure_msg": "Bad thing %s",
 	}}
 
-	chain := [{"annotations": rule_annotations, "path": ["release", "package_name", "deny"]}]
+	chain := [{"annotations": rule_annotations, "path": ["package_name", "deny"]}]
 
 	lib.assert_equal(expected_result, lib.result_helper(chain, ["foo"]))
 }
@@ -77,7 +77,7 @@ test_result_helper_with_term if {
 	}}
 
 	chain := [
-		{"annotations": rule_annotations, "path": ["data", "release", "path", "oh", "deny"]},
+		{"annotations": rule_annotations, "path": ["data", "path", "oh", "deny"]},
 		{"annotations": {}, "path": ["ignored", "also_ignored"]},
 	]
 
@@ -86,43 +86,24 @@ test_result_helper_with_term if {
 
 test_result_helper_pkg_name if {
 	# "Normal" for ec-policies repo
-	lib.assert_equal("foo", lib._pkg_name(["data", "release", "foo", "deny"]))
-	lib.assert_equal("foo", lib._pkg_name(["data", "pipeline", "foo", "warn"]))
+	lib.assert_equal("foo", lib._pkg_name(["data", "foo", "deny"]))
+	lib.assert_equal("foo", lib._pkg_name(["data", "foo", "warn"]))
 
-	# Other categories that also get removed. These might be buggy in ec-cli
-	lib.assert_equal("foo", lib._pkg_name(["data", "task", "foo", "deny"]))
-	lib.assert_equal("foo", lib._pkg_name(["data", "build_task", "foo", "warn"]))
-
-	# Some other category other than release or pipeline
-	lib.assert_equal("another.foo.bar", lib._pkg_name(["data", "policy", "another", "foo", "bar", "deny"]))
-
-	# One extra level of package namespace
-	lib.assert_equal("foo.bar", lib._pkg_name(["data", "release", "foo", "bar", "deny"]))
-	lib.assert_equal("foo.bar", lib._pkg_name(["data", "pipeline", "foo", "bar", "warn"]))
-
-	# A custom policy that doesn't follow the conventions
-	lib.assert_equal("my_policy", lib._pkg_name(["data", "my_policy", "deny"]))
-	lib.assert_equal("my_policy.stuff", lib._pkg_name(["data", "my_policy", "stuff", "warn"]))
+	# Long package paths are retained
+	lib.assert_equal("another.foo.bar", lib._pkg_name(["data", "another", "foo", "bar", "deny"]))
+	lib.assert_equal("another.foo.bar", lib._pkg_name(["data", "another", "foo", "bar", "warn"]))
 
 	# Unlikely edge case: No deny or warn
 	lib.assert_equal("foo", lib._pkg_name(["data", "foo"]))
 	lib.assert_equal("foo.bar", lib._pkg_name(["data", "foo", "bar"]))
 
 	# Unlikely edge case: No data
-	# lib.assert_equal("foo", lib._pkg_name(["foo", "deny"]))
+	lib.assert_equal("foo", lib._pkg_name(["foo", "deny"]))
 	lib.assert_equal("foo.bar", lib._pkg_name(["foo", "bar", "warn"]))
 
-	# Unlikely edge case: Documenting this since it likely doesn't match the ec-cli behavior,
-	# but actually I think this way is slightly more sane, so let's accept the discrepancy for now.
-	# lib.assert_equal("pipeline.foo", lib._pkg_name(["data", "release", "pipeline", "foo", "deny"]))
-	lib.assert_equal("release.foo", lib._pkg_name(["data", "pipeline", "release", "foo", "deny"]))
-
 	# Very unlikely edge case: Just to illustrate how deny/warn/data are stripped once
-	# lib.assert_equal("foo", lib._pkg_name(["data", "policy", "release", "foo", "warn", "deny"]))
-	lib.assert_equal("foo.deny", lib._pkg_name(["data", "release", "foo", "deny", "warn"]))
-	lib.assert_equal("foo.warn", lib._pkg_name(["data", "release", "foo", "warn", "warn"]))
-	lib.assert_equal(
-		"data.release.foo.warn.deny",
-		lib._pkg_name(["data", "data", "release", "foo", "warn", "deny", "warn"]),
-	)
+	lib.assert_equal("foo", lib._pkg_name(["data", "foo", "warn", "deny"]))
+	lib.assert_equal("foo.deny", lib._pkg_name(["data", "foo", "deny", "warn"]))
+	lib.assert_equal("foo.warn", lib._pkg_name(["data", "foo", "warn", "warn"]))
+	lib.assert_equal("data.foo.warn.deny", lib._pkg_name(["data", "data", "foo", "warn", "deny", "warn"]))
 }

--- a/policy/pipeline/basic/basic.rego
+++ b/policy/pipeline/basic/basic.rego
@@ -4,7 +4,7 @@
 # description: >-
 #   Policies to confirm the Tekton Pipeline definition has the expected kind.
 #
-package pipeline.basic
+package basic
 
 import rego.v1
 

--- a/policy/pipeline/basic/basic_test.rego
+++ b/policy/pipeline/basic/basic_test.rego
@@ -1,9 +1,9 @@
-package pipeline.basic_test
+package basic_test
 
 import rego.v1
 
+import data.basic
 import data.lib
-import data.pipeline.basic
 
 test_unexpected_kind if {
 	lib.assert_equal_results(basic.deny, {{

--- a/policy/pipeline/required_tasks/required_tasks.rego
+++ b/policy/pipeline/required_tasks/required_tasks.rego
@@ -6,7 +6,7 @@
 #   This package includes policy rules to confirm that the pipeline definition
 #   includes those required tasks.
 #
-package pipeline.required_tasks
+package required_tasks
 
 import rego.v1
 

--- a/policy/pipeline/required_tasks/required_tasks_test.rego
+++ b/policy/pipeline/required_tasks/required_tasks_test.rego
@@ -1,9 +1,9 @@
-package pipeline.required_tasks_test
+package required_tasks_test
 
 import rego.v1
 
 import data.lib
-import data.pipeline.required_tasks
+import data.required_tasks
 
 test_required_tasks_met if {
 	pipeline := _pipeline_with_tasks_and_label(_expected_required_tasks, [], [])

--- a/policy/pipeline/task_bundle/task_bundle.rego
+++ b/policy/pipeline/task_bundle/task_bundle.rego
@@ -10,7 +10,7 @@
 #   bundles, and that the task bundles are from the list of known
 #   and trusted bundles.
 #
-package pipeline.task_bundle
+package task_bundle
 
 import rego.v1
 

--- a/policy/pipeline/task_bundle/task_bundle_test.rego
+++ b/policy/pipeline/task_bundle/task_bundle_test.rego
@@ -1,9 +1,9 @@
-package pipeline.task_bundle_test
+package task_bundle_test
 
 import rego.v1
 
 import data.lib
-import data.pipeline.task_bundle
+import data.task_bundle
 
 test_bundle_not_exists if {
 	tasks := [{"name": "my-task", "taskRef": {}}]

--- a/policy/release/attestation_task_bundle/attestation_task_bundle.rego
+++ b/policy/release/attestation_task_bundle/attestation_task_bundle.rego
@@ -10,7 +10,7 @@
 #   bundles, and that the task bundles used are from the list of known
 #   and trusted bundles.
 #
-package release.attestation_task_bundle
+package attestation_task_bundle
 
 import rego.v1
 

--- a/policy/release/attestation_task_bundle/attestation_task_bundle_test.rego
+++ b/policy/release/attestation_task_bundle/attestation_task_bundle_test.rego
@@ -1,11 +1,11 @@
-package release.attestation_task_bundle_test
+package attestation_task_bundle_test
 
 import rego.v1
 
+import data.attestation_task_bundle
 import data.lib
 import data.lib.tekton_test
 import data.lib_test
-import data.release.attestation_task_bundle
 
 mock_data(task) := {"statement": {"predicate": {
 	"buildConfig": {"tasks": [task]},

--- a/policy/release/attestation_type/attestation_type.rego
+++ b/policy/release/attestation_type/attestation_type.rego
@@ -4,7 +4,7 @@
 # description: >-
 #   Sanity checks related to the format of the image build's attestation.
 #
-package release.attestation_type
+package attestation_type
 
 import rego.v1
 

--- a/policy/release/attestation_type/attestation_type_test.rego
+++ b/policy/release/attestation_type/attestation_type_test.rego
@@ -1,9 +1,9 @@
-package release.attestation_type_test
+package attestation_type_test
 
 import rego.v1
 
+import data.attestation_type
 import data.lib
-import data.release.attestation_type
 
 good_type := "https://in-toto.io/Statement/v0.1"
 

--- a/policy/release/base_image_registries/base_image_registries.rego
+++ b/policy/release/base_image_registries/base_image_registries.rego
@@ -5,7 +5,7 @@
 #   This package is responsible for verifying the base (parent) images
 #   reported in the SLSA Provenace or the SBOM are allowed.
 #
-package release.base_image_registries
+package base_image_registries
 
 import rego.v1
 

--- a/policy/release/base_image_registries/base_image_registries_test.rego
+++ b/policy/release/base_image_registries/base_image_registries_test.rego
@@ -1,9 +1,9 @@
-package release.base_image_registries_test
+package base_image_registries_test
 
 import rego.v1
 
+import data.base_image_registries
 import data.lib
-import data.release.base_image_registries
 
 test_allowed_base_images if {
 	sboms := [{"formulation": [

--- a/policy/release/buildah_build_task/buildah_build_task.rego
+++ b/policy/release/buildah_build_task/buildah_build_task.rego
@@ -4,7 +4,7 @@
 # description: >-
 #   This package is responsible for verifying the buildah build task
 #
-package release.buildah_build_task
+package buildah_build_task
 
 import rego.v1
 

--- a/policy/release/buildah_build_task/buildah_build_task_test.rego
+++ b/policy/release/buildah_build_task/buildah_build_task_test.rego
@@ -1,10 +1,10 @@
-package release.buildah_build_task_test
+package buildah_build_task_test
 
 import rego.v1
 
+import data.buildah_build_task
 import data.lib
 import data.lib.tekton_test
-import data.release.buildah_build_task
 
 test_good_dockerfile_param if {
 	attestation := _attestation("buildah", {"parameters": {"DOCKERFILE": "./Dockerfile"}}, _results)

--- a/policy/release/collection/github/github.rego
+++ b/policy/release/collection/github/github.rego
@@ -3,6 +3,6 @@
 # title: github
 # description: >-
 #   A set of policy rules to validate artifacts built on GitHub.
-package release.collection.github
+package collection.github
 
 import rego.v1

--- a/policy/release/collection/minimal/minimal.rego
+++ b/policy/release/collection/minimal/minimal.rego
@@ -5,6 +5,6 @@
 #   Includes a minimal set of policy rules to ensure the build pipeline is
 #   functioning as expected, and able to produce signed attestations of the
 #   expected type.
-package release.collection.minimal
+package collection.minimal
 
 import rego.v1

--- a/policy/release/collection/policy_data/policy_data.rego
+++ b/policy/release/collection/policy_data/policy_data.rego
@@ -3,6 +3,6 @@
 # title: policy_data
 # description: >-
 #   Include policy rules responsible for validating rule data.
-package release.collection.policy_data
+package collection.policy_data
 
 import rego.v1

--- a/policy/release/collection/redhat/redhat.rego
+++ b/policy/release/collection/redhat/redhat.rego
@@ -3,6 +3,6 @@
 # title: redhat
 # description: >-
 #   Include the set of policy rules required for Red Hat products.
-package release.collection.redhat
+package collection.redhat
 
 import rego.v1

--- a/policy/release/collection/slsa3/slsa3.rego
+++ b/policy/release/collection/slsa3/slsa3.rego
@@ -3,6 +3,6 @@
 # title: slsa3
 # description: >-
 #   Includes policy rules required to meet SLSA Level 3.
-package release.collection.slsa3
+package collection.slsa3
 
 import rego.v1

--- a/policy/release/cve/cve.rego
+++ b/policy/release/cve/cve.rego
@@ -6,7 +6,7 @@
 #   the build pipeline, and that the image under test does not contain CVEs
 #   of certain security levels.
 #
-package release.cve
+package cve
 
 import rego.v1
 

--- a/policy/release/cve/cve_test.rego
+++ b/policy/release/cve/cve_test.rego
@@ -1,11 +1,11 @@
-package release.cve_test
+package cve_test
 
 import rego.v1
 
+import data.cve
 import data.lib
 import data.lib.tekton_test
 import data.lib_test
-import data.release.cve
 
 test_success if {
 	slsav1_task_with_result := tekton_test.slsav1_task_result_ref(

--- a/policy/release/external_parameters/external_parameters.rego
+++ b/policy/release/external_parameters/external_parameters.rego
@@ -5,7 +5,7 @@
 #   Verify the attribute .predicate.buildDefinition.externalParameters of a
 #   SLSA Provenance v1.0 matches the expectation.
 #
-package release.external_parameters
+package external_parameters
 
 import rego.v1
 

--- a/policy/release/external_parameters/external_parameters_test.rego
+++ b/policy/release/external_parameters/external_parameters_test.rego
@@ -1,9 +1,9 @@
-package release.external_parameters_test
+package external_parameters_test
 
 import rego.v1
 
+import data.external_parameters
 import data.lib
-import data.release.external_parameters
 
 test_success if {
 	lib.assert_empty(external_parameters.deny) with input.attestations as [good_provenance]

--- a/policy/release/github_certificate/github_certificate.rego
+++ b/policy/release/github_certificate/github_certificate.rego
@@ -5,7 +5,7 @@
 #   Verify attributes on the certificate involved in the image signature when using
 #   slsa-github-generator on GitHub Actions with Sigstore Fulcio
 #
-package release.github_certificate
+package github_certificate
 
 import rego.v1
 

--- a/policy/release/github_certificate/github_certificate_test.rego
+++ b/policy/release/github_certificate/github_certificate_test.rego
@@ -1,9 +1,9 @@
-package release.github_certificate_test
+package github_certificate_test
 
 import rego.v1
 
+import data.github_certificate
 import data.lib
-import data.release.github_certificate
 
 test_all_good if {
 	signatures := [{"certificate": good_cert}]

--- a/policy/release/hermetic_build_task/hermetic_build_task.rego
+++ b/policy/release/hermetic_build_task/hermetic_build_task.rego
@@ -5,7 +5,7 @@
 #   This package verifies the build task in the attestation was invoked
 #   with the expected parameters to perform a hermetic build.
 #
-package release.hermetic_build_task
+package hermetic_build_task
 
 import rego.v1
 

--- a/policy/release/hermetic_build_task/hermetic_build_task_test.rego
+++ b/policy/release/hermetic_build_task/hermetic_build_task_test.rego
@@ -1,9 +1,9 @@
-package release.hermetic_build_task_test
+package hermetic_build_task_test
 
 import rego.v1
 
+import data.hermetic_build_task
 import data.lib
-import data.release.hermetic_build_task
 
 test_hermetic_build if {
 	lib.assert_empty(hermetic_build_task.deny) with input.attestations as [_good_attestation]

--- a/policy/release/java/java.rego
+++ b/policy/release/java/java.rego
@@ -15,7 +15,7 @@
 #   Default configuration in Konflux currently includes Maven repositories with
 #   names : 'jboss', 'confluent', 'redhat', 'jitpack' and 'gradle'.
 #
-package release.java
+package java
 
 import rego.v1
 

--- a/policy/release/java/java_test.rego
+++ b/policy/release/java/java_test.rego
@@ -1,11 +1,11 @@
-package release.java_test
+package java_test
 
 import rego.v1
 
+import data.java
 import data.lib
 import data.lib.tekton_test
 import data.lib_test
-import data.release.java
 
 test_all_good if {
 	attestations := [

--- a/policy/release/labels/labels.rego
+++ b/policy/release/labels/labels.rego
@@ -8,7 +8,7 @@
 #   An FBC image is detected by the presence of the
 #   operators.operatorframework.io.index.configs.v1 label.
 #
-package release.labels
+package labels
 
 import rego.v1
 

--- a/policy/release/labels/labels_test.rego
+++ b/policy/release/labels/labels_test.rego
@@ -1,9 +1,9 @@
-package release.labels_test
+package labels_test
 
 import rego.v1
 
+import data.labels
 import data.lib
-import data.release.labels
 
 # For these tests builtin functions ec.oci.image_manifest and ec.oci.blob need
 # to be mocked. Both take a single parameter -- the image reference, for which

--- a/policy/release/olm/olm.rego
+++ b/policy/release/olm/olm.rego
@@ -4,7 +4,7 @@
 # description: >-
 #   Checks for Operator Lifecycle Manager (OLM) bundles.
 #
-package release.olm
+package olm
 
 import rego.v1
 

--- a/policy/release/olm/olm_test.rego
+++ b/policy/release/olm/olm_test.rego
@@ -1,9 +1,9 @@
-package release.olm_test
+package olm_test
 
 import rego.v1
 
 import data.lib
-import data.release.olm
+import data.olm
 
 pinned := "registry.io/repository/image@sha256:cafe"
 

--- a/policy/release/provenance_materials/provenance_materials.rego
+++ b/policy/release/provenance_materials/provenance_materials.rego
@@ -5,7 +5,7 @@
 #   This package provides rules for verifying the contents of the materials section
 #   of the SLSA Provenance attestation.
 #
-package release.provenance_materials
+package provenance_materials
 
 import rego.v1
 

--- a/policy/release/provenance_materials/provenance_materials_test.rego
+++ b/policy/release/provenance_materials/provenance_materials_test.rego
@@ -1,9 +1,9 @@
-package release.provenance_materials_test
+package provenance_materials_test
 
 import rego.v1
 
 import data.lib
-import data.release.provenance_materials
+import data.provenance_materials
 
 test_all_good if {
 	tasks := [{

--- a/policy/release/quay_expiration/quay_expiration.rego
+++ b/policy/release/quay_expiration/quay_expiration.rego
@@ -7,7 +7,7 @@
 #   produced by "on-pr" build pipelines, i.e. pre-merge CI builds,
 #   so this is intended to prevent accidentally releasing a CI build.
 #
-package release.quay_expiration
+package quay_expiration
 
 import rego.v1
 

--- a/policy/release/quay_expiration/quay_expiration_test.rego
+++ b/policy/release/quay_expiration/quay_expiration_test.rego
@@ -1,9 +1,9 @@
-package release.quay_expiration_test
+package quay_expiration_test
 
 import rego.v1
 
 import data.lib
-import data.release.quay_expiration
+import data.quay_expiration
 
 test_ci_pipeline if {
 	# Should not produce violations when we're in a non-release pipeline

--- a/policy/release/rhtap_jenkins/rhtap_jenkins.rego
+++ b/policy/release/rhtap_jenkins/rhtap_jenkins.rego
@@ -8,7 +8,7 @@
 #   Jenkins pipelines are defined under
 #   https://github.com/redhat-appstudio/tssc-sample-templates/tree/main/skeleton/ci
 #
-package release.rhtap_jenkins
+package rhtap_jenkins
 
 import rego.v1
 

--- a/policy/release/rhtap_jenkins/rhtap_jenkins_test.rego
+++ b/policy/release/rhtap_jenkins/rhtap_jenkins_test.rego
@@ -1,9 +1,9 @@
-package release.rhtap_jenkins_test
+package rhtap_jenkins_test
 
 import rego.v1
 
 import data.lib
-import data.release.rhtap_jenkins
+import data.rhtap_jenkins
 
 test_jenkins_atts_happy_path if {
 	lib.assert_empty(rhtap_jenkins.deny) with input.attestations as [good_att]

--- a/policy/release/rpm_ostree_task/rpm_ostree_task.rego
+++ b/policy/release/rpm_ostree_task/rpm_ostree_task.rego
@@ -5,7 +5,7 @@
 #   This package is responsible for verifying the rpm-ostree Tekton Task was executed with the
 #   expected parameters.
 #
-package release.rpm_ostree_task
+package rpm_ostree_task
 
 import rego.v1
 

--- a/policy/release/rpm_ostree_task/rpm_ostree_task_test.rego
+++ b/policy/release/rpm_ostree_task/rpm_ostree_task_test.rego
@@ -1,9 +1,9 @@
-package release.rpm_ostree_task_test
+package rpm_ostree_task_test
 
 import rego.v1
 
 import data.lib
-import data.release.rpm_ostree_task
+import data.rpm_ostree_task
 
 test_success if {
 	slsa_v02_attestation := {"statement": {"predicate": {

--- a/policy/release/rpm_repos/rpm_repos.rego
+++ b/policy/release/rpm_repos/rpm_repos.rego
@@ -5,7 +5,7 @@
 #   This package defines rules to confirm that all RPM packages listed
 #   in SBOMs specify a known and permitted repository id.
 #
-package release.rpm_repos
+package rpm_repos
 
 import rego.v1
 

--- a/policy/release/rpm_repos/rpm_repos_test.rego
+++ b/policy/release/rpm_repos/rpm_repos_test.rego
@@ -1,9 +1,9 @@
-package release.rpm_repos_test
+package rpm_repos_test
 
 import rego.v1
 
 import data.lib
-import data.release.rpm_repos
+import data.rpm_repos
 
 test_repo_id_data_empty if {
 	expected := {

--- a/policy/release/rpm_signature/rpm_signature.rego
+++ b/policy/release/rpm_signature/rpm_signature.rego
@@ -5,7 +5,7 @@
 #   This package provides rules for verifying the signatures of RPMs identified in the the SLSA
 #   Provenance attestation.
 #
-package release.rpm_signature
+package rpm_signature
 
 import rego.v1
 

--- a/policy/release/rpm_signature/rpm_signature_test.rego
+++ b/policy/release/rpm_signature/rpm_signature_test.rego
@@ -1,11 +1,11 @@
-package release.rpm_signature_test
+package rpm_signature_test
 
 import rego.v1
 
 import data.lib
 import data.lib.tekton_test
 import data.lib_test
-import data.release.rpm_signature
+import data.rpm_signature
 
 test_success if {
 	result_value := {"keys": {"abcdef0123456789": 1, "ABCDEF0123456789": 2, "unsigned": 0}}

--- a/policy/release/sbom/sbom.rego
+++ b/policy/release/sbom/sbom.rego
@@ -5,7 +5,7 @@
 #   Checks general properties of the SBOMs associated with the image being validated. More specific
 #   rules for SPDX and CycloneDX SBOMs are in separate packages.
 #
-package release.sbom
+package sbom
 
 import rego.v1
 

--- a/policy/release/sbom/sbom_test.rego
+++ b/policy/release/sbom/sbom_test.rego
@@ -1,9 +1,9 @@
-package release.sbom_test
+package sbom_test
 
 import rego.v1
 
 import data.lib
-import data.release.sbom
+import data.sbom
 
 test_not_found if {
 	expected := {{"code": "sbom.found", "msg": "No SBOM attestations found"}}

--- a/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego
+++ b/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego
@@ -6,7 +6,7 @@
 #   The SBOMs are read from multiple locations: a file within the image, and a CycloneDX SBOM
 #   attestation.
 #
-package release.sbom_cyclonedx
+package sbom_cyclonedx
 
 import rego.v1
 

--- a/policy/release/sbom_cyclonedx/sbom_cyclonedx_schema.rego
+++ b/policy/release/sbom_cyclonedx/sbom_cyclonedx_schema.rego
@@ -1,4 +1,4 @@
-package release.sbom_cyclonedx
+package sbom_cyclonedx
 
 import rego.v1
 

--- a/policy/release/sbom_cyclonedx/sbom_cyclonedx_test.rego
+++ b/policy/release/sbom_cyclonedx/sbom_cyclonedx_test.rego
@@ -1,10 +1,10 @@
-package release.sbom_cyclonedx_test
+package sbom_cyclonedx_test
 
 import rego.v1
 
 import data.lib
 import data.lib.sbom
-import data.release.sbom_cyclonedx
+import data.sbom_cyclonedx
 
 test_all_good_from_attestation if {
 	lib.assert_empty(sbom_cyclonedx.deny) with input.attestations as [_sbom_attestation]

--- a/policy/release/sbom_spdx/sbom_spdx.rego
+++ b/policy/release/sbom_spdx/sbom_spdx.rego
@@ -5,7 +5,7 @@
 #   Checks different properties of the CycloneDX SBOMs associated with the image being validated.
 #   The SBOMs are read from multiple locations: a file within the image, and a CycloneDX SBOM
 #   attestation.
-package release.sbom_spdx
+package sbom_spdx
 
 import rego.v1
 

--- a/policy/release/sbom_spdx/sbom_spdx_schema.rego
+++ b/policy/release/sbom_spdx/sbom_spdx_schema.rego
@@ -1,4 +1,4 @@
-package release.sbom_spdx
+package sbom_spdx
 
 import rego.v1
 

--- a/policy/release/sbom_spdx/sbom_spdx_test.rego
+++ b/policy/release/sbom_spdx/sbom_spdx_test.rego
@@ -1,10 +1,10 @@
-package release.sbom_spdx_test
+package sbom_spdx_test
 
 import rego.v1
 
 import data.lib
 import data.lib.sbom
-import data.release.sbom_spdx
+import data.sbom_spdx
 
 test_all_good if {
 	lib.assert_empty(sbom_spdx.deny) with input.attestations as [_sbom_attestation]

--- a/policy/release/schedule/schedule.rego
+++ b/policy/release/schedule/schedule.rego
@@ -4,7 +4,7 @@
 # description: >-
 #   Rules that verify the current date conform to a given schedule.
 #
-package release.schedule
+package schedule
 
 import rego.v1
 

--- a/policy/release/schedule/schedule_test.rego
+++ b/policy/release/schedule/schedule_test.rego
@@ -1,9 +1,9 @@
-package release.schedule_test
+package schedule_test
 
 import rego.v1
 
 import data.lib
-import data.release.schedule
+import data.schedule
 
 test_no_restriction_by_default if {
 	lib.assert_empty(schedule.deny)

--- a/policy/release/slsa_build_build_service/slsa_build_build_service.rego
+++ b/policy/release/slsa_build_build_service/slsa_build_build_service.rego
@@ -10,7 +10,7 @@
 #   This package verifies the requirement by asserting the image was
 #   built by Tekton Pipelines.
 #
-package release.slsa_build_build_service
+package slsa_build_build_service
 
 import rego.v1
 

--- a/policy/release/slsa_build_build_service/slsa_build_build_service_test.rego
+++ b/policy/release/slsa_build_build_service/slsa_build_build_service_test.rego
@@ -1,9 +1,9 @@
-package release.slsa_build_build_service_test
+package slsa_build_build_service_test
 
 import rego.v1
 
 import data.lib
-import data.release.slsa_build_build_service
+import data.slsa_build_build_service
 
 test_all_good if {
 	builder_id := lib.rule_data("allowed_builder_ids")[0]

--- a/policy/release/slsa_build_scripted_build/slsa_build_scripted_build.rego
+++ b/policy/release/slsa_build_scripted_build/slsa_build_scripted_build.rego
@@ -10,7 +10,7 @@
 #   This package verifies the requirement by asserting the image was
 #   built by Tekton Pipelines.
 #
-package release.slsa_build_scripted_build
+package slsa_build_scripted_build
 
 import rego.v1
 

--- a/policy/release/slsa_build_scripted_build/slsa_build_scripted_build_test.rego
+++ b/policy/release/slsa_build_scripted_build/slsa_build_scripted_build_test.rego
@@ -1,9 +1,9 @@
-package release.slsa_build_scripted_build_test
+package slsa_build_scripted_build_test
 
 import rego.v1
 
 import data.lib
-import data.release.slsa_build_scripted_build
+import data.slsa_build_scripted_build
 
 mock_bundle_digest := "sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb"
 

--- a/policy/release/slsa_provenance_available/slsa_provenance_available.rego
+++ b/policy/release/slsa_provenance_available/slsa_provenance_available.rego
@@ -10,7 +10,7 @@
 #
 #   This package only accepts the in-toto SLSA Provenance format.
 #
-package release.slsa_provenance_available
+package slsa_provenance_available
 
 import rego.v1
 

--- a/policy/release/slsa_provenance_available/slsa_provenance_available_test.rego
+++ b/policy/release/slsa_provenance_available/slsa_provenance_available_test.rego
@@ -1,9 +1,9 @@
-package release.slsa_provenance_available_test
+package slsa_provenance_available_test
 
 import rego.v1
 
 import data.lib
-import data.release.slsa_provenance_available
+import data.slsa_provenance_available
 
 test_expected_predicate_type if {
 	attestations := _mock_attestations(["https://slsa.dev/provenance/v0.2"])

--- a/policy/release/slsa_source_correlated/slsa_source_correlated.rego
+++ b/policy/release/slsa_source_correlated/slsa_source_correlated.rego
@@ -10,7 +10,7 @@
 #   This package correlates the provided source code reference with the source
 #   code referenced in the attestation.
 #
-package release.slsa_source_correlated
+package slsa_source_correlated
 
 import rego.v1
 

--- a/policy/release/slsa_source_correlated/slsa_source_correlated_test.rego
+++ b/policy/release/slsa_source_correlated/slsa_source_correlated_test.rego
@@ -1,9 +1,9 @@
-package release.slsa_source_correlated_test
+package slsa_source_correlated_test
 
 import rego.v1
 
 import data.lib
-import data.release.slsa_source_correlated
+import data.slsa_source_correlated
 
 test_deny_missing_source_code_happy_day if {
 	lib.assert_empty(slsa_source_correlated.deny) with input.image as {"source": {"something": "here"}}

--- a/policy/release/slsa_source_version_controlled/slsa_source_version_controlled.rego
+++ b/policy/release/slsa_source_version_controlled/slsa_source_version_controlled.rego
@@ -24,7 +24,7 @@
 #   This package verifies the requirement by asserting the image was built
 #   from a git repository.
 #
-package release.slsa_source_version_controlled
+package slsa_source_version_controlled
 
 import rego.v1
 

--- a/policy/release/slsa_source_version_controlled/slsa_source_version_controlled_test.rego
+++ b/policy/release/slsa_source_version_controlled/slsa_source_version_controlled_test.rego
@@ -1,9 +1,9 @@
-package release.slsa_source_version_controlled_test
+package slsa_source_version_controlled_test
 
 import rego.v1
 
 import data.lib
-import data.release.slsa_source_version_controlled
+import data.slsa_source_version_controlled
 
 test_all_good if {
 	materials := [

--- a/policy/release/source_image/source_image.rego
+++ b/policy/release/source_image/source_image.rego
@@ -5,7 +5,7 @@
 #   This package is reponsible for verifying the source container image associated with the image
 #   being validated.
 #
-package release.source_image
+package source_image
 
 import rego.v1
 

--- a/policy/release/source_image/source_image_test.rego
+++ b/policy/release/source_image/source_image_test.rego
@@ -1,9 +1,9 @@
-package release.source_image_test
+package source_image_test
 
 import rego.v1
 
 import data.lib
-import data.release.source_image
+import data.source_image
 
 test_success if {
 	_mock_digest_nl := sprintf("%s\n", [_mock_digest])

--- a/policy/release/tasks/tasks.rego
+++ b/policy/release/tasks/tasks.rego
@@ -23,7 +23,7 @@
 #   required task definition for each parameter seperately.
 #
 #
-package release.tasks
+package tasks
 
 import rego.v1
 

--- a/policy/release/tasks/tasks_test.rego
+++ b/policy/release/tasks/tasks_test.rego
@@ -1,11 +1,11 @@
 # regal ignore:file-length
-package release.tasks_test
+package tasks_test
 
 import rego.v1
 
 import data.lib
 import data.lib.tekton_test
-import data.release.tasks
+import data.tasks
 
 test_no_tasks_present if {
 	expected := {{

--- a/policy/release/test/test.rego
+++ b/policy/release/test/test.rego
@@ -6,7 +6,7 @@
 #   to a set of tests and that those tests all passed. This package
 #   includes a set of rules to verify that.
 #
-package release.test
+package test
 
 import rego.v1
 

--- a/policy/release/test/test_test.rego
+++ b/policy/release/test/test_test.rego
@@ -1,11 +1,11 @@
-package release.test_test
+package test_test
 
 import rego.v1
 
 import data.lib
 import data.lib.tekton_test
 import data.lib_test
-import data.release.test
+import data.test
 
 # Because TEST_OUTPUT isn't in the task results, the lib.results_from_tests will be empty
 test_needs_non_empty_data if {

--- a/policy/release/trusted_task/trusted_task.rego
+++ b/policy/release/trusted_task/trusted_task.rego
@@ -10,7 +10,7 @@
 #   The list can be extended or customized using the `trusted_tasks` rule data key which is merged
 #   into the `trusted_tasks` data.
 #
-package release.trusted_task
+package trusted_task
 
 import rego.v1
 

--- a/policy/release/trusted_task/trusted_task_test.rego
+++ b/policy/release/trusted_task/trusted_task_test.rego
@@ -1,9 +1,9 @@
-package release.trusted_task_test
+package trusted_task_test
 
 import rego.v1
 
 import data.lib
-import data.release.trusted_task
+import data.trusted_task
 
 test_success if {
 	att_no_ta := {"statement": {"predicate": {

--- a/policy/task/annotations/annotations.rego
+++ b/policy/task/annotations/annotations.rego
@@ -5,7 +5,7 @@
 #   Policies to verify that a Tekton Task definition uses well formed expected
 #   annotations .
 #
-package task.annotations
+package annotations
 
 import rego.v1
 

--- a/policy/task/annotations/annotations_test.rego
+++ b/policy/task/annotations/annotations_test.rego
@@ -1,9 +1,9 @@
-package task.annotations_test
+package annotations_test
 
 import rego.v1
 
+import data.annotations
 import data.lib
-import data.task.annotations
 
 test_valid_expiry_dates if {
 	# regal ignore:line-length

--- a/policy/task/kind/kind.rego
+++ b/policy/task/kind/kind.rego
@@ -5,7 +5,7 @@
 #   Policies to verify that a Tekton task definition has the expected
 #   value for kind.
 #
-package task.kind
+package kind
 
 import rego.v1
 

--- a/policy/task/kind/kind_test.rego
+++ b/policy/task/kind/kind_test.rego
@@ -1,9 +1,9 @@
-package task.kind_test
+package kind_test
 
 import rego.v1
 
+import data.kind
 import data.lib
-import data.task.kind
 
 test_unexpected_kind if {
 	lib.assert_equal_results(kind.deny, {{

--- a/policy/task/results/results.rego
+++ b/policy/task/results/results.rego
@@ -3,7 +3,7 @@
 # title: Tekton Task result
 # description: Verify Tekton Task definitions provide expected results.
 #
-package task.results
+package results
 
 import rego.v1
 

--- a/policy/task/results/results_test.rego
+++ b/policy/task/results/results_test.rego
@@ -1,9 +1,9 @@
-package task.results_test
+package results_test
 
 import rego.v1
 
 import data.lib
-import data.task.results
+import data.results
 
 test_all_good if {
 	lib.assert_empty(results.deny) with input as _mock_task

--- a/policy/task/step_image_registries/step_image_registries.rego
+++ b/policy/task/step_image_registries/step_image_registries.rego
@@ -5,7 +5,7 @@
 #   This package ensures that a Task definition contains expected values for the image references
 #   used by the Task's steps.
 #
-package task.step_image_registries
+package step_image_registries
 
 import rego.v1
 

--- a/policy/task/step_image_registries/step_image_registries_test.rego
+++ b/policy/task/step_image_registries/step_image_registries_test.rego
@@ -1,9 +1,9 @@
-package task.step_image_registries_test
+package step_image_registries_test
 
 import rego.v1
 
 import data.lib
-import data.task.step_image_registries
+import data.step_image_registries
 
 good_image := "registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:af7dd5b3b"
 

--- a/policy/task/trusted_artifacts/trusted_artifacts.rego
+++ b/policy/task/trusted_artifacts/trusted_artifacts.rego
@@ -5,7 +5,7 @@
 #   Policies to verify that a Tekton task definition conforms to the expected conventions required
 #   for using Trusted Artifacts.
 #
-package task.trusted_artifacts
+package trusted_artifacts
 
 import rego.v1
 

--- a/policy/task/trusted_artifacts/trusted_artifacts_test.rego
+++ b/policy/task/trusted_artifacts/trusted_artifacts_test.rego
@@ -1,9 +1,9 @@
-package task.trusted_artifacts_test
+package trusted_artifacts_test
 
 import rego.v1
 
 import data.lib
-import data.task.trusted_artifacts
+import data.trusted_artifacts
 
 test_all_good if {
 	lib.assert_empty(trusted_artifacts.deny) with input as _task


### PR DESCRIPTION
This commit changes the package name of all the policy rules to a single level, e.g. `release.cve` becomes `cve`. This better aligns with how these packages are used today. It moves the EC ecosystem closer to using package names as they are defined without having to rely on dynamically alterations to the package name.

All package shortening code is removed from this repository. The package name used is now an exact match to the value provided to the `package` keyword in the rego files. (Note that package shortening still exists in the EC CLI, but that is expected to be removed soon as well.)

The docs generation code is modified to take into account the file path of the policies in addition to its annotations. This is needed to distinguish between the policies in different directories.

The "Package full name" section from the docs is removed since it is now exactly the same as the value of "Package name".

Although policy rules under different directories are never used together, the tests in this repo load them all at once. As such, the package names have to be unique across the different directories. The one case where this caused a conflict was with
`policy/build_task/labels` and `policy/release/labels`. To mitigate this, `policy/build_task/labels` is renamed to
`policy/build_task/build_labels`. This is a breaking change but given that this policy is not widely used, this is ok.

Ref: EC-864