### PR TITLE
Handle more pipeline_intention values

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -950,7 +950,7 @@ Policies to prevent releasing an image to quay that has a quay expiration date. 
 [#quay_expiration__expires_label]
 === link:#quay_expiration__expires_label[Expires label]
 
-Check the image metadata for the presence of a "quay.expires-after" label. If it's present then produce a violation. This check is enforced only for a "release" pipeline, as determined by the value of the `pipeline_intention` rule data.
+Check the image metadata for the presence of a "quay.expires-after" label. If it's present then produce a violation. This check is enforced only for a "release", "production", or "staging" pipeline, as determined by the value of the `pipeline_intention` rule data.
 
 *Solution*: Make sure the image is built without setting the "quay.expires-after" label. This label is usually set if the container image was built by an "on-pr" pipeline during pre-merge CI.
 
@@ -1523,7 +1523,7 @@ Rules that verify the current date conform to a given schedule.
 [#schedule__date_restriction]
 === link:#schedule__date_restriction[Date Restriction]
 
-Check if the current date is not allowed based on the rule data value from the key `disallowed_dates`. By default, the list is empty in which case *any* day is allowed. This check is enforced only for a "release" pipeline, as determined by the value of the `pipeline_intention` rule data.
+Check if the current date is not allowed based on the rule data value from the key `disallowed_dates`. By default, the list is empty in which case *any* day is allowed. This check is enforced only for a "release" or "production" pipeline, as determined by the value of the `pipeline_intention` rule data.
 
 *Solution*: Try again on a different day.
 
@@ -1542,12 +1542,12 @@ Confirm the expected rule data keys have been provided in the expected format. T
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `schedule.rule_data_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/schedule/schedule.rego#L59[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/schedule/schedule.rego#L60[Source, window="_blank"]
 
 [#schedule__weekday_restriction]
 === link:#schedule__weekday_restriction[Weekday Restriction]
 
-Check if the current weekday is allowed based on the rule data value from the key `disallowed_weekdays`. By default, the list is empty in which case *any* weekday is allowed. This check is enforced only for a "release" pipeline, as determined by the value of the `pipeline_intention` rule data.
+Check if the current weekday is allowed based on the rule data value from the key `disallowed_weekdays`. By default, the list is empty in which case *any* weekday is allowed. This check is enforced only for a "release" or "production" pipeline, as determined by the value of the `pipeline_intention` rule data.
 
 *Solution*: Try again on a different weekday.
 

--- a/policy/release/olm/olm.rego
+++ b/policy/release/olm/olm.rego
@@ -438,7 +438,7 @@ _subscription_annotation := "operators.openshift.io/valid-subscription"
 default _release_restrictions_apply := false
 
 _release_restrictions_apply if {
-	lib.rule_data("pipeline_intention") == "release"
+	lib.rule_data("pipeline_intention") in {"release", "production", "staging"}
 }
 
 # Used by allowed_registries

--- a/policy/release/quay_expiration/quay_expiration.rego
+++ b/policy/release/quay_expiration/quay_expiration.rego
@@ -18,8 +18,8 @@ import data.lib
 # description: >-
 #   Check the image metadata for the presence of a "quay.expires-after"
 #   label. If it's present then produce a violation. This check is enforced
-#   only for a "release" pipeline, as determined by the value of the
-#   `pipeline_intention` rule data.
+#   only for a "release", "production", or "staging" pipeline, as determined by
+#   the value of the `pipeline_intention` rule data.
 # custom:
 #   short_name: expires_label
 #   failure_msg: The image has a 'quay.expires-after' label set to '%s'
@@ -52,5 +52,5 @@ deny contains result if {
 default _expires_label_check_applies := false
 
 _expires_label_check_applies if {
-	lib.rule_data("pipeline_intention") == "release"
+	lib.rule_data("pipeline_intention") in {"release", "production", "staging"}
 }

--- a/policy/release/schedule/schedule.rego
+++ b/policy/release/schedule/schedule.rego
@@ -16,8 +16,8 @@ import data.lib.json as j
 # description: >-
 #   Check if the current weekday is allowed based on the rule data value from the key
 #   `disallowed_weekdays`. By default, the list is empty in which case *any* weekday is
-#   allowed. This check is enforced only for a "release" pipeline, as determined by
-#   the value of the `pipeline_intention` rule data.
+#   allowed. This check is enforced only for a "release" or "production"
+#   pipeline, as determined by the value of the `pipeline_intention` rule data.
 # custom:
 #   short_name: weekday_restriction
 #   failure_msg: '%s is a disallowed weekday: %s'
@@ -39,8 +39,9 @@ deny contains result if {
 # description: >-
 #   Check if the current date is not allowed based on the rule data value
 #   from the key `disallowed_dates`. By default, the list is empty in which
-#   case *any* day is allowed. This check is enforced only for a "release" pipeline,
-#   as determined by the value of the `pipeline_intention` rule data.
+#   case *any* day is allowed. This check is enforced only for a "release" or
+#   "production" pipeline, as determined by the value of the
+#   `pipeline_intention` rule data.
 # custom:
 #   short_name: date_restriction
 #   failure_msg: '%s is a disallowed date: %s'
@@ -76,11 +77,12 @@ deny contains result if {
 }
 
 # We want these checks to apply only if we're doing a release. Detect that by checking
-# the `pipeline_intention` value which is set to "release" for Konflux release pipelines.
+# the `pipeline_intention` value which is set to "release" or "production" for Konflux release pipelines.
+# Notably, the value "staging" is not checked here. The disallowed dates rule doesn't apply to staging releases.
 default _schedule_restrictions_apply := false
 
 _schedule_restrictions_apply if {
-	lib.rule_data("pipeline_intention") == "release"
+	lib.rule_data("pipeline_intention") in {"release", "production"} # But not staging
 }
 
 _rule_data_errors contains error if {


### PR DESCRIPTION
The goal here is to make the schedule rules only apply to production releases.

The konflux-ci release pipelines don't yet provide these new pipeline_intention values. I'll follow up in a separate PR with them to provide those.