### PR TITLE
feat(KONFLUX-6986): OLM bundle images should not be multi-arch

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -127,6 +127,7 @@ Rules included:
 * xref:release_policy.adoc#olm__csv_semver_format[OLM: ClusterServiceVersion semver format]
 * xref:release_policy.adoc#olm__feature_annotations_format[OLM: Feature annotations have expected value]
 * xref:release_policy.adoc#olm__allowed_registries[OLM: Images referenced by OLM bundle are from allowed registries]
+* xref:release_policy.adoc#olm__olm_bundle_multi_arch[OLM: OLM bundle images are not multi-arch]
 * xref:release_policy.adoc#olm__allowed_registries_related[OLM: Related images references are from allowed registries]
 * xref:release_policy.adoc#olm__required_olm_features_annotations_provided[OLM: Required OLM feature annotations list provided]
 * xref:release_policy.adoc#olm__subscriptions_annotation_format[OLM: Subscription annotation has expected value]
@@ -801,7 +802,20 @@ Each image referenced by the OLM bundle should match an entry in the list of pre
 * FAILURE message: `The %q CSV image reference is not from an allowed registry.`
 * Code: `olm.allowed_registries`
 * Effective from: `2024-09-01T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L288[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L287[Source, window="_blank"]
+
+[#olm__olm_bundle_multi_arch]
+=== link:#olm__olm_bundle_multi_arch[OLM bundle images are not multi-arch]
+
+OLM bundle images should be multi-arch. It should not be an OCI image index nor should it be a Docker v2s2 manifest list.
+
+*Solution*: Rebuild your bundle image without creating an image index.
+
+* Rule type: [rule-type-indicator failure]#FAILURE#
+* FAILURE message: `The %q bundle image is a multi-arch reference.`
+* Code: `olm.olm_bundle_multi_arch`
+* Effective from: `2025-5-01T00:00:00Z`
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L320[Source, window="_blank"]
 
 [#olm__allowed_registries_related]
 === link:#olm__allowed_registries_related[Related images references are from allowed registries]
@@ -814,7 +828,7 @@ Each image indicated as a related image should match an entry in the list of pre
 * FAILURE message: `The %q related image reference is not from an allowed registry.`
 * Code: `olm.allowed_registries_related`
 * Effective from: `2025-04-15T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L218[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L217[Source, window="_blank"]
 
 [#olm__required_olm_features_annotations_provided]
 === link:#olm__required_olm_features_annotations_provided[Required OLM feature annotations list provided]
@@ -876,7 +890,7 @@ Check the OLM bundle image for the presence of unmapped image references. Unmapp
 * FAILURE message: `The %q CSV image reference is not in the snapshot or accessible.`
 * Code: `olm.unmapped_references`
 * Effective from: `2024-08-15T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L248[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L247[Source, window="_blank"]
 
 [#olm__unpinned_references]
 === link:#olm__unpinned_references[Unpinned images in OLM bundle]

--- a/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
+++ b/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
@@ -57,6 +57,7 @@
 **** xref:release_policy.adoc#olm__csv_semver_format[ClusterServiceVersion semver format]
 **** xref:release_policy.adoc#olm__feature_annotations_format[Feature annotations have expected value]
 **** xref:release_policy.adoc#olm__allowed_registries[Images referenced by OLM bundle are from allowed registries]
+**** xref:release_policy.adoc#olm__olm_bundle_multi_arch[OLM bundle images are not multi-arch]
 **** xref:release_policy.adoc#olm__allowed_registries_related[Related images references are from allowed registries]
 **** xref:release_policy.adoc#olm__required_olm_features_annotations_provided[Required OLM feature annotations list provided]
 **** xref:release_policy.adoc#olm__subscriptions_annotation_format[Subscription annotation has expected value]

--- a/policy/release/olm/olm.rego
+++ b/policy/release/olm/olm.rego
@@ -192,7 +192,6 @@ deny contains result if {
 #   effective_on: 2025-03-10T00:00:00Z
 #
 deny contains result if {
-	# This rule was removed from the "redhat" collection for testing
 	_release_restrictions_apply
 
 	snapshot_components := input.snapshot.components
@@ -316,6 +315,29 @@ deny contains result if {
 	img_str := image.str(img.ref)
 
 	result := lib.result_helper_with_term(rego.metadata.chain(), [img_str], img.ref.repo)
+}
+
+# METADATA
+# title: OLM bundle images are not multi-arch
+# description: >-
+#   OLM bundle images should be multi-arch. It should not be an OCI image index
+#   nor should it be a Docker v2s2 manifest list.
+# custom:
+#   short_name: olm_bundle_multi_arch
+#   failure_msg: The %q bundle image is a multi-arch reference.
+#   solution: >-
+#     Rebuild your bundle image without creating an image index.
+#   collections:
+#   - redhat
+#   effective_on: 2025-5-01T00:00:00Z
+deny contains result if {
+	# Parse manifests from snapshot
+	some csv_manifest in _csv_manifests
+
+	# If we have a CSV manifest, ensure that the input image is not an image index
+	image.is_image_index(input.image.ref)
+
+	result := lib.result_helper_with_term(rego.metadata.chain(), [input.image.ref], input.image.ref)
 }
 
 _name(o) := n if {

--- a/policy/release/olm/olm_test.rego
+++ b/policy/release/olm/olm_test.rego
@@ -433,6 +433,23 @@ test_allowed_registries if {
 		with input.image.files as {"manifests/csv.yaml": manifest}
 }
 
+test_bundle_image_index if {
+	descriptor := {"mediaType": "application/vnd.oci.image.index.v1+json"}
+
+	expected_deny := {{
+		"code": "olm.olm_bundle_multi_arch",
+		"msg": "The \"registry.io/repository/image@sha256:cafe\" bundle image is a multi-arch reference.",
+		"term": "registry.io/repository/image@sha256:cafe",
+	}}
+
+	lib.assert_equal_results(olm.deny, expected_deny) with data.rule_data.pipeline_intention as "release"
+		with data.rule_data.allowed_registry_prefixes as ["registry.io", "registry.redhat.io"]
+		with input.image.config.Labels as {olm.manifestv1: "manifests/"}
+		with input.image.files as {"manifests/csv.yaml": manifest}
+		with input.image.ref as pinned
+		with ec.oci.descriptor as descriptor
+}
+
 test_unallowed_registries if {
 	expected := {
 		{


### PR DESCRIPTION
If OLM bundle images are multi-arch then the image pulled by the client will be interpolated to match the client's platform. This can result in inconsitent behaviors between architectures. Instead, a single image manifest should be created since there is no binary and therefore no architecture dependencies.

resolves: KONFLUX-6986