### PR TITLE
Emit warning for bundle references without tags

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -203,6 +203,7 @@ Rules included:
 * xref:release_policy.adoc#test__test_results_found[Test: Test data includes results key]
 * xref:release_policy.adoc#trusted_task__data_format[Trusted Task checks: Data format]
 * xref:release_policy.adoc#trusted_task__pinned[Trusted Task checks: Task references are pinned]
+* xref:release_policy.adoc#trusted_task__tagged[Trusted Task checks: Task references are tagged]
 * xref:release_policy.adoc#trusted_task__data[Trusted Task checks: Task tracking data was provided]
 * xref:release_policy.adoc#trusted_task__trusted[Trusted Task checks: Tasks are trusted]
 * xref:release_policy.adoc#trusted_task__current[Trusted Task checks: Tasks using the latest versions]
@@ -276,6 +277,7 @@ Rules included:
 * xref:release_policy.adoc#test__test_results_found[Test: Test data includes results key]
 * xref:release_policy.adoc#trusted_task__data_format[Trusted Task checks: Data format]
 * xref:release_policy.adoc#trusted_task__pinned[Trusted Task checks: Task references are pinned]
+* xref:release_policy.adoc#trusted_task__tagged[Trusted Task checks: Task references are tagged]
 * xref:release_policy.adoc#trusted_task__data[Trusted Task checks: Task tracking data was provided]
 * xref:release_policy.adoc#trusted_task__current[Trusted Task checks: Tasks using the latest versions]
 * xref:release_policy.adoc#trusted_task__valid_trusted_artifact_inputs[Trusted Task checks: Trusted Artifact produced in pipeline]
@@ -2064,7 +2066,7 @@ Confirm the expected `trusted_tasks` data keys have been provided in the expecte
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `trusted_task.data_format`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L195[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L219[Source, window="_blank"]
 
 [#trusted_task__pinned]
 === link:#trusted_task__pinned[Task references are pinned]
@@ -2076,6 +2078,19 @@ Check if all Tekton Tasks use a Task definition by a pinned reference. When usin
 * Rule type: [rule-type-indicator warning]#WARNING#
 * WARNING message: `Pipeline task %q uses an unpinned task reference, %s`
 * Code: `trusted_task.pinned`
+* Effective from: `2024-05-07T00:00:00Z`
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L49[Source, window="_blank"]
+
+[#trusted_task__tagged]
+=== link:#trusted_task__tagged[Task references are tagged]
+
+Check if all Tekton Tasks defined with the bundle format contain a tag reference.
+
+*Solution*: Update the Pipeline definition so that all Task references have a tagged value as mentioned in the description.
+
+* Rule type: [rule-type-indicator warning]#WARNING#
+* WARNING message: `Pipeline task %q uses an untagged task reference, %s`
+* Code: `trusted_task.tagged`
 * Effective from: `2024-05-07T00:00:00Z`
 * https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L25[Source, window="_blank"]
 
@@ -2090,7 +2105,7 @@ Confirm the `trusted_tasks` rule data was provided, since it's required by the p
 * FAILURE message: `Missing required trusted_tasks data`
 * Code: `trusted_task.data`
 * Effective from: `2024-05-07T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L144[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L168[Source, window="_blank"]
 
 [#trusted_task__trusted]
 === link:#trusted_task__trusted[Tasks are trusted]
@@ -2103,7 +2118,7 @@ Check the trust of the Tekton Tasks used in the build Pipeline. There are two mo
 * FAILURE message: `%s`
 * Code: `trusted_task.trusted`
 * Effective from: `2024-05-07T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L80[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L104[Source, window="_blank"]
 
 [#trusted_task__current]
 === link:#trusted_task__current[Tasks using the latest versions]
@@ -2116,7 +2131,7 @@ Check if all Tekton Tasks use the latest known Task reference. When warnings wil
 * WARNING message: `A newer version of task %q exists. Please update before %s. The current bundle is %q and the latest bundle ref is %q`
 * Code: `trusted_task.current`
 * Effective from: `2024-05-07T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L51[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L75[Source, window="_blank"]
 
 [#trusted_task__valid_trusted_artifact_inputs]
 === link:#trusted_task__valid_trusted_artifact_inputs[Trusted Artifact produced in pipeline]
@@ -2128,7 +2143,7 @@ All input trusted artifacts must be produced on the pipeline. If they are not th
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Code tampering detected, input %q for task %q was not produced by the pipeline as attested.`
 * Code: `trusted_task.valid_trusted_artifact_inputs`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L106[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L130[Source, window="_blank"]
 
 [#trusted_task__trusted_parameters]
 === link:#trusted_task__trusted_parameters[Trusted parameters]
@@ -2141,7 +2156,7 @@ Confirm certain parameters provided to each builder Task have come from trusted 
 * FAILURE message: `The %q parameter of the %q PipelineTask includes an untrusted digest: %s`
 * Code: `trusted_task.trusted_parameters`
 * Effective from: `2021-07-04T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L164[Source, window="_blank"]
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L188[Source, window="_blank"]
 
 [#rpm_ostree_task_package]
 == link:#rpm_ostree_task_package[rpm-ostree Task]

--- a/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
+++ b/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
@@ -165,6 +165,7 @@
 *** xref:release_policy.adoc#trusted_task_package[Trusted Task checks]
 **** xref:release_policy.adoc#trusted_task__data_format[Data format]
 **** xref:release_policy.adoc#trusted_task__pinned[Task references are pinned]
+**** xref:release_policy.adoc#trusted_task__tagged[Task references are tagged]
 **** xref:release_policy.adoc#trusted_task__data[Task tracking data was provided]
 **** xref:release_policy.adoc#trusted_task__trusted[Tasks are trusted]
 **** xref:release_policy.adoc#trusted_task__current[Tasks using the latest versions]

--- a/policy/lib/tekton/refs_test.rego
+++ b/policy/lib/tekton/refs_test.rego
@@ -28,36 +28,42 @@ _git_key := "git+https://git.local/repo.git//tasks/test.yaml"
 test_bundle_in_definition if {
 	lib.assert_equal(
 		tekton.task_ref({"taskRef": {"bundle": _image, "name": "test", "kind": "Task"}}),
-		{"bundle": _image, "kind": "task", "name": "test", "pinned": true, "pinned_ref": _image_digest, "key": _image_key},
+		# regal ignore:line-length
+		{"bundle": _image, "kind": "task", "name": "test", "pinned": true, "pinned_ref": _image_digest, "tagged": false, "key": _image_key},
 	)
 
 	lib.assert_equal(
 		tekton.task_ref({"taskRef": {"bundle": _unpinned_image, "name": "test", "kind": "Task"}}),
-		{"bundle": _unpinned_image, "kind": "task", "name": "test", "pinned": false, "key": _unpinned_image_key},
+		# regal ignore:line-length
+		{"bundle": _unpinned_image, "kind": "task", "name": "test", "pinned": false, "tagged": true, "tagged_ref": "latest", "key": _unpinned_image_key},
 	)
 }
 
 test_bundle_in_slsa_v1_0 if {
 	lib.assert_equal(
 		tekton.task_ref({"spec": {"taskRef": {"name": "test", "kind": "Task", "bundle": _image}}}),
-		{"bundle": _image, "kind": "task", "name": "test", "pinned": true, "pinned_ref": _image_digest, "key": _image_key},
+		# regal ignore:line-length
+		{"bundle": _image, "kind": "task", "name": "test", "pinned": true, "pinned_ref": _image_digest, "tagged": false, "key": _image_key},
 	)
 
 	lib.assert_equal(
 		tekton.task_ref({"spec": {"taskRef": {"name": "test", "kind": "Task", "bundle": _unpinned_image}}}),
-		{"bundle": _unpinned_image, "kind": "task", "name": "test", "pinned": false, "key": _unpinned_image_key},
+		# regal ignore:line-length
+		{"bundle": _unpinned_image, "kind": "task", "name": "test", "pinned": false, "tagged": true, "tagged_ref": "latest", "key": _unpinned_image_key},
 	)
 }
 
 test_bundle_in_slsa_v0_2 if {
 	lib.assert_equal(
 		tekton.task_ref({"ref": {"name": "test", "kind": "Task", "bundle": _image}}),
-		{"bundle": _image, "kind": "task", "name": "test", "pinned": true, "pinned_ref": _image_digest, "key": _image_key},
+		# regal ignore:line-length
+		{"bundle": _image, "kind": "task", "name": "test", "pinned": true, "pinned_ref": _image_digest, "tagged": false, "key": _image_key},
 	)
 
 	lib.assert_equal(
 		tekton.task_ref({"ref": {"name": "test", "kind": "Task", "bundle": _unpinned_image}}),
-		{"bundle": _unpinned_image, "kind": "task", "name": "test", "pinned": false, "key": _unpinned_image_key},
+		# regal ignore:line-length
+		{"bundle": _unpinned_image, "kind": "task", "name": "test", "pinned": false, "tagged": true, "tagged_ref": "latest", "key": _unpinned_image_key},
 	)
 }
 
@@ -68,7 +74,8 @@ test_bundles_resolver_in_definition if {
 			{"name": "name", "value": "test"},
 			{"name": "kind", "value": "task"},
 		]}}),
-		{"bundle": _image, "kind": "task", "name": "test", "pinned": true, "pinned_ref": _image_digest, "key": _image_key},
+		# regal ignore:line-length
+		{"bundle": _image, "kind": "task", "name": "test", "pinned": true, "pinned_ref": _image_digest, "tagged": false, "key": _image_key},
 	)
 
 	lib.assert_equal(
@@ -77,7 +84,8 @@ test_bundles_resolver_in_definition if {
 			{"name": "name", "value": "test"},
 			{"name": "kind", "value": "task"},
 		]}}),
-		{"bundle": _unpinned_image, "kind": "task", "name": "test", "pinned": false, "key": _unpinned_image_key},
+		# regal ignore:line-length
+		{"bundle": _unpinned_image, "kind": "task", "name": "test", "pinned": false, "tagged": true, "tagged_ref": "latest", "key": _unpinned_image_key},
 	)
 }
 
@@ -88,7 +96,8 @@ test_bundles_resolver_in_slsa_v1_0 if {
 			{"name": "name", "value": "test"},
 			{"name": "kind", "value": "task"},
 		]}}}),
-		{"bundle": _image, "kind": "task", "name": "test", "pinned": true, "pinned_ref": _image_digest, "key": _image_key},
+		# regal ignore:line-length
+		{"bundle": _image, "kind": "task", "name": "test", "pinned": true, "pinned_ref": _image_digest, "tagged": false, "key": _image_key},
 	)
 
 	lib.assert_equal(
@@ -97,7 +106,8 @@ test_bundles_resolver_in_slsa_v1_0 if {
 			{"name": "name", "value": "test"},
 			{"name": "kind", "value": "task"},
 		]}}}),
-		{"bundle": _unpinned_image, "kind": "task", "name": "test", "pinned": false, "key": _unpinned_image_key},
+		# regal ignore:line-length
+		{"bundle": _unpinned_image, "kind": "task", "name": "test", "pinned": false, "tagged": true, "tagged_ref": "latest", "key": _unpinned_image_key},
 	)
 }
 
@@ -108,7 +118,8 @@ test_bundles_resolver_in_slsa_v0_2 if {
 			{"name": "name", "value": "test"},
 			{"name": "kind", "value": "task"},
 		]}}),
-		{"bundle": _image, "kind": "task", "name": "test", "pinned": true, "pinned_ref": _image_digest, "key": _image_key},
+		# regal ignore:line-length
+		{"bundle": _image, "kind": "task", "name": "test", "pinned": true, "pinned_ref": _image_digest, "tagged": false, "key": _image_key},
 	)
 
 	lib.assert_equal(
@@ -117,7 +128,8 @@ test_bundles_resolver_in_slsa_v0_2 if {
 			{"name": "name", "value": "test"},
 			{"name": "kind", "value": "task"},
 		]}}),
-		{"bundle": _unpinned_image, "kind": "task", "name": "test", "pinned": false, "key": _unpinned_image_key},
+		# regal ignore:line-length
+		{"bundle": _unpinned_image, "kind": "task", "name": "test", "pinned": false, "tagged": true, "tagged_ref": "latest", "key": _unpinned_image_key},
 	)
 }
 
@@ -324,7 +336,7 @@ test_bundle_with_defaults if {
 	lib.assert_equal(
 		tekton.task_ref({"ref": {"bundle": _image}}),
 		# regal ignore:line-length
-		{"bundle": _image, "kind": "task", "name": tekton._no_task_name, "pinned": true, "pinned_ref": _image_digest, "key": _image_key},
+		{"bundle": _image, "kind": "task", "name": tekton._no_task_name, "pinned": true, "pinned_ref": _image_digest, "tagged": false, "key": _image_key},
 	)
 }
 
@@ -332,6 +344,6 @@ test_bundle_resolver_with_defaults if {
 	lib.assert_equal(
 		tekton.task_ref({"ref": {"resolver": "bundles", "params": [{"name": "bundle", "value": _image}]}}),
 		# regal ignore:line-length
-		{"bundle": _image, "kind": "task", "name": tekton._no_task_name, "pinned": true, "pinned_ref": _image_digest, "key": _image_key},
+		{"bundle": _image, "kind": "task", "name": tekton._no_task_name, "pinned": true, "pinned_ref": _image_digest, "tagged": false, "key": _image_key},
 	)
 }

--- a/policy/lib/tekton/trusted_test.rego
+++ b/policy/lib/tekton/trusted_test.rego
@@ -135,6 +135,21 @@ test_is_trusted_task if {
 	tekton.is_trusted_task(newest_trusted_git_task) with data.trusted_tasks as future_trusted_tasks
 }
 
+test_trusted_task_records if {
+	task_ref_expected_matches := {
+		"oci://registry.local/trusty:1.0": 3,
+		"oci://registry.local/trusty": 3,
+		"git+git.local/repo.git//tasks/honest-abe.yaml": 2,
+		"git+git.local/repo.git//tasks/untrusted.yaml": 0,
+		"oci://reg": 0,
+	}
+
+	every ref, expected in task_ref_expected_matches {
+		records := tekton.trusted_task_records(ref) with data.trusted_tasks as trusted_tasks
+		lib.assert_equal(expected, count(records))
+	}
+}
+
 test_rule_data_merging if {
 	lib.assert_equal(tekton._trusted_tasks_data.foo, "baz") with data.trusted_tasks as {"foo": "baz"}
 

--- a/policy/release/trusted_task/trusted_task.rego
+++ b/policy/release/trusted_task/trusted_task.rego
@@ -23,6 +23,30 @@ _supported_ta_uris_reg := {"oci:.*@sha256:[0-9a-f]{64}"}
 _digest_patterns := {`sha256:[0-9a-f]{64}`}
 
 # METADATA
+# title: Task references are tagged
+# description: >-
+#   Check if all Tekton Tasks defined with the bundle format contain a tag reference.
+# custom:
+#   short_name: tagged
+#   failure_msg: Pipeline task %q uses an untagged task reference, %s
+#   solution: >-
+#     Update the Pipeline definition so that all Task references have a tagged value as mentioned
+#     in the description.
+#   collections:
+#   - redhat
+#   - redhat_rpms
+#   effective_on: 2024-05-07T00:00:00Z
+#
+warn contains result if {
+	some task in tekton.untagged_task_references(lib.tasks_from_pipelinerun)
+	result := lib.result_helper_with_term(
+		rego.metadata.chain(),
+		[tekton.pipeline_task_name(task), _task_info(task)],
+		tekton.task_name(task),
+	)
+}
+
+# METADATA
 # title: Task references are pinned
 # description: >-
 #   Check if all Tekton Tasks use a Task definition by a pinned reference. When using the git


### PR DESCRIPTION
Extend the trusted tasks lookup logic to also support bundle references without tag information, as long as a match for the digest is found. Now the presence of an untagged task reference throws a warning instead of a violation.

Ref: https://issues.redhat.com/browse/EC-712