### PR TITLE
Move SBOM rpm processing to lib

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -1004,7 +1004,7 @@ Each RPM package listed in an SBOM must specify the repository id that it comes 
 * FAILURE message: `RPM repo id check failed: %s`
 * Code: `rpm_repos.ids_known`
 * Effective from: `2024-11-10T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/rpm_repos/rpm_repos.rego#L36[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/rpm_repos/rpm_repos.rego#L37[Source, window="_blank"]
 
 [#rpm_repos__rule_data_provided]
 === link:#rpm_repos__rule_data_provided[Known repo id list provided]
@@ -1016,7 +1016,7 @@ A list of known and permitted repository ids should be available in the rule dat
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Rule data '%s' has unexpected format: %s`
 * Code: `rpm_repos.rule_data_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/rpm_repos/rpm_repos.rego#L15[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/rpm_repos/rpm_repos.rego#L16[Source, window="_blank"]
 
 [#rpm_signature_package]
 == link:#rpm_signature_package[RPM Signature]

--- a/policy/lib/sbom/rpm.rego
+++ b/policy/lib/sbom/rpm.rego
@@ -1,0 +1,64 @@
+package lib.sbom
+
+import rego.v1
+
+all_rpm_entities contains entity if {
+	some sbom in all_sboms
+	some entity in rpms_from_sbom(sbom)
+}
+
+rpms_from_sbom(s) := entities if {
+	# CycloneDX
+	entities := {entity |
+		some component in s.components
+		purl := component.purl
+		_is_rpmish(purl)
+		entity := {
+			"purl": purl,
+			"found_by_cachi2": _component_found_by_cachi2(component),
+		}
+	}
+	count(entities) > 0
+} else := entities if {
+	# SPDX
+	entities := {entity |
+		some pkg in s.packages
+		some ref in pkg.externalRefs
+		ref.referenceType == "purl"
+		ref.referenceCategory == "PACKAGE-MANAGER"
+		purl := ref.referenceLocator
+		_is_rpmish(purl)
+		entity := {
+			"purl": purl,
+			"found_by_cachi2": _package_found_by_cachi2(pkg),
+		}
+	}
+	count(entities) > 0
+}
+
+# Match rpms and modules
+# (Use a string match instead of parsing it and checking the type)
+_is_rpmish(purl) if {
+	startswith(purl, "pkg:rpm/")
+} else if {
+	startswith(purl, "pkg:rpmmod/")
+}
+
+_component_found_by_cachi2(component) if {
+	some property in component.properties
+	property == cachi2_found_by_property
+} else := false
+
+# This is what cachi2 produces in the component property list
+cachi2_found_by_property := {
+	"name": "cachi2:found_by",
+	"value": "cachi2",
+}
+
+_package_found_by_cachi2(pkg) if {
+	some annotation in pkg.annotations
+	regex.match(`.*cachi2.*`, annotation.annotator)
+	annotation.annotationType == "OTHER"
+	# `comment` contains additional information, but that is not needed for the purpose of
+	# simply filtering what was found by cachi2.
+} else := false

--- a/policy/lib/sbom/rpm_test.rego
+++ b/policy/lib/sbom/rpm_test.rego
@@ -1,0 +1,117 @@
+package lib.sbom_test
+
+import rego.v1
+
+import data.lib
+import data.lib.sbom
+
+test_all_rpm_entities if {
+	s_cyclonedx := _cyclonedx_sbom([_cyclonedx_component(_rpm_spam_1, [sbom.cachi2_found_by_property])])
+	s_spdx := _spdx_sbom([_spdx_package(_rpm_spam_2, [_cachi2_spdx_annotation])])
+
+	expected := {
+		{
+			"found_by_cachi2": true,
+			"purl": _rpm_spam_1,
+		},
+		{
+			"found_by_cachi2": true,
+			"purl": _rpm_spam_2,
+		},
+	}
+
+	all_sboms := [s_cyclonedx, s_spdx]
+	lib.assert_equal_results(expected, sbom.all_rpm_entities) with lib.sbom.all_sboms as all_sboms
+}
+
+test_all_rpm_entities_no_dupes if {
+	s_cyclonedx := _cyclonedx_sbom([
+		_cyclonedx_component(_rpm_spam_1, [sbom.cachi2_found_by_property]),
+		_cyclonedx_component(_rpm_spam_2, [sbom.cachi2_found_by_property]),
+	])
+	s_spdx := _spdx_sbom([
+		_spdx_package(_rpm_spam_1, [_cachi2_spdx_annotation]),
+		_spdx_package(_rpm_spam_2, [_cachi2_spdx_annotation]),
+	])
+
+	# Duplicated entries across SBOMs are ignored.
+	expected := {
+		{
+			"found_by_cachi2": true,
+			"purl": _rpm_spam_1,
+		},
+		{
+			"found_by_cachi2": true,
+			"purl": _rpm_spam_2,
+		},
+	}
+
+	all_sboms := [s_cyclonedx, s_spdx]
+	lib.assert_equal_results(expected, sbom.all_rpm_entities) with lib.sbom.all_sboms as all_sboms
+}
+
+test_rpms_from_sbom_cyclonedx if {
+	s := _cyclonedx_sbom([
+		_cyclonedx_component(_rpm_spam_1, []),
+		_cyclonedx_component(_rpm_spam_2, [sbom.cachi2_found_by_property]),
+		_cyclonedx_component(_not_rpm, []),
+	])
+	expected := {
+		{
+			"found_by_cachi2": false,
+			"purl": _rpm_spam_1,
+		},
+		{
+			"found_by_cachi2": true,
+			"purl": _rpm_spam_2,
+		},
+	}
+
+	lib.assert_equal_results(expected, sbom.rpms_from_sbom(s))
+}
+
+test_rpms_from_sbom_spdx if {
+	s := _spdx_sbom([
+		_spdx_package(_rpm_spam_1, []),
+		_spdx_package(_rpm_spam_2, [_cachi2_spdx_annotation]),
+		_spdx_package(_not_rpm, []),
+	])
+	expected := {
+		{
+			"found_by_cachi2": false,
+			"purl": _rpm_spam_1,
+		},
+		{
+			"found_by_cachi2": true,
+			"purl": _rpm_spam_2,
+		},
+	}
+
+	lib.assert_equal_results(expected, sbom.rpms_from_sbom(s))
+}
+
+_cyclonedx_sbom(components) := {"components": components}
+
+_cyclonedx_component(purl, properties) := {
+	"purl": purl,
+	"properties": properties,
+}
+
+_spdx_sbom(packages) := {"packages": packages}
+
+_spdx_package(purl, annotations) := {
+	"annotations": annotations,
+	"externalRefs": [{
+		"referenceType": "purl",
+		"referenceCategory": "PACKAGE-MANAGER",
+		"referenceLocator": purl,
+	}],
+}
+
+_cachi2_spdx_annotation := {"annotator": "Tool: cachi2:jsonencoded", "annotationType": "OTHER"}
+
+_rpm_spam_1 := "pkg:rpm/redhat/spam@1.0.0-1"
+
+_rpm_spam_2 := "pkg:rpm/redhat/spam@1.0.0-2"
+
+_not_rpm := "pkg:golang/gitplanet.com/bacon@1.2.3?arch=amd64"

--- a/policy/release/rpm_repos/rpm_repos_test.rego
+++ b/policy/release/rpm_repos/rpm_repos_test.rego
@@ -3,6 +3,7 @@ package rpm_repos_test
 import rego.v1
 
 import data.lib
+import data.lib.sbom
 import data.rpm_repos
 
 test_repo_id_data_empty if {
@@ -212,7 +213,7 @@ fake_cyclonedx_sboms := [fake_cyclonedx_sbom({p1, p2, p3, p4, p5, p6, p7})]
 fake_cyclonedx_sbom(fake_purls) := {"components": [
 {
 	"purl": p,
-	"properties": [rpm_repos._cachi2_found_by_property],
+	"properties": [sbom.cachi2_found_by_property],
 } |
 	some p in fake_purls
 ]}


### PR DESCRIPTION
This change moves `all_rpm_entities` and `rpms_from_sbom` to a lib module so it can be used by other policy packages. This is in preparation for EC-1142.