### PR TITLE
Use go 1.23

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.22.7
+golang 1.23.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/enterprise-contract/ec-policies
 
-go 1.22.7
+go 1.23.1
+
 toolchain go1.23.4
 
 require (


### PR DESCRIPTION
A few dependencies, e.g. oras and sigstore, now require Go 1.23. This commit updates the version of Go to 1.23.1.

Without this fix, the CI is failing to create new bundles.