### PR TITLE
Ignore missing SBOM for Image Indexes

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -308,7 +308,7 @@ Confirm the `allowed_registry_prefixes` rule data was provided, since it's requi
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `base_image_registries.allowed_registries_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/base_image_registries/base_image_registries.rego#L72[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/base_image_registries/base_image_registries.rego#L77[Source, window="_blank"]
 
 [#base_image_registries__base_image_permitted]
 === link:#base_image_registries__base_image_permitted[Base image comes from permitted registry]
@@ -320,7 +320,7 @@ Verify that the base images used when building a container image come from a kno
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Base image %q is from a disallowed registry`
 * Code: `base_image_registries.base_image_permitted`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/base_image_registries/base_image_registries.rego#L17[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/base_image_registries/base_image_registries.rego#L18[Source, window="_blank"]
 
 [#base_image_registries__base_image_info_found]
 === link:#base_image_registries__base_image_info_found[Base images provided]
@@ -332,7 +332,7 @@ Verify the expected information was provided about which base images were used d
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Base images information is missing`
 * Code: `base_image_registries.base_image_info_found`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/base_image_registries/base_image_registries.rego#L46[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/base_image_registries/base_image_registries.rego#L47[Source, window="_blank"]
 
 [#buildah_build_task_package]
 == link:#buildah_build_task_package[Buildah build task]
@@ -1066,7 +1066,7 @@ Confirm the `disallowed_packages` and `disallowed_attributes` rule data were pro
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `sbom.disallowed_packages_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom/sbom.rego#L31[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom/sbom.rego#L36[Source, window="_blank"]
 
 [#sbom__found]
 === link:#sbom__found[Found]
@@ -1078,7 +1078,7 @@ Confirm an SBOM attestation exists.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `No SBOM attestations found`
 * Code: `sbom.found`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom/sbom.rego#L14[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom/sbom.rego#L15[Source, window="_blank"]
 
 [#sbom_cyclonedx_package]
 == link:#sbom_cyclonedx_package[SBOM CycloneDX]

--- a/policy/lib/konflux/konflux.rego
+++ b/policy/lib/konflux/konflux.rego
@@ -1,0 +1,26 @@
+package lib.konflux
+
+import rego.v1
+
+import data.lib
+import data.lib.image
+import data.lib.tekton
+
+# Currently, it's not possible to determine if the image being validated is an Image Index or an
+# Image Manifest, see https://github.com/enterprise-contract/ec-cli/issues/2121. This function is
+# implemented as a workaround. It uses Konflux-specific heuristics to determine if the provided
+# image is an Image Index.
+is_validating_image_index if {
+	image_index_digests := {digest |
+		some attestation in lib.pipelinerun_attestations
+		some task in tekton.build_tasks(attestation)
+
+		# In Konflux, the Task that creates an Image Index emits the IMAGES result which contains
+		# all of the related Image Manifests.
+		count(trim_space(tekton.task_result(task, "IMAGES"))) > 0
+		digest := trim_space(tekton.task_result(task, "IMAGE_DIGEST"))
+		count(digest) > 0
+	}
+
+	image.parse(input.image.ref).digest in image_index_digests
+}

--- a/policy/lib/konflux/konflux_test.rego
+++ b/policy/lib/konflux/konflux_test.rego
@@ -1,0 +1,46 @@
+package lib.konflux_test
+
+import rego.v1
+
+import data.lib
+import data.lib.konflux
+
+test_is_image_index if {
+	konflux.is_validating_image_index with input.attestations as [_attestation]
+		with input.image.ref as "registry.local/ham@sha256:fff"
+}
+
+test_is_image_index_unknown_digest if {
+	not konflux.is_validating_image_index with input.attestations as [_attestation]
+		with input.image.ref as "registry.local/ham@sha256:bbb"
+}
+
+test_is_image_index_empty_images if {
+	att := json.patch(
+		_attestation,
+		[{"op": "add", "path": "/statement/predicate/buildConfig/tasks/0/results/0/value", "value": ""}],
+	)
+	not konflux.is_validating_image_index with input.attestations as [att]
+		with input.image.ref as "registry.local/ham@sha256:fff"
+}
+
+_attestation := {"statement": {"predicate": {
+	"buildType": lib.tekton_pipeline_run,
+	"buildConfig": {"tasks": [{"results": [
+		{
+			"name": "IMAGES",
+			"type": "string",
+			"value": "registry.local/spam@sha256:abc, registry.local/bacon@sha256:bcd",
+		},
+		{
+			"name": "IMAGE_URL",
+			"type": "string",
+			"value": "registry.local/eggs:latest",
+		},
+		{
+			"name": "IMAGE_DIGEST",
+			"type": "string",
+			"value": "sha256:fff",
+		},
+	]}]},
+}}}

--- a/policy/release/base_image_registries/base_image_registries.rego
+++ b/policy/release/base_image_registries/base_image_registries.rego
@@ -12,6 +12,7 @@ import rego.v1
 import data.lib
 import data.lib.image
 import data.lib.json as j
+import data.lib.konflux
 import data.lib.sbom
 
 # METADATA
@@ -61,6 +62,10 @@ deny contains result if {
 #   - attestation_type.known_attestation_type
 #
 deny contains result if {
+	# TODO: Workaround until Konflux produces SBOMs for Image Indexes:
+	# https://issues.redhat.com/browse/KONFLUX-4330
+	not konflux.is_validating_image_index
+
 	# Some images are built "from scratch" and not have any base images, e.g. UBI.
 	# This check distinguishes such images by simply ensuring that at least one SBOM
 	# is attached to the image.

--- a/policy/release/sbom/sbom.rego
+++ b/policy/release/sbom/sbom.rego
@@ -10,6 +10,7 @@ package sbom
 import rego.v1
 
 import data.lib
+import data.lib.konflux
 
 # METADATA
 # title: Found
@@ -24,6 +25,10 @@ import data.lib
 #   - redhat
 #
 deny contains result if {
+	# TODO: Workaround until Konflux produces SBOMs for Image Indexes:
+	# https://issues.redhat.com/browse/KONFLUX-4330
+	not konflux.is_validating_image_index
+
 	count(_sboms) == 0
 	result := lib.result_helper(rego.metadata.chain(), [])
 }

--- a/policy/release/sbom/sbom_test.rego
+++ b/policy/release/sbom/sbom_test.rego
@@ -11,6 +11,32 @@ test_not_found if {
 		with input.image.ref as "registry.local/spam@sha256:123"
 }
 
+test_not_found_image_index if {
+	att := {"statement": {"predicate": {
+		"buildType": lib.tekton_pipeline_run,
+		"buildConfig": {"tasks": [{"results": [
+			{
+				"name": "IMAGES",
+				"type": "string",
+				"value": "registry.local/spam@sha256:abc, registry.local/bacon@sha256:bcd",
+			},
+			{
+				"name": "IMAGE_URL",
+				"type": "string",
+				"value": "registry.local/eggs:latest",
+			},
+			{
+				"name": "IMAGE_DIGEST",
+				"type": "string",
+				"value": "sha256:fff",
+			},
+		]}]},
+	}}}
+
+	lib.assert_empty(sbom.deny) with input.attestations as [att]
+		with input.image.ref as "registry.local/ham@sha256:fff"
+}
+
 test_rule_data_validation if {
 	d := {
 		"disallowed_packages": [


### PR DESCRIPTION
Currently, Konflux does not create an SBOM for Image Indexes: https://issues.redhat.com/browse/KONFLUX-4330

Until then, do not trigger a violation when an SBOM is not found for such images.

Today, it's not possible to determine if the image being validated is an Image Index or an Image Manifest, see
https://github.com/enterprise-contract/ec-cli/issues/2121. The Image Index detection is done via Konflux-specific heuristics as a workaround.