### PR TITLE
feat(ec-965): verify a set of pullspecs related to an image

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,11 @@ Create a `policy.yaml` file in your local `ec-cli` repo with something like:
     ---
     sources:
       - policy:
-        - <path-to>/ec-policies/policy/lib
-        - <path-to>/ec-policies/policy/release
-      data:
-        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
-        - github.com/release-engineering/rhtap-ec-policy//data
+          - <path-to>/ec-policies/policy/lib
+          - <path-to>/ec-policies/policy/release
+        data:
+          - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+          - github.com/release-engineering/rhtap-ec-policy//data
 
 Run the locally built `ec-cli` command
 

--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -130,6 +130,7 @@ Rules included:
 * xref:release_policy.adoc#olm__required_olm_features_annotations_provided[OLM: Required OLM feature annotations list provided]
 * xref:release_policy.adoc#olm__subscriptions_annotation_format[OLM: Subscription annotation has expected value]
 * xref:release_policy.adoc#olm__inaccessible_snapshot_references[OLM: Unable to access images in the input snapshot]
+* xref:release_policy.adoc#olm__inaccessible_related_images[OLM: Unable to access related images for a component]
 * xref:release_policy.adoc#olm__unmapped_references[OLM: Unmapped images in OLM bundle]
 * xref:release_policy.adoc#olm__unpinned_references[OLM: Unpinned images in OLM bundle]
 * xref:release_policy.adoc#olm__unpinned_snapshot_references[OLM: Unpinned images in input snapshot]
@@ -798,7 +799,7 @@ Each image referenced by the OLM bundle should match an entry in the list of pre
 * FAILURE message: `The %q CSV image reference is not from an allowed registry.`
 * Code: `olm.allowed_registries`
 * Effective from: `2024-09-01T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L219[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L256[Source, window="_blank"]
 
 [#olm__required_olm_features_annotations_provided]
 === link:#olm__required_olm_features_annotations_provided[Required OLM feature annotations list provided]
@@ -836,6 +837,18 @@ Check the input snapshot and make sure all the images are accessible.
 * Effective from: `2024-08-15T00:00:00Z`
 * https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L156[Source, window="_blank"]
 
+[#olm__inaccessible_related_images]
+=== link:#olm__inaccessible_related_images[Unable to access related images for a component]
+
+Check the input image for the presence of related images. Ensure that all images are accessible.
+
+*Solution*: Ensure all related images are available. The related images are defined by an file containing a json array attached to the validated image. The digest of the attached file is pulled from the RELATED_IMAGES_DIGEST result.
+
+* Rule type: [rule-type-indicator failure]#FAILURE#
+* FAILURE message: `The %q related image reference is not accessible.`
+* Code: `olm.inaccessible_related_images`
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L178[Source, window="_blank"]
+
 [#olm__unmapped_references]
 === link:#olm__unmapped_references[Unmapped images in OLM bundle]
 
@@ -847,7 +860,7 @@ Check the OLM bundle image for the presence of unmapped image references. Unmapp
 * FAILURE message: `The %q CSV image reference is not in the snapshot or accessible.`
 * Code: `olm.unmapped_references`
 * Effective from: `2024-08-15T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L178[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L215[Source, window="_blank"]
 
 [#olm__unpinned_references]
 === link:#olm__unpinned_references[Unpinned images in OLM bundle]

--- a/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
+++ b/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
@@ -60,6 +60,7 @@
 **** xref:release_policy.adoc#olm__required_olm_features_annotations_provided[Required OLM feature annotations list provided]
 **** xref:release_policy.adoc#olm__subscriptions_annotation_format[Subscription annotation has expected value]
 **** xref:release_policy.adoc#olm__inaccessible_snapshot_references[Unable to access images in the input snapshot]
+**** xref:release_policy.adoc#olm__inaccessible_related_images[Unable to access related images for a component]
 **** xref:release_policy.adoc#olm__unmapped_references[Unmapped images in OLM bundle]
 **** xref:release_policy.adoc#olm__unpinned_references[Unpinned images in OLM bundle]
 **** xref:release_policy.adoc#olm__unpinned_snapshot_references[Unpinned images in input snapshot]

--- a/policy/release/olm/olm.rego
+++ b/policy/release/olm/olm.rego
@@ -176,6 +176,43 @@ deny contains result if {
 }
 
 # METADATA
+# title: Unable to access related images for a component
+# description: >-
+#   Check the input image for the presence of related images.
+#   Ensure that all images are accessible.
+# custom:
+#   short_name: inaccessible_related_images
+#   failure_msg: The %q related image reference is not accessible.
+#   solution: >-
+#     Ensure all related images are available. The related images are defined by
+#     an file containing a json array attached to the validated image. The digest
+#     of the attached file is pulled from the RELATED_IMAGES_DIGEST result.
+#   collections:
+#   - redhat
+deny contains result if {
+	_release_restrictions_apply
+
+	snapshot_components := input.snapshot.components
+	component_images_digests := [component_image.digest |
+		some component in snapshot_components
+		component_image := image.parse(component.containerImage)
+	]
+
+	some related_images in _related_images(input.image)
+
+	unmatched_image_refs := [related |
+		some related in related_images
+		not related.digest in component_images_digests
+	]
+
+	some unmatched_image in unmatched_image_refs
+	unmatched_ref := sprintf("%s@%s", [unmatched_image.repo, unmatched_image.digest])
+	not ec.oci.descriptor(unmatched_ref)
+
+	result := lib.result_helper_with_term(rego.metadata.chain(), [unmatched_ref], unmatched_ref)
+}
+
+# METADATA
 # title: Unmapped images in OLM bundle
 # description: >-
 #   Check the OLM bundle image for the presence of unmapped image references.
@@ -248,6 +285,36 @@ deny contains result if {
 
 	result := lib.result_helper_with_term(rego.metadata.chain(), [img_str], img.ref.repo)
 }
+
+# Extracts the related images attached to the image. The RELATED_IMAGES_DIGEST result
+# contains the digest of a referring image manifest containing the related image json
+# array. We need to find the blob sha in order to download the related images.
+_related_images(tested_image) := [e |
+	some imgs in [[r |
+		input_image := image.parse(tested_image.ref)
+
+		some related in lib.results_named(_related_images_result_name)
+		result_digest := object.union(input_image, {"digest": sprintf("%s", [trim_space(related.value)])})
+		related_image_ref := image.str(result_digest)
+		related_image_manifest := ec.oci.image_manifest(related_image_ref)
+
+		some layer in related_image_manifest.layers
+		layer.mediaType == _related_images_oci_mime_type
+		related_image_blob := object.union(input_image, {"digest": layer.digest})
+		related_image_blob_ref := image.str(related_image_blob)
+
+		raw_related_images := json.unmarshal(ec.oci.blob(related_image_blob_ref))
+
+		some related_ref in raw_related_images
+		r := {
+			"path": "relatedImage",
+			"ref": image.parse(related_ref),
+		}
+	]]
+	some i in imgs
+
+	e := {"ref": i.ref, "path": i.path}
+]
 
 _name(o) := n if {
 	n := o.name
@@ -446,3 +513,7 @@ _image_registry_allowed(image_repo, allowed_prefixes) if {
 	some allowed_prefix in allowed_prefixes
 	startswith(image_repo, allowed_prefix)
 }
+
+_related_images_result_name := "RELATED_IMAGES_DIGEST"
+
+_related_images_oci_mime_type := "application/vnd.konflux-ci.attached-artifact.related-images+json"


### PR DESCRIPTION
We were previously only able to verify certain pullspecs at build-time
which resulted in a failed test. This would prevent multiple images from
being built and all staged for release. Even if the image references are
valid at release time, the check used was old and the results are not
updated without a rebuild.

If a task has a result named RELATED_IMAGES_DIGEST, all references in the
json array contained within the pushed file will be checked for validity.

implements: EC-965