### PR TITLE
Strip extra digest from base image name annotation

### DIFF
--- a/policy/release/labels/labels_test.rego
+++ b/policy/release/labels/labels_test.rego
@@ -578,6 +578,13 @@ test_rule_data_provided if {
 		with data.rule_data as d
 }
 
+test_strip_digest if {
+	lib.assert_equal("foo", labels._strip_digest("foo"))
+	lib.assert_equal("foo", labels._strip_digest("foo@bar"))
+	lib.assert_equal("foo:latest", labels._strip_digest("foo:latest@bar"))
+	lib.assert_equal("registry.io/registry/image", labels._strip_digest("registry.io/registry/image@sha256:ace0fba5e"))
+}
+
 _default_manifest := {
 	"schemaVersion": 2,
 	"mediaType": "application/vnd.oci.image.manifest.v1+json",


### PR DESCRIPTION
The rego code here is not expecting the `org.opencontainers.image.base.name` annotation to include a digest, so we end up with a broken image ref containing two digests, which causes a "a digest must contain exactly one '@' separator" error when ec.oci.image_manifest is called.
    
Fix it by using a regex replace to strip off the digest from the name annotation value before putting it together with the digest from the digest annotation value.
    
See also Luiz' explanation in Jira.
    
Note: The regex replace could have been done inline, but moving it to its own rule makes it easier to write the simple test coverage.

Ref: [EC-1041](https://issues.redhat.com/browse/EC-1041)