### PR TITLE
Push effective date on rpm_packages.unique_version

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -1075,7 +1075,7 @@ Check if there is more than one version of the same RPM installed across differe
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Multiple versions of the %q RPM were found: %s`
 * Code: `rpm_packages.unique_version`
-* Effective from: `2025-04-28T00:00:00Z`
+* Effective from: `2025-06-28T00:00:00Z`
 * https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/rpm_packages/rpm_packages.rego#L17[Source, window="_blank"]
 
 [#rpm_pipeline_package]

--- a/policy/release/rpm_packages/rpm_packages.rego
+++ b/policy/release/rpm_packages/rpm_packages.rego
@@ -25,7 +25,8 @@ import data.lib.tekton
 #   failure_msg: 'Multiple versions of the %q RPM were found: %s'
 #   collections:
 #   - redhat
-#   effective_on: 2025-04-28T00:00:00Z
+#   # Pushed back due to https://issues.redhat.com/browse/EC-1232
+#   effective_on: 2025-06-28T00:00:00Z
 #
 deny contains result if {
 	image.is_image_index(input.image.ref)


### PR DESCRIPTION
This check went active today, and it sems to be causing problems. While we figure out the details, let's disable it. Rather than revert, I've pushed it the effective date back two months. (Of course we can bring if forward or push it back again if needed.)

Ref: https://issues.redhat.com/browse/EC-1142

Original story:
Ref: https://issues.redhat.com/browse/EC-1232