### PR TITLE
Fix step_images.step_images_accessible check

### DIFF
--- a/antora/docs/modules/ROOT/pages/task_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/task_policy.adoc
@@ -21,6 +21,7 @@ Confirm that each step in the Task uses a container image that is accessible.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Step %d uses inaccessible image ref '%s'`
 * Code: `step_images.step_images_accessible`
+* Effective from: `2025-01-10T00:00:00Z`
 * https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/task/step_images/step_images.rego#L14[Source, window="_blank"]
 
 [#step_image_registries_package]

--- a/policy/task/step_images/step_images.rego
+++ b/policy/task/step_images/step_images.rego
@@ -21,13 +21,14 @@ import data.lib
 #   solution: >-
 #     Make sure the container image used in each step of the Task is pushed to the
 #     registry and that it can be fetched.
+#   effective_on: 2025-01-10T00:00:00Z
 #
 deny contains result if {
 	input.kind == "Task"
 
 	some step_index, step in input.spec.steps
 	image_ref := step.image
-	is_null(ec.oci.image_manifest(image_ref))
+	not ec.oci.image_manifest(image_ref)
 
 	result := lib.result_helper_with_term(
 		rego.metadata.chain(),

--- a/policy/task/step_images/step_images_test.rego
+++ b/policy/task/step_images/step_images_test.rego
@@ -65,4 +65,4 @@ test_task_with_invalid_steps if {
 mock_image_manifest(ref) := m if {
 	startswith(ref, "registry.io/repository/ok")
 	m := {}
-} else := null
+}


### PR DESCRIPTION
Although the implementation of ec.oci.image_manifest does return nil if the Image Manifest is not found, rego converts that to no value at all. Thus, asserting that the returned value is nil will never be true causing this policy rule to always pass.

This commit changes the rule evaluation to check for the lack of a value instead.