### PR TITLE
fix: enforce related images are from allowed registries

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -127,6 +127,7 @@ Rules included:
 * xref:release_policy.adoc#olm__csv_semver_format[OLM: ClusterServiceVersion semver format]
 * xref:release_policy.adoc#olm__feature_annotations_format[OLM: Feature annotations have expected value]
 * xref:release_policy.adoc#olm__allowed_registries[OLM: Images referenced by OLM bundle are from allowed registries]
+* xref:release_policy.adoc#olm__allowed_registries_related[OLM: Related images references are from allowed registries]
 * xref:release_policy.adoc#olm__required_olm_features_annotations_provided[OLM: Required OLM feature annotations list provided]
 * xref:release_policy.adoc#olm__subscriptions_annotation_format[OLM: Subscription annotation has expected value]
 * xref:release_policy.adoc#olm__inaccessible_snapshot_references[OLM: Unable to access images in the input snapshot]
@@ -800,7 +801,20 @@ Each image referenced by the OLM bundle should match an entry in the list of pre
 * FAILURE message: `The %q CSV image reference is not from an allowed registry.`
 * Code: `olm.allowed_registries`
 * Effective from: `2024-09-01T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L258[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L288[Source, window="_blank"]
+
+[#olm__allowed_registries_related]
+=== link:#olm__allowed_registries_related[Related images references are from allowed registries]
+
+Each image indicated as a related image should match an entry in the list of prefixes defined by the rule data key `allowed_registry_prefixes` in your policy configuration.
+
+*Solution*: Use image from an allowed registry, or modify your xref:ec-cli:ROOT:configuration.adoc#_data_sources[policy configuration] to include additional registry prefixes.
+
+* Rule type: [rule-type-indicator failure]#FAILURE#
+* FAILURE message: `The %q related image reference is not from an allowed registry.`
+* Code: `olm.allowed_registries_related`
+* Effective from: `2025-04-15T00:00:00Z`
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L218[Source, window="_blank"]
 
 [#olm__required_olm_features_annotations_provided]
 === link:#olm__required_olm_features_annotations_provided[Required OLM feature annotations list provided]
@@ -862,7 +876,7 @@ Check the OLM bundle image for the presence of unmapped image references. Unmapp
 * FAILURE message: `The %q CSV image reference is not in the snapshot or accessible.`
 * Code: `olm.unmapped_references`
 * Effective from: `2024-08-15T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L218[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L248[Source, window="_blank"]
 
 [#olm__unpinned_references]
 === link:#olm__unpinned_references[Unpinned images in OLM bundle]

--- a/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
+++ b/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
@@ -57,6 +57,7 @@
 **** xref:release_policy.adoc#olm__csv_semver_format[ClusterServiceVersion semver format]
 **** xref:release_policy.adoc#olm__feature_annotations_format[Feature annotations have expected value]
 **** xref:release_policy.adoc#olm__allowed_registries[Images referenced by OLM bundle are from allowed registries]
+**** xref:release_policy.adoc#olm__allowed_registries_related[Related images references are from allowed registries]
 **** xref:release_policy.adoc#olm__required_olm_features_annotations_provided[Required OLM feature annotations list provided]
 **** xref:release_policy.adoc#olm__subscriptions_annotation_format[Subscription annotation has expected value]
 **** xref:release_policy.adoc#olm__inaccessible_snapshot_references[Unable to access images in the input snapshot]


### PR DESCRIPTION
We missed testing the related images against the
allowed_registry_prefixes in a previous change. We now add an additional policy check to ensure that related images detected are from approved registries.