### PR TITLE
Remove severity reduction to warning

### DIFF
--- a/policy/lib/json/schema.rego
+++ b/policy/lib/json/schema.rego
@@ -59,8 +59,3 @@ _prepare_document(doc) := d if {
 _severity(e) := "warning" if {
 	startswith(e.desc, "Additional property")
 } else := "failure"
-
-with_severity_for_pattern(issue, severity, pattern) := updated_issue if {
-	regex.match(pattern, issue.message)
-	updated_issue := object.union(issue, {"severity": severity})
-} else := issue

--- a/policy/lib/json/schema_test.rego
+++ b/policy/lib/json/schema_test.rego
@@ -96,29 +96,3 @@ test_validate_schema_unknown_property_warning if {
 		}),
 	)
 }
-
-test_with_severity_for_pattern if {
-	# Empty issue
-	lib.assert_equal(
-		{},
-		j.with_severity_for_pattern({}, "warning", ".*"),
-	)
-
-	# Empty message
-	lib.assert_equal(
-		{"message": "", "severity": "warning"},
-		j.with_severity_for_pattern({"message": ""}, "warning", ".*"),
-	)
-
-	# Message not matched
-	lib.assert_equal(
-		{"message": "spam"},
-		j.with_severity_for_pattern({"message": "spam"}, "warning", "bacon"),
-	)
-
-	# Severity overwritten
-	lib.assert_equal(
-		{"message": "spam", "severity": "warning"},
-		j.with_severity_for_pattern({"message": "spam", "severity": "failure"}, "warning", "spam"),
-	)
-}

--- a/policy/lib/tekton/trusted.rego
+++ b/policy/lib/tekton/trusted.rego
@@ -95,12 +95,10 @@ data_errors contains error if {
 		},
 	)
 
-	original_error := {
+	error := {
 		"message": sprintf("trusted_tasks data has unexpected format: %s", [e.message]),
 		"severity": e.severity,
 	}
-
-	error := j.with_severity_for_pattern(original_error, "warning", "must be unique")
 }
 
 data_errors contains error if {


### PR DESCRIPTION
We're no longer requiring unique items so this makes the call to
`with_severity_for_pattern` dead code.

Reference: https://issues.redhat.com/browse/EC-1015