### PR TITLE
Make image.parse only validates valid hostnames

### DIFF
--- a/policy/lib/image/image_test.rego
+++ b/policy/lib/image/image_test.rego
@@ -9,7 +9,6 @@ import data.lib.image
 test_parse if {
 	repository := "registry.com/re/po"
 	repository_with_port := "registry.com:8443/re/po"
-	bad_repository := "http://not-a-registry.com"
 	tag := "latest"
 	digest := "sha256:01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"
 
@@ -47,8 +46,15 @@ test_parse if {
 		image.parse(concat("", [repository_with_port, ":", tag, " "])),
 		{"repo": repository_with_port, "tag": tag, "digest": ""},
 	)
+}
 
-	not image.parse(concat("", [bad_repository, ":", tag, "@", digest]))
+test_not_parse if {
+	tag := "latest"
+	digest := "sha256:01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"
+	not image.parse(concat("", ["http://not-a-registry.com", ":", tag, "@", digest]))
+	not image.parse("oci://not-a-registry.com")
+	not image.parse("operator-sdk-v1.32.0")
+	not image.parse("quay.io")
 }
 
 test_equal if {

--- a/policy/release/olm/olm_test.rego
+++ b/policy/release/olm/olm_test.rego
@@ -59,6 +59,8 @@ manifest := {
 		"features.operators.openshift.io/token-auth-gcp": "false",
 		"operators.openshift.io/valid-subscription": `["spam"]`,
 		"alm-examples": `"endpoint": "http://example:4317" spam`,
+		# regal ignore:line-length
+		"features.operators.image": `{"kind":"Namespace","apiVersion":"v1","metadata":{"name":"openshift-workload-availability","annotations":{"openshift.io/node-selector":""}}}`,
 	}},
 	"spec": {
 		"version": "0.1.3",


### PR DESCRIPTION
image.parse was allowing invalid hostnames.
Adding a regex to strengthen the validation.

https://issues.redhat.com/browse/EC-1153