### PR TITLE
Show rhtap-multi-ci collection in generated docs

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -206,8 +206,8 @@ Rules included:
 * xref:release_policy.adoc#rpm_ostree_task__builder_image_param[rpm-ostree Task: Builder image parameter]
 * xref:release_policy.adoc#rpm_ostree_task__rule_data[rpm-ostree Task: Rule data]
 
-| [#rhtap-jenkins]`rhtap-jenkins`
-a| A set of policy rules to validate artifacts built using RHTAP Jenkins pipelines.
+| [#rhtap-multi-ci]`rhtap-multi-ci`
+a| A set of policy rules to validate artifacts built using RHTAP Multi-CI pipelines.
 
 Rules included:
 

--- a/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
+++ b/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
@@ -4,7 +4,7 @@
 *** xref:release_policy.adoc#minimal[minimal]
 *** xref:release_policy.adoc#policy_data[policy_data]
 *** xref:release_policy.adoc#redhat[redhat]
-*** xref:release_policy.adoc#rhtap-jenkins[rhtap-jenkins]
+*** xref:release_policy.adoc#rhtap-multi-ci[rhtap-multi-ci]
 *** xref:release_policy.adoc#slsa3[slsa3]
 ** Release Rules
 *** xref:release_policy.adoc#attestation_type_package[Attestation type]

--- a/policy/release/collection/rhtap_jenkins/rhtap_jenkins.rego
+++ b/policy/release/collection/rhtap_jenkins/rhtap_jenkins.rego
@@ -1,8 +1,0 @@
-#
-# METADATA
-# title: rhtap-jenkins
-# description: >-
-#   A set of policy rules to validate artifacts built using RHTAP Jenkins pipelines.
-package policy.release.collection.rhtap_jenkins
-
-import rego.v1

--- a/policy/release/collection/rhtap_multi_ci/rhtap_multi_ci.rego
+++ b/policy/release/collection/rhtap_multi_ci/rhtap_multi_ci.rego
@@ -1,0 +1,8 @@
+#
+# METADATA
+# title: rhtap-multi-ci
+# description: >-
+#   A set of policy rules to validate artifacts built using RHTAP Multi-CI pipelines.
+package policy.release.collection.rhtap_multi_ci
+
+import rego.v1


### PR DESCRIPTION
A fixup for #1236 which introduced the rhtap-multi-ci collection and deprecated the rhtap-{jenkins,gitlab,github} collections, (two of which hadn't been included in the docs yet anyhow).

Ref: https://issues.redhat.com/browse/EC-1032