### PR TITLE
Use gitCommit as intended

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -1367,7 +1367,7 @@ Verify that the provided source code reference is the one being attested.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `The expected source code reference %q is not attested`
 * Code: `slsa_source_correlated.expected_source_code_reference`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/slsa_source_correlated/slsa_source_correlated.rego#L70[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/slsa_source_correlated/slsa_source_correlated.rego#L66[Source, window="_blank"]
 
 [#slsa_source_correlated__rule_data_provided]
 === link:#slsa_source_correlated__rule_data_provided[Rule data provided]
@@ -1377,7 +1377,7 @@ Confirm the expected rule data keys have been provided in the expected format. T
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `slsa_source_correlated.rule_data_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/slsa_source_correlated/slsa_source_correlated.rego#L108[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/slsa_source_correlated/slsa_source_correlated.rego#L104[Source, window="_blank"]
 
 [#slsa_source_correlated__source_code_reference_provided]
 === link:#slsa_source_correlated__source_code_reference_provided[Source code reference provided]
@@ -1389,7 +1389,7 @@ Check if the expected source code reference is provided.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Expected source code reference was not provided for verification`
 * Code: `slsa_source_correlated.source_code_reference_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/slsa_source_correlated/slsa_source_correlated.rego#L24[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/slsa_source_correlated/slsa_source_correlated.rego#L20[Source, window="_blank"]
 
 [#slsa_source_correlated__attested_source_code_reference]
 === link:#slsa_source_correlated__attested_source_code_reference[Source reference]
@@ -1401,7 +1401,7 @@ Attestation contains source reference.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `The attested material contains no source code reference`
 * Code: `slsa_source_correlated.attested_source_code_reference`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/slsa_source_correlated/slsa_source_correlated.rego#L44[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/slsa_source_correlated/slsa_source_correlated.rego#L40[Source, window="_blank"]
 
 [#sbom_spdx_package]
 == link:#sbom_spdx_package[SPDX SBOM]

--- a/policy/release/slsa_source_correlated/slsa_source_correlated_test.rego
+++ b/policy/release/slsa_source_correlated/slsa_source_correlated_test.rego
@@ -105,7 +105,7 @@ test_deny_expected_source_code_reference_happy_day if {
 	lib.assert_empty(slsa_source_correlated.deny) with input.image as expected
 		with input.attestations as [_resolved_dependencies_attestation([{
 			"uri": "git+https://git.repository",
-			"digest": {"gitCommit": "ec74e6310316babc451947a1a749a233e8da0585"}, # printf 'commit 3\0ref' | sha1sum
+			"digest": {"gitCommit": "ref"},
 			"name": "inputs/result",
 		}])]
 
@@ -153,7 +153,7 @@ test_deny_expected_source_code_reference_happy_day if {
 	lib.assert_empty(slsa_source_correlated.deny) with input.image as expected
 		with input.attestations as [_resolved_dependencies_attestation([{
 			"uri": "git+https://git.repository.git",
-			"digest": {"gitCommit": "ec74e6310316babc451947a1a749a233e8da0585"},
+			"digest": {"gitCommit": "ref"},
 			"name": "inputs/result",
 		}])]
 
@@ -163,7 +163,7 @@ test_deny_expected_source_code_reference_happy_day if {
 	lib.assert_empty(slsa_source_correlated.deny) with input.image as img7
 		with input.attestations as [_resolved_dependencies_attestation([{
 			"uri": "git+https://git.repository",
-			"digest": {"gitCommit": "ec74e6310316babc451947a1a749a233e8da0585"},
+			"digest": {"gitCommit": "ref"},
 			"name": "inputs/result",
 		}])]
 
@@ -173,7 +173,7 @@ test_deny_expected_source_code_reference_happy_day if {
 	lib.assert_empty(slsa_source_correlated.deny) with input.image as img8
 		with input.attestations as [_resolved_dependencies_attestation([{
 			"uri": "git+https://git.repository.git",
-			"digest": {"gitCommit": "ec74e6310316babc451947a1a749a233e8da0585"},
+			"digest": {"gitCommit": "ref"},
 			"name": "inputs/result",
 		}])]
 
@@ -183,7 +183,7 @@ test_deny_expected_source_code_reference_happy_day if {
 	lib.assert_empty(slsa_source_correlated.deny) with input.image as img9
 		with input.attestations as [_resolved_dependencies_attestation([{
 			"uri": "git+https://git.repository.git.git",
-			"digest": {"gitCommit": "ec74e6310316babc451947a1a749a233e8da0585"},
+			"digest": {"gitCommit": "ref"},
 			"name": "inputs/result",
 		}])]
 }
@@ -444,26 +444,26 @@ test_refs if {
 		{"https://git.repository": "rev"}: {
 			"https://git.repository@sha1:rev",
 			"https://git.repository.git@sha1:rev",
-			"https://git.repository@gitCommit:80fb0826a7207841d9c59ec544bf16b8c8a93c8b",
-			"https://git.repository.git@gitCommit:80fb0826a7207841d9c59ec544bf16b8c8a93c8b",
+			"https://git.repository@gitCommit:rev",
+			"https://git.repository.git@gitCommit:rev",
 		},
 		{"https://git.repository.git": "rev"}: {
 			"https://git.repository.git@sha1:rev",
 			"https://git.repository.git.git@sha1:rev",
 			"https://git.repository@sha1:rev",
-			"https://git.repository.git@gitCommit:80fb0826a7207841d9c59ec544bf16b8c8a93c8b",
-			"https://git.repository.git.git@gitCommit:80fb0826a7207841d9c59ec544bf16b8c8a93c8b",
-			"https://git.repository@gitCommit:80fb0826a7207841d9c59ec544bf16b8c8a93c8b",
+			"https://git.repository.git@gitCommit:rev",
+			"https://git.repository.git.git@gitCommit:rev",
+			"https://git.repository@gitCommit:rev",
 		},
 		{"https://git.repository/": "rev"}: {
 			"https://git.repository/@sha1:rev",
 			"https://git.repository/.git@sha1:rev",
 			"https://git.repository@sha1:rev",
 			"https://git.repository.git@sha1:rev",
-			"https://git.repository/@gitCommit:80fb0826a7207841d9c59ec544bf16b8c8a93c8b",
-			"https://git.repository/.git@gitCommit:80fb0826a7207841d9c59ec544bf16b8c8a93c8b",
-			"https://git.repository@gitCommit:80fb0826a7207841d9c59ec544bf16b8c8a93c8b",
-			"https://git.repository.git@gitCommit:80fb0826a7207841d9c59ec544bf16b8c8a93c8b",
+			"https://git.repository/@gitCommit:rev",
+			"https://git.repository/.git@gitCommit:rev",
+			"https://git.repository@gitCommit:rev",
+			"https://git.repository.git@gitCommit:rev",
 		},
 	}
 


### PR DESCRIPTION
Instead of using `sha1` as a digest algorithm, the in-toto spec allows using `gitCommit` to give additional meaning to the digest: https://github.com/in-toto/attestation/blob/main/spec/v1/digest_set.md#gitcommit-gittree-gitblob-gittag

The spec docs are a somewhat confusing on this which lead it to be interpreted as:

```
gitCommit="$(printf 'commit 3\0'`git rev-parse HEAD` | sha1sum)"
```

However, the intended use of `gitCommit` is to capture a git commit ID as is:

```
gitCommit="$(git rev-parse HEAD)"
```

Fixes #1037