### PR TITLE
Emit term for base_image_permitted

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -311,7 +311,7 @@ Confirm the `allowed_registry_prefixes` rule data was provided, since it's requi
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `base_image_registries.allowed_registries_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/base_image_registries/base_image_registries.rego#L77[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/base_image_registries/base_image_registries.rego#L78[Source, window="_blank"]
 
 [#base_image_registries__base_image_permitted]
 === link:#base_image_registries__base_image_permitted[Base image comes from permitted registry]
@@ -335,7 +335,7 @@ Verify the expected information was provided about which base images were used d
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Base images information is missing`
 * Code: `base_image_registries.base_image_info_found`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/base_image_registries/base_image_registries.rego#L47[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/base_image_registries/base_image_registries.rego#L48[Source, window="_blank"]
 
 [#buildah_build_task_package]
 == link:#buildah_build_task_package[Buildah build task]

--- a/policy/release/base_image_registries/base_image_registries.rego
+++ b/policy/release/base_image_registries/base_image_registries.rego
@@ -41,7 +41,8 @@ import data.lib.sbom
 deny contains result if {
 	some image_ref in _base_images
 	not _image_ref_permitted(image_ref)
-	result := lib.result_helper(rego.metadata.chain(), [image_ref])
+	repo := image.parse(image_ref).repo
+	result := lib.result_helper_with_term(rego.metadata.chain(), [image_ref], repo)
 }
 
 # METADATA

--- a/policy/release/base_image_registries/base_image_registries_test.rego
+++ b/policy/release/base_image_registries/base_image_registries_test.rego
@@ -94,14 +94,17 @@ test_disallowed_base_images if {
 		{
 			"code": "base_image_registries.base_image_permitted",
 			"msg": "Base image \"registry.redhat.yo/ubi7/3\" is from a disallowed registry",
+			"term": "registry.redhat.yo/ubi7/3",
 		},
 		{
 			"code": "base_image_registries.base_image_permitted",
 			"msg": "Base image \"registry.redhat.ioo/spam/3\" is from a disallowed registry",
+			"term": "registry.redhat.ioo/spam/3",
 		},
 		{
 			"code": "base_image_registries.base_image_permitted",
 			"msg": "Base image \"dockery.io/busybox/3\" is from a disallowed registry",
+			"term": "dockery.io/busybox/3",
 		},
 	}
 	lib.assert_equal_results(base_image_registries.deny, expected) with lib.sbom.cyclonedx_sboms as sboms
@@ -136,10 +139,12 @@ test_disallowed_base_images_with_snapshot if {
 		{
 			"code": "base_image_registries.base_image_permitted",
 			"msg": "Base image \"docker.io/library/registry:latest@sha256:bcd\" is from a disallowed registry",
+			"term": "docker.io/library/registry",
 		},
 		{
 			"code": "base_image_registries.base_image_permitted",
 			"msg": "Base image \"registry.redhat.io/ubi7:latest@sha256:abc\" is from a disallowed registry",
+			"term": "registry.redhat.io/ubi7",
 		},
 	}
 


### PR DESCRIPTION
This commit changes the policy rule
`base_image_registries.base_image_permitted` so it includes a term in its result. The term is the repository portion of the base image reference - everything but the tag and digest.

This allows users to allow certain base image registries as an exception, especially if time bound, e.g.:

```yaml
volatileConfig:
  exclude:
    - value: 'base_image_registries.base_image_permitted:my-shady-registry.io/foo/bar'
      effectiveUntil: '2024-12-01T00:00:00Z'
```

Ref: EC-649