### PR TITLE
Add `rpm_packages` policy package

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -137,6 +137,7 @@ Rules included:
 * xref:release_policy.adoc#provenance_materials__git_clone_source_matches_provenance[Provenance Materials: Git clone source matches materials provenance]
 * xref:release_policy.adoc#provenance_materials__git_clone_task_found[Provenance Materials: Git clone task found]
 * xref:release_policy.adoc#quay_expiration__expires_label[Quay expiration: Expires label]
+* xref:release_policy.adoc#rpm_packages__unique_version[RPM Packages: Unique Version]
 * xref:release_policy.adoc#rpm_repos__ids_known[RPM Repos: All rpms have known repo ids]
 * xref:release_policy.adoc#rpm_repos__rule_data_provided[RPM Repos: Known repo id list provided]
 * xref:release_policy.adoc#rpm_signature__allowed[RPM Signature: Allowed RPM signature key]
@@ -968,6 +969,24 @@ Verify an attestation created by the RHTAP Multi-CI build pipeline is present.
 * FAILURE message: `A SLSA v1.0 provenance with one of the following RHTAP Multi-CI build types was not found: %s.`
 * Code: `rhtap_multi_ci.attestation_found`
 * https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/rhtap_multi_ci/rhtap_multi_ci.rego#L16[Source, window="_blank"]
+
+[#rpm_packages_package]
+== link:#rpm_packages_package[RPM Packages]
+
+Rules used to verify different properties of specific RPM packages found in the SBOM of the image being validated.
+
+* Package name: `rpm_packages`
+
+[#rpm_packages__unique_version]
+=== link:#rpm_packages__unique_version[Unique Version]
+
+Check if there is more than one version of the same RPM installed across different architectures. This check only applies for Image Indexes, aka multi-platform images. Use the `non_unique_rpm_names` rule data key to ignore certain RPMs.
+
+* Rule type: [rule-type-indicator failure]#FAILURE#
+* FAILURE message: `Multiple versions of the %q RPM were found: %s`
+* Code: `rpm_packages.unique_version`
+* Effective from: `2025-04-28T00:00:00Z`
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/rpm_packages/rpm_packages.rego#L17[Source, window="_blank"]
 
 [#rpm_pipeline_package]
 == link:#rpm_pipeline_package[RPM Pipeline]

--- a/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
+++ b/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
@@ -72,6 +72,8 @@
 *** xref:release_policy.adoc#rhtap_multi_ci_package[RHTAP Multi-CI]
 **** xref:release_policy.adoc#rhtap_multi_ci__attestation_format[SLSA Provenance Attestation Format]
 **** xref:release_policy.adoc#rhtap_multi_ci__attestation_found[SLSA Provenance Attestation Found]
+*** xref:release_policy.adoc#rpm_packages_package[RPM Packages]
+**** xref:release_policy.adoc#rpm_packages__unique_version[Unique Version]
 *** xref:release_policy.adoc#rpm_pipeline_package[RPM Pipeline]
 **** xref:release_policy.adoc#rpm_pipeline__invalid_pipeline[Task version invalid_pipeline]
 *** xref:release_policy.adoc#rpm_repos_package[RPM Repos]

--- a/policy/lib/rule_data.rego
+++ b/policy/lib/rule_data.rego
@@ -99,6 +99,8 @@ rule_data_defaults := {
 	"trusted_tasks": {},
 	# Number of days before a version of the Task expires that warnings are reported
 	"task_expiry_warning_days": 0,
+	# The gpg-pubkey RPM does not abide to the rule of a single RPM name being installed.
+	"non_unique_rpm_names": ["gpg-pubkey"],
 }
 
 # Returns the "first found" of the following:

--- a/policy/release/rpm_packages/rpm_packages.rego
+++ b/policy/release/rpm_packages/rpm_packages.rego
@@ -1,0 +1,67 @@
+#
+# METADATA
+# title: RPM Packages
+# description: >-
+#   Rules used to verify different properties of specific RPM packages found in the SBOM of the
+#   image being validated.
+#
+package policy.release.rpm_packages
+
+import rego.v1
+
+import data.lib
+import data.lib.image
+import data.lib.sbom
+import data.lib.tekton
+
+# METADATA
+# title: Unique Version
+# description: >-
+#   Check if there is more than one version of the same RPM installed across different
+#   architectures. This check only applies for Image Indexes, aka multi-platform images.
+#   Use the `non_unique_rpm_names` rule data key to ignore certain RPMs.
+# custom:
+#   short_name: unique_version
+#   failure_msg: 'Multiple versions of the %q RPM were found: %s'
+#   collections:
+#   - redhat
+#   effective_on: 2025-04-28T00:00:00Z
+#
+deny contains result if {
+	image.is_image_index(input.image.ref)
+
+	some name, versions in grouped_rpm_purls
+	count(versions) > 1
+	not name in lib.rule_data("non_unique_rpm_names")
+	result := lib.result_helper_with_term(
+		rego.metadata.chain(),
+		[name, concat(", ", versions)],
+		name,
+	)
+}
+
+# grouped_rpm_purls groups the found RPMs by name to facilitate detecting different versions. It
+# has the following structure:
+# {
+#     "spam-maps": {"1.2.3-0", "1.2.3-9"},
+#     "bacon": {"7.8.8-8"},
+# }
+grouped_rpm_purls[name] contains version if {
+	some rpm_purl in all_rpm_purls
+	rpm := ec.purl.parse(rpm_purl)
+	name := rpm.name
+
+	# NOTE: This includes both version and release.
+	version := rpm.version
+}
+
+all_rpm_purls contains rpm.purl if {
+	some attestation in lib.pipelinerun_attestations
+	some build_task in tekton.build_tasks(attestation)
+	some result in tekton.task_results(build_task)
+	result.name == "SBOM_BLOB_URL"
+	url := result.value
+	blob := ec.oci.blob(url)
+	s := json.unmarshal(blob)
+	some rpm in sbom.rpms_from_sbom(s)
+}

--- a/policy/release/rpm_packages/rpm_packages_test.rego
+++ b/policy/release/rpm_packages/rpm_packages_test.rego
@@ -1,0 +1,157 @@
+package policy.release.rpm_packages_test
+
+import rego.v1
+
+import data.lib
+import data.lib.tekton_test
+import data.lib_test
+import data.policy.release.rpm_packages
+
+test_success_cyclonedx if {
+	att := _attestation_with_sboms([_cyclonedx_url_1, _cyclonedx_url_1])
+
+	lib.assert_empty(rpm_packages.deny) with input.attestations as [att]
+		with input.image.ref as "registry.local/image-index@sha256:image_index_digest"
+		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.index.v1+json"}
+		with ec.oci.blob as _mock_blob
+}
+
+test_success_spdx if {
+	att := _attestation_with_sboms([_spdx_url_1, _spdx_url_1])
+
+	lib.assert_empty(rpm_packages.deny) with input.attestations as [att]
+		with input.image.ref as "registry.local/image-index@sha256:image_index_digest"
+		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.index.v1+json"}
+		with ec.oci.blob as _mock_blob
+}
+
+test_failure_cyclonedx if {
+	att := _attestation_with_sboms([_cyclonedx_url_1, _cyclonedx_url_2])
+
+	expected := {{
+		"code": "policy.release.rpm_packages.unique_version",
+		"msg": "Multiple versions of the \"spam\" RPM were found: 1.0.0-1, 1.0.0-2",
+		"term": "spam",
+	}}
+
+	lib.assert_equal_results(expected, rpm_packages.deny) with input.attestations as [att]
+		with input.image.ref as "registry.local/image-index@sha256:image_index_digest"
+		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.index.v1+json"}
+		with ec.oci.blob as _mock_blob
+}
+
+test_failure_spdx if {
+	att := _attestation_with_sboms([_spdx_url_1, _spdx_url_2])
+
+	expected := {{
+		"code": "policy.release.rpm_packages.unique_version",
+		"msg": "Multiple versions of the \"spam\" RPM were found: 1.0.0-1, 1.0.0-2",
+		"term": "spam",
+	}}
+
+	lib.assert_equal_results(expected, rpm_packages.deny) with input.attestations as [att]
+		with input.image.ref as "registry.local/image-index@sha256:image-index-digest"
+		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.index.v1+json"}
+		with ec.oci.blob as _mock_blob
+}
+
+test_non_image_index if {
+	att := _attestation_with_sboms([_spdx_url_1, _spdx_url_2])
+
+	lib.assert_empty(rpm_packages.deny) with input.attestations as [att]
+		with input.image.ref as "registry.local/image-manifest@sha256:image-manifest-digest"
+		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.manifest.v1+json"}
+		with ec.oci.blob as _mock_blob
+}
+
+test_ignore_names if {
+	att := _attestation_with_sboms([_spdx_url_1, _spdx_url_2])
+
+	lib.assert_empty(rpm_packages.deny) with input.attestations as [att]
+		with input.image.ref as "registry.local/image-index@sha256:image-index-digest"
+		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.index.v1+json"}
+		with ec.oci.blob as _mock_blob
+		with data.rule_data.non_unique_rpm_names as ["spam"]
+}
+
+_mock_blob(`"registry.local/cyclonedx-1@sha256:cyclonedx-1-digest"`) := json.marshal({"components": [
+	{"purl": "pkg:rpm/redhat/spam@1.0.0-1"},
+	{"purl": "pkg:rpm/redhat/bacon@1.0.0-2"},
+	{"purl": "pkg:rpm/redhat/ham@4.2.0-0"},
+]})
+
+_mock_blob(`"registry.local/cyclonedx-2@sha256:cyclonedx-2-digest"`) := json.marshal({"components": [
+	{"purl": "pkg:rpm/redhat/spam@1.0.0-2"},
+	{"purl": "pkg:rpm/redhat/bacon@1.0.0-2"},
+	{"purl": "pkg:rpm/redhat/eggs@4.2.0-0"},
+]})
+
+_mock_blob(`"registry.local/spdx-1@sha256:spdx-1-digest"`) := json.marshal({"packages": [
+	{"externalRefs": [{
+		"referenceType": "purl",
+		"referenceCategory": "PACKAGE-MANAGER",
+		"referenceLocator": "pkg:rpm/redhat/spam@1.0.0-1",
+	}]},
+	{"externalRefs": [{
+		"referenceType": "purl",
+		"referenceCategory": "PACKAGE-MANAGER",
+		"referenceLocator": "pkg:rpm/redhat/bacon@1.0.0-2",
+	}]},
+	{"externalRefs": [{
+		"referenceType": "purl",
+		"referenceCategory": "PACKAGE-MANAGER",
+		"referenceLocator": "pkg:rpm/redhat/ham@4.2.0-0",
+	}]},
+]})
+
+_mock_blob(`"registry.local/spdx-2@sha256:spdx-2-digest"`) := json.marshal({"packages": [
+	{"externalRefs": [{
+		"referenceType": "purl",
+		"referenceCategory": "PACKAGE-MANAGER",
+		"referenceLocator": "pkg:rpm/redhat/spam@1.0.0-2",
+	}]},
+	{"externalRefs": [{
+		"referenceType": "purl",
+		"referenceCategory": "PACKAGE-MANAGER",
+		"referenceLocator": "pkg:rpm/redhat/bacon@1.0.0-2",
+	}]},
+	{"externalRefs": [{
+		"referenceType": "purl",
+		"referenceCategory": "PACKAGE-MANAGER",
+		"referenceLocator": "pkg:rpm/redhat/eggs@4.2.0-0",
+	}]},
+]})
+
+_cyclonedx_url_1 := "registry.local/cyclonedx-1@sha256:cyclonedx-1-digest"
+
+_cyclonedx_url_2 := "registry.local/cyclonedx-2@sha256:cyclonedx-2-digest"
+
+_spdx_url_1 := "registry.local/spdx-1@sha256:spdx-1-digest"
+
+_spdx_url_2 := "registry.local/spdx-2@sha256:spdx-2-digest"
+
+_attestation_with_sboms(sbom_urls) := attestation if {
+	tasks := [task |
+		some i, url in sbom_urls
+		task_with_result := tekton_test.slsav1_task_result_ref(
+			sprintf("some-build-%d", [i]),
+			[
+				{
+					"name": "SBOM_BLOB_URL",
+					"type": "string",
+					"value": url,
+				},
+				{
+					"name": "IMAGES",
+					"type": "string",
+					"value": "registry.local/image@sha256:abc",
+				},
+			],
+		)
+		task := tekton_test.slsav1_task_bundle(task_with_result, _bundle)
+	]
+
+	attestation := lib_test.mock_slsav1_attestation_with_tasks(tasks)
+}
+
+_bundle := "registry.img/spam@sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb"


### PR DESCRIPTION
This new policy package includes a policy rule that is used to ensure the installed RPMs are of the same version across the different Image Manifests of an Image Index.

Ref: EC-1142