### PR TITLE
Fix SBOM count condition for base_image_info_found

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -339,7 +339,7 @@ Verify that the base images used when building a container image come from a kno
 [#base_image_registries__base_image_info_found]
 === link:#base_image_registries__base_image_info_found[Base images provided]
 
-Verify the expected information was provided about which base images were used during the build process.The list of base images comes from the components in the `formulation` attribute of any associated CycloneDX SBOMs.
+Verify the expected information was provided about which base images were used during the build process. The list of base images comes from any associated CycloneDX or SPDX SBOMs.
 
 *Solution*: Ensure a CycloneDX SBOM is associated with the image.
 

--- a/policy/release/base_image_registries/base_image_registries.rego
+++ b/policy/release/base_image_registries/base_image_registries.rego
@@ -49,8 +49,8 @@ deny contains result if {
 # title: Base images provided
 # description: >-
 #   Verify the expected information was provided about which base images were used during
-#   the build process.The list of base images comes from the components in the `formulation`
-#   attribute of any associated CycloneDX SBOMs.
+#   the build process. The list of base images comes from any associated CycloneDX or SPDX
+#   SBOMs.
 # custom:
 #   short_name: base_image_info_found
 #   failure_msg: Base images information is missing
@@ -70,7 +70,7 @@ deny contains result if {
 	# Some images are built "from scratch" and not have any base images, e.g. UBI.
 	# This check distinguishes such images by simply ensuring that at least one SBOM
 	# is attached to the image.
-	count(sbom.cyclonedx_sboms) == 0
+	count(sbom.all_sboms) == 0
 
 	result := lib.result_helper(rego.metadata.chain(), [])
 }


### PR DESCRIPTION
Previously, the check asserted that there was at least 1 CycloneDX SBOM. Use the 'sbom.all_sboms' property instead to also count SPDX SBOMs.

Also reword the description of the check. Make it less specific to avoid having to explain where the base images are in each SBOM format. All the check does is assert that there are some SBOMs, anyway.