### PR TITLE
Set dupe entries as warnings in trusted tasks

### DIFF
--- a/policy/lib/json/schema.rego
+++ b/policy/lib/json/schema.rego
@@ -59,3 +59,8 @@ _prepare_document(doc) := d if {
 _severity(e) := "warning" if {
 	startswith(e.desc, "Additional property")
 } else := "failure"
+
+with_severity_for_pattern(issue, severity, pattern) := updated_issue if {
+	regex.match(pattern, issue.message)
+	updated_issue := object.union(issue, {"severity": severity})
+} else := issue

--- a/policy/lib/json/schema_test.rego
+++ b/policy/lib/json/schema_test.rego
@@ -96,3 +96,29 @@ test_validate_schema_unknown_property_warning if {
 		}),
 	)
 }
+
+test_with_severity_for_pattern if {
+	# Empty issue
+	lib.assert_equal(
+		{},
+		j.with_severity_for_pattern({}, "warning", ".*"),
+	)
+
+	# Empty message
+	lib.assert_equal(
+		{"message": "", "severity": "warning"},
+		j.with_severity_for_pattern({"message": ""}, "warning", ".*"),
+	)
+
+	# Message not matched
+	lib.assert_equal(
+		{"message": "spam"},
+		j.with_severity_for_pattern({"message": "spam"}, "warning", "bacon"),
+	)
+
+	# Severity overwritten
+	lib.assert_equal(
+		{"message": "spam", "severity": "warning"},
+		j.with_severity_for_pattern({"message": "spam", "severity": "failure"}, "warning", "spam"),
+	)
+}

--- a/policy/lib/tekton/trusted.rego
+++ b/policy/lib/tekton/trusted.rego
@@ -95,10 +95,13 @@ data_errors contains error if {
 			}},
 		},
 	)
-	error := {
+
+	original_error := {
 		"message": sprintf("trusted_tasks data has unexpected format: %s", [e.message]),
 		"severity": e.severity,
 	}
+
+	error := j.with_severity_for_pattern(original_error, "warning", "must be unique")
 }
 
 data_errors contains error if {

--- a/policy/lib/tekton/trusted_test.rego
+++ b/policy/lib/tekton/trusted_test.rego
@@ -86,6 +86,10 @@ test_data_errors if {
 			{"ref": "bad-effective-on", "effective_on": "not-a-date"},
 			{"ref": "bad-effective-on", "effective_on": "2024-01-01T00:00:00Z", "expires_on": "not-a-date"},
 		],
+		"duplicated-entries": [
+			{"ref": "sha256:digest", "effective_on": "2099-01-01T00:00:00Z"},
+			{"ref": "sha256:digest", "effective_on": "2099-01-01T00:00:00Z"},
+		],
 	}
 
 	expected := {
@@ -117,6 +121,10 @@ test_data_errors if {
 		{
 			"message": `trusted_tasks.bad-dates[1].expires_on is not valid RFC3339 format: "not-a-date"`,
 			"severity": "failure",
+		},
+		{
+			"message": "trusted_tasks data has unexpected format: duplicated-entries: array items[0,1] must be unique",
+			"severity": "warning",
 		},
 	}
 


### PR DESCRIPTION
This commit demotes duplicated entries in the trusted tasks from a violation to warning. The current understanding is that preventing duplicated items is nice to have but does not affect functionality. As such, these should not trigger an EC violation.