### PR TITLE
Use binaries for OPA IDE integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 .cache/
 *.swp
 coverage.json
+bin/

--- a/Makefile
+++ b/Makefile
@@ -323,3 +323,15 @@ acceptance: ## Run acceptance tests
 	@cd acceptance && go test ./...
 
 #--------------------------------------------------------------------
+
+##@ IDE Binaries
+
+bin/ec: go.mod ## Create the EC binary
+	@go build -o bin/ec github.com/enterprise-contract/ec-cli
+
+bin/regal: go.mod regal.go ## Create the regal binary
+	@go build -o bin/regal regal.go
+
+.PHONY: ide-binaries
+ide-binaries: bin/ec bin/regal ## Build binaries for IDE integration
+#--------------------------------------------------------------------

--- a/hack/ec-opa.sh
+++ b/hack/ec-opa.sh
@@ -19,4 +19,5 @@
 # by EC, e.g. ec.oci.image_files, a custom version of OPA is required.
 set -euo pipefail
 cd "$(dirname "$0")/.."
-exec go run github.com/enterprise-contract/ec-cli opa "$@"
+make --silent bin/ec
+exec bin/ec opa "$@"

--- a/hack/regal.sh
+++ b/hack/regal.sh
@@ -19,5 +19,5 @@
 # the expected regal version is used.
 set -euo pipefail
 cd "$(dirname "$0")/.."
-# exec go run github.com/styrainc/regal "$@"
-exec go run regal.go "$@"
+make --silent bin/regal
+exec bin/regal "$@"


### PR DESCRIPTION
The OPA VSCode plugin relies on the OPA and Regal binaries to be available on the system. The exact version of those matter. In fact, the OPA binary used has to be the one wrapped by the EC CLI, i.e. `ec opa`. To make this easier, we track those dependencies in go.mod and use bash scripts to call `go run ...` on the corresponding modules. This works ok, but it's kind of slow, and it's likely the reason the VSCode plugin crashes all the time.

This commit changes the bash script to no longer use `go run`. Instead, it introduces Make targets to create the required binaries. The bash scripts are modified to automatically call the Make targets, which should be a no-op if the binaries don't need to be created, and then invoking the binary directly.

This should give us a snappier development experience.