### PR TITLE
Support both old and new names for cachi2/hermeto

### DIFF
--- a/policy/lib/sbom/rpm.rego
+++ b/policy/lib/sbom/rpm.rego
@@ -44,21 +44,29 @@ _is_rpmish(purl) if {
 	startswith(purl, "pkg:rpmmod/")
 }
 
+# CycloneDX style
 _component_found_by_cachi2(component) if {
 	some property in component.properties
-	property == cachi2_found_by_property
+	some cachi2_name in _cachi2_names
+	property == _cachi2_found_by_property(cachi2_name)
 } else := false
 
-# This is what cachi2 produces in the component property list
-cachi2_found_by_property := {
-	"name": "cachi2:found_by",
-	"value": "cachi2",
+# Expecting this to be called with one of _cachi2_names
+_cachi2_found_by_property(cachi2_name) := {
+	"name": sprintf("%s:found_by", [cachi2_name]),
+	"value": cachi2_name,
 }
 
+# SPDX style
 _package_found_by_cachi2(pkg) if {
 	some annotation in pkg.annotations
-	regex.match(`.*cachi2.*`, annotation.annotator)
+	some cachi2_name in _cachi2_names
+	regex.match(sprintf(`.*%s.*`, [cachi2_name]), annotation.annotator)
 	annotation.annotationType == "OTHER"
 	# `comment` contains additional information, but that is not needed for the purpose of
 	# simply filtering what was found by cachi2.
 } else := false
+
+# The new name for cachi2 is hermeto. We want to treat them
+# as as synonymous when looking in the SBOM data.
+_cachi2_names := ["cachi2", "hermeto"]

--- a/policy/lib/sbom/rpm_test.rego
+++ b/policy/lib/sbom/rpm_test.rego
@@ -6,7 +6,7 @@ import data.lib
 import data.lib.sbom
 
 test_all_rpm_entities if {
-	s_cyclonedx := _cyclonedx_sbom([_cyclonedx_component(_rpm_spam_1, [sbom.cachi2_found_by_property])])
+	s_cyclonedx := _cyclonedx_sbom([_cyclonedx_component(_rpm_spam_1, [_cachi2_found_by_property])])
 	s_spdx := _spdx_sbom([_spdx_package(_rpm_spam_2, [_cachi2_spdx_annotation])])
 
 	expected := {
@@ -26,12 +26,12 @@ test_all_rpm_entities if {
 
 test_all_rpm_entities_no_dupes if {
 	s_cyclonedx := _cyclonedx_sbom([
-		_cyclonedx_component(_rpm_spam_1, [sbom.cachi2_found_by_property]),
-		_cyclonedx_component(_rpm_spam_2, [sbom.cachi2_found_by_property]),
+		_cyclonedx_component(_rpm_spam_1, [_cachi2_found_by_property]),
+		_cyclonedx_component(_rpm_spam_2, [_hermeto_found_by_property]),
 	])
 	s_spdx := _spdx_sbom([
 		_spdx_package(_rpm_spam_1, [_cachi2_spdx_annotation]),
-		_spdx_package(_rpm_spam_2, [_cachi2_spdx_annotation]),
+		_spdx_package(_rpm_spam_2, [_hermeto_spdx_annotation]),
 	])
 
 	# Duplicated entries across SBOMs are ignored.
@@ -53,7 +53,7 @@ test_all_rpm_entities_no_dupes if {
 test_rpms_from_sbom_cyclonedx if {
 	s := _cyclonedx_sbom([
 		_cyclonedx_component(_rpm_spam_1, []),
-		_cyclonedx_component(_rpm_spam_2, [sbom.cachi2_found_by_property]),
+		_cyclonedx_component(_rpm_spam_2, [_cachi2_found_by_property]),
 		_cyclonedx_component(_not_rpm, []),
 	])
 	expected := {
@@ -108,7 +108,13 @@ _spdx_package(purl, annotations) := {
 	}],
 }
 
+_cachi2_found_by_property := sbom._cachi2_found_by_property("cachi2")
+
+_hermeto_found_by_property := sbom._cachi2_found_by_property("hermeto")
+
 _cachi2_spdx_annotation := {"annotator": "Tool: cachi2:jsonencoded", "annotationType": "OTHER"}
+
+_hermeto_spdx_annotation := {"annotator": "Tool: hermeto:jsonencoded", "annotationType": "OTHER"}
 
 _rpm_spam_1 := "pkg:rpm/redhat/spam@1.0.0-1"
 

--- a/policy/release/rpm_repos/rpm_repos_test.rego
+++ b/policy/release/rpm_repos/rpm_repos_test.rego
@@ -213,7 +213,7 @@ fake_cyclonedx_sboms := [fake_cyclonedx_sbom({p1, p2, p3, p4, p5, p6, p7})]
 fake_cyclonedx_sbom(fake_purls) := {"components": [
 {
 	"purl": p,
-	"properties": [sbom.cachi2_found_by_property],
+	"properties": [sbom._cachi2_found_by_property("hermeto")],
 } |
 	some p in fake_purls
 ]}


### PR DESCRIPTION
The name is changing and so the annotations we need to look for in sbom component/package lists are changing accordingly. Match both the old and new names so we can transition smoothly.

There are two different matches, one for CycloneDX and one for SPDX formatted SBOMs.

Ref: https://issues.redhat.com/browse/EC-1176