### PR TITLE
Docs: fix broken links to ec-cli docs in ec-policies docs

### DIFF
--- a/acceptance/samples/README.md
+++ b/acceptance/samples/README.md
@@ -3,7 +3,7 @@
 This directory contains sample files meant to use in the acceptance test scenarios.
 
 [policy-input-golden-container.json](./policy-input-golden-container.json) holds the
-[policy input](https://conforma.dev/docs/ec-cli/main/policy_input.html) as used by the
+[policy input](https://conforma.dev/docs/ec-cli/policy_input.html) as used by the
 the EC CLI.
 
 The script `hack/refresh-examples.sh` will regenerate these files.

--- a/antora/docs/modules/ROOT/pages/authoring.adoc
+++ b/antora/docs/modules/ROOT/pages/authoring.adoc
@@ -55,9 +55,9 @@ further reference on annotations.
 
 == Input
 
-The https://conforma.dev/docs/ec-cli/main/index.html[ec-cli] is reponsible for gathering
+The https://conforma.dev/docs/ec-cli/index.html[ec-cli] is reponsible for gathering
 the information to be validated which is made available to policies via the `input` object. Its
-structure is defined https://conforma.dev/docs/ec-cli/main/policy_input.html[here].
+structure is defined https://conforma.dev/docs/ec-cli/policy_input.html[here].
 
 == Pitfalls
 

--- a/antora/docs/modules/ROOT/pages/trusting_tasks.adoc
+++ b/antora/docs/modules/ROOT/pages/trusting_tasks.adoc
@@ -5,7 +5,7 @@
 :image-built-by-trusted-task: release_policy#slsa_build_scripted_build__image_built_by_trusted_task
 :build-definitions: https://github.com/konflux-ci/build-definitions
 :ec-policies: https://github.com/enterprise-contract/ec-policies
-:ec-track-bundle: https://conforma.dev/docs/ec-cli/main/ec_track_bundle.html
+:ec-track-bundle: https://conforma.dev/docs/ec-cli/ec_track_bundle.html
 :tekton-bundles: https://tekton.dev/docs/pipelines/pipelines/#tekton-bundles
 
 This document details the process of trusting a Task originating in a
@@ -190,7 +190,7 @@ sources:
 
 That custom data source should be kept updated as new Tekton task bundles are
 pushed, perhaps via some automation or using
-https://conforma.dev/docs/ec-cli/main/ec_track_bundle.html[`ec track tekton-task`].
+https://conforma.dev/docs/ec-cli/ec_track_bundle.html[`ec track tekton-task`].
 
 The customized policy can be provided to EC with the `--policy` parameter, and
 should allow custom tasks to validate using the new data source.


### PR DESCRIPTION
References to ec-cli docs from ec-policies docs are broken, as they contain a reference to branch name "main".
Remove the branch from the URL to fix the links.

Ref: EC-1230