### PR TITLE
Add allowed package sources policy

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -75,6 +75,7 @@ Rules included:
 * xref:release_policy.adoc#rpm_repos__rule_data_provided[RPM Repos: Known repo id list provided]
 * xref:release_policy.adoc#rpm_signature__rule_data_provided[RPM Signature: Rule data provided]
 * xref:release_policy.adoc#sbom_cyclonedx__allowed_package_external_references[SBOM CycloneDX: Allowed package external references]
+* xref:release_policy.adoc#sbom_cyclonedx__allowed_package_sources[SBOM CycloneDX: Allowed package sources]
 * xref:release_policy.adoc#sbom_cyclonedx__disallowed_package_attributes[SBOM CycloneDX: Disallowed package attributes]
 * xref:release_policy.adoc#sbom_cyclonedx__disallowed_package_external_references[SBOM CycloneDX: Disallowed package external references]
 * xref:release_policy.adoc#sbom__disallowed_packages_provided[SBOM: Disallowed packages list is provided]
@@ -142,6 +143,7 @@ Rules included:
 * xref:release_policy.adoc#rpm_signature__rule_data_provided[RPM Signature: Rule data provided]
 * xref:release_policy.adoc#sbom_cyclonedx__allowed[SBOM CycloneDX: Allowed]
 * xref:release_policy.adoc#sbom_cyclonedx__allowed_package_external_references[SBOM CycloneDX: Allowed package external references]
+* xref:release_policy.adoc#sbom_cyclonedx__allowed_package_sources[SBOM CycloneDX: Allowed package sources]
 * xref:release_policy.adoc#sbom_cyclonedx__disallowed_package_attributes[SBOM CycloneDX: Disallowed package attributes]
 * xref:release_policy.adoc#sbom_cyclonedx__disallowed_package_external_references[SBOM CycloneDX: Disallowed package external references]
 * xref:release_policy.adoc#sbom_cyclonedx__valid[SBOM CycloneDX: Valid]
@@ -1148,6 +1150,19 @@ Confirm the CycloneDX SBOM contains only packages with explicitly allowed extern
 * FAILURE message: `Package %s has reference %q of type %q which is not explicitly allowed%s`
 * Code: `sbom_cyclonedx.allowed_package_external_references`
 * https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego#L89[Source, window="_blank"]
+
+[#sbom_cyclonedx__allowed_package_sources]
+=== link:#sbom_cyclonedx__allowed_package_sources[Allowed package sources]
+
+For each of the components fetched by Cachi2 which define externalReferences of type distribution, verify they are allowed based on the allowed_package_sources rule data key. By default, allowed_package_sources is empty, which means no components with such references are allowed.
+
+*Solution*: Update the image to not use a package from a disallowed source.
+
+* Rule type: [rule-type-indicator failure]#FAILURE#
+* FAILURE message: `Package %s fetched by cachi2 was sourced from %q which is not allowed`
+* Code: `sbom_cyclonedx.allowed_package_sources`
+* Effective from: `2024-12-15T00:00:00Z`
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego#L151[Source, window="_blank"]
 
 [#sbom_cyclonedx__disallowed_package_attributes]
 === link:#sbom_cyclonedx__disallowed_package_attributes[Disallowed package attributes]

--- a/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
+++ b/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
@@ -90,6 +90,7 @@
 *** xref:release_policy.adoc#sbom_cyclonedx_package[SBOM CycloneDX]
 **** xref:release_policy.adoc#sbom_cyclonedx__allowed[Allowed]
 **** xref:release_policy.adoc#sbom_cyclonedx__allowed_package_external_references[Allowed package external references]
+**** xref:release_policy.adoc#sbom_cyclonedx__allowed_package_sources[Allowed package sources]
 **** xref:release_policy.adoc#sbom_cyclonedx__disallowed_package_attributes[Disallowed package attributes]
 **** xref:release_policy.adoc#sbom_cyclonedx__disallowed_package_external_references[Disallowed package external references]
 **** xref:release_policy.adoc#sbom_cyclonedx__valid[Valid]

--- a/policy/lib/sbom/sbom.rego
+++ b/policy/lib/sbom/sbom.rego
@@ -255,6 +255,38 @@ rule_data_errors contains error if {
 	}
 }
 
+# Verify allowed_package_sources is array of purl/regex list pairs
+rule_data_errors contains error if {
+	some e in j.validate_schema(
+		lib.rule_data(rule_data_allowed_package_sources_key),
+		{
+			"$schema": "http://json-schema.org/draft-07/schema#",
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"type": {"type": "string"},
+					"patterns": {
+						"type": "array",
+						"items": {
+							"type": "string",
+							"format": "regex",
+						},
+					},
+				},
+				"required": ["type", "patterns"],
+				"additionalProperties": false,
+			},
+		},
+	)
+
+	error := {
+		# regal ignore:line-length
+		"message": sprintf("Rule data %s has unexpected format: %s", [rule_data_allowed_package_sources_key, e.message]),
+		"severity": e.severity,
+	}
+}
+
 _sbom_cyclonedx_image_path := "root/buildinfo/content_manifests/sbom-cyclonedx.json"
 
 _sbom_spdx_image_path := "root/buildinfo/content_manifests/sbom-spdx.json"
@@ -266,3 +298,5 @@ rule_data_attributes_key := "disallowed_attributes"
 rule_data_allowed_external_references_key := "allowed_external_references"
 
 rule_data_disallowed_external_references_key := "disallowed_external_references"
+
+rule_data_allowed_package_sources_key := "allowed_package_sources"

--- a/policy/release/sbom/sbom_test.rego
+++ b/policy/release/sbom/sbom_test.rego
@@ -77,6 +77,10 @@ test_rule_data_validation if {
 			{"type": "distribution", "url": "badurl"},
 			{"invalid": "foo"},
 		],
+		lib.sbom.rule_data_allowed_package_sources_key: [
+			{"type": "generic", "patterns": ["["]},
+			{"invalid": "foo"},
+		],
 	}
 
 	expected := {
@@ -195,6 +199,26 @@ test_rule_data_validation if {
 		},
 		{
 			"code": "sbom.disallowed_packages_provided",
+			"msg": "Rule data allowed_package_sources has unexpected format: 0.patterns.0: Does not match format 'regex'",
+			"severity": "failure",
+		},
+		{
+			"code": "sbom.disallowed_packages_provided",
+			"msg": "Rule data allowed_package_sources has unexpected format: 1: Additional property invalid is not allowed",
+			"severity": "warning",
+		},
+		{
+			"code": "sbom.disallowed_packages_provided",
+			"msg": "Rule data allowed_package_sources has unexpected format: 1: patterns is required",
+			"severity": "failure",
+		},
+		{
+			"code": "sbom.disallowed_packages_provided",
+			"msg": "Rule data allowed_package_sources has unexpected format: 1: type is required",
+			"severity": "failure",
+		},
+		{
+			"code": "sbom.disallowed_packages_provided",
 			# regal ignore:line-length
 			"msg": "Rule data disallowed_external_references has unexpected format: 1: Additional property invalid is not allowed",
 			"severity": "warning",
@@ -227,6 +251,7 @@ test_rule_data_validation if {
 		with data.rule_data as {
 			lib.sbom.rule_data_packages_key: [],
 			lib.sbom.rule_data_attributes_key: [],
+			lib.sbom.rule_data_allowed_package_sources_key: [],
 		}
 }
 


### PR DESCRIPTION
This adds a new `allowed_package_sources` policy that can gate content fetched by cachi2. This rule take a lot from the `allowed_external_references`, but makes it specific to content fetched by cachi2, because it is not uncommon for dependencies fetched by other means to define externalReferences of type `distribution`. Cachi2 currently produces the mentioned external reference only for packages fetched with the generic fetcher ([docs WIP](https://github.com/containerbuildsystem/cachi2/pull/718)) that always produces a `pkg:generic` purl, but it is possible it will be extended to other package managers supported by cachi2 as well. 

The rule data for this policy are structured as a list of regex patterns for a given purl type. Examples in tests.

Finally, this is my first contribution to EC (and rego) so please excuse any antipatterns I might have invented, feedback very much welcomed. 

Resolves ISV-5342