### PR TITLE
Update go for module updates

### DIFF
--- a/docs/go.mod
+++ b/docs/go.mod
@@ -1,6 +1,6 @@
 module github.com/enterprise-contract/ec-policies/docs
 
-go 1.22.7
+go 1.23.6
 
 require github.com/open-policy-agent/opa v0.68.0
 


### PR DESCRIPTION
Security updates are requiring `>1.23` for the go version.