### PR TITLE
Add rule for PRIVILEGED_NESTED buildah parameter

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -104,6 +104,7 @@ Rules included:
 * xref:release_policy.adoc#buildah_build_task__add_capabilities_param[Buildah build task: ADD_CAPABILITIES parameter]
 * xref:release_policy.adoc#buildah_build_task__buildah_uses_local_dockerfile[Buildah build task: Buildah task uses a local Dockerfile]
 * xref:release_policy.adoc#buildah_build_task__platform_param[Buildah build task: PLATFORM parameter]
+* xref:release_policy.adoc#buildah_build_task__privileged_nested_param[Buildah build task: PRIVILEGED_NESTED parameter]
 * xref:release_policy.adoc#buildah_build_task__disallowed_platform_patterns_pattern[Buildah build task: disallowed_platform_patterns format]
 * xref:release_policy.adoc#cve__cve_blockers[CVE checks: Blocking CVE check]
 * xref:release_policy.adoc#cve__unpatched_cve_blockers[CVE checks: Blocking unpatched CVE check]
@@ -378,6 +379,18 @@ Verify the value of the PLATFORM parameter of a builder Task is allowed by match
 * Code: `buildah_build_task.platform_param`
 * Effective from: `2024-09-01T00:00:00Z`
 * https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/buildah_build_task/buildah_build_task.rego#L58[Source, window="_blank"]
+
+[#buildah_build_task__privileged_nested_param]
+=== link:#buildah_build_task__privileged_nested_param[PRIVILEGED_NESTED parameter]
+
+Verify the PRIVILEGED_NESTED parameter of a builder Tasks was not set to `true`.
+
+*Solution*: Setting PRIVILEGED_NESTED parameter to true is not allowed for most container image builds. Either set the parameter value to false or use a policy config that excludes this policy rule.
+
+* Rule type: [rule-type-indicator failure]#FAILURE#
+* FAILURE message: `setting PRIVILEGED_NESTED parameter to true is not allowed`
+* Code: `buildah_build_task.privileged_nested_param`
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/buildah_build_task/buildah_build_task.rego#L97[Source, window="_blank"]
 
 [#buildah_build_task__disallowed_platform_patterns_pattern]
 === link:#buildah_build_task__disallowed_platform_patterns_pattern[disallowed_platform_patterns format]

--- a/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
+++ b/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
@@ -20,6 +20,7 @@
 **** xref:release_policy.adoc#buildah_build_task__add_capabilities_param[ADD_CAPABILITIES parameter]
 **** xref:release_policy.adoc#buildah_build_task__buildah_uses_local_dockerfile[Buildah task uses a local Dockerfile]
 **** xref:release_policy.adoc#buildah_build_task__platform_param[PLATFORM parameter]
+**** xref:release_policy.adoc#buildah_build_task__privileged_nested_param[PRIVILEGED_NESTED parameter]
 **** xref:release_policy.adoc#buildah_build_task__disallowed_platform_patterns_pattern[disallowed_platform_patterns format]
 *** xref:release_policy.adoc#cve_package[CVE checks]
 **** xref:release_policy.adoc#cve__cve_blockers[Blocking CVE check]

--- a/policy/release/buildah_build_task/buildah_build_task.rego
+++ b/policy/release/buildah_build_task/buildah_build_task.rego
@@ -94,6 +94,28 @@ deny contains result if {
 	result := lib.result_helper_with_severity(rego.metadata.chain(), [error.message], error.severity)
 }
 
+# METADATA
+# title: PRIVILEGED_NESTED parameter
+# description: >-
+#   Verify the PRIVILEGED_NESTED parameter of a builder Tasks was not set to `true`.
+# custom:
+#   short_name: privileged_nested_param
+#   failure_msg: setting PRIVILEGED_NESTED parameter to true is not allowed
+#   solution: >-
+#     Setting PRIVILEGED_NESTED parameter to true is not allowed for most container
+#     image builds. Either set the parameter value to false or use a policy config
+#     that excludes this policy rule.
+#   collections:
+#   - redhat
+#   depends_on:
+#   - attestation_type.known_attestation_type
+#
+deny contains result if {
+	some param in _privileged_nested_params
+	trim_space(param) == "true"
+	result := lib.result_helper(rego.metadata.chain(), [])
+}
+
 _not_allowed_prefix(search) if {
 	not_allowed_prefixes := ["http://", "https://"]
 	some not_allowed_prefix in not_allowed_prefixes
@@ -118,6 +140,11 @@ _add_capabilities_params contains param if {
 _platform_params contains param if {
 	some buildah_task in _buildah_tasks
 	param := lib.tekton.task_param(buildah_task, "PLATFORM")
+}
+
+_privileged_nested_params contains param if {
+	some buildah_task in _buildah_tasks
+	param := lib.tekton.task_param(buildah_task, "PRIVILEGED_NESTED")
 }
 
 # Verify disallowed_platform_patterns is a list of strings. Empty list is fine.

--- a/policy/release/buildah_build_task/buildah_build_task_test.rego
+++ b/policy/release/buildah_build_task/buildah_build_task_test.rego
@@ -270,6 +270,22 @@ test_plat_patterns_rule_data_validation if {
 	lib.assert_equal_results(buildah_build_task.deny, expected) with data.rule_data as d
 }
 
+test_privileged_nested_param if {
+	expected := {{
+		"code": "buildah_build_task.privileged_nested_param",
+		"msg": "setting PRIVILEGED_NESTED parameter to true is not allowed",
+	}}
+
+	attestation := _slsav1_attestation("buildah", [{"name": "PRIVILEGED_NESTED", "value": "true"}], _results)
+	lib.assert_equal_results(expected, buildah_build_task.deny) with input.attestations as [attestation]
+
+	attestation_empty := _slsav1_attestation("buildah", [{"name": "PRIVILEGED_NESTED", "value": ""}], _results)
+	lib.assert_empty(buildah_build_task.deny) with input.attestations as [attestation_empty]
+
+	attestation_false := _slsav1_attestation("buildah", [{"name": "PRIVILEGED_NESTED", "value": "false"}], _results)
+	lib.assert_empty(buildah_build_task.deny) with input.attestations as [attestation_false]
+}
+
 _attestation(task_name, params, results) := {"statement": {"predicate": {
 	"buildType": lib.tekton_pipeline_run,
 	"buildConfig": {"tasks": [{


### PR DESCRIPTION
The `PRIVILEGED_NESTED` parameter must not be set to `true`.

Reference: https://issues.redhat.com/browse/EC-1011