### PR TITLE
Remove old docs update trigger

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -31,8 +31,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - APP_INSTALL_ID: 29980719
-            REPOSITORY: enterprise-contract/enterprise-contract.github.io
           - APP_INSTALL_ID: 59973090
             REPOSITORY: conforma/conforma.github.io
     steps:


### PR DESCRIPTION
For a brief period both website repos existed, but now the old one is gone. This should fix CI breakage when triggering a website update.

Ref: https://issues.redhat.com/browse/EC-1081