### PR TITLE
Shorten some long unflat package names

### DIFF
--- a/policy/release/collection/rhtap_multi_ci/rhtap_multi_ci.rego
+++ b/policy/release/collection/rhtap_multi_ci/rhtap_multi_ci.rego
@@ -3,6 +3,6 @@
 # title: rhtap-multi-ci
 # description: >-
 #   A set of policy rules to validate artifacts built using RHTAP Multi-CI pipelines.
-package policy.release.collection.rhtap_multi_ci
+package collection.rhtap_multi_ci
 
 import rego.v1

--- a/policy/release/rpm_packages/rpm_packages.rego
+++ b/policy/release/rpm_packages/rpm_packages.rego
@@ -5,7 +5,7 @@
 #   Rules used to verify different properties of specific RPM packages found in the SBOM of the
 #   image being validated.
 #
-package policy.release.rpm_packages
+package rpm_packages
 
 import rego.v1
 

--- a/policy/release/rpm_packages/rpm_packages_test.rego
+++ b/policy/release/rpm_packages/rpm_packages_test.rego
@@ -1,11 +1,11 @@
-package policy.release.rpm_packages_test
+package rpm_packages_test
 
 import rego.v1
 
 import data.lib
 import data.lib.tekton_test
 import data.lib_test
-import data.policy.release.rpm_packages
+import data.rpm_packages
 
 test_success_cyclonedx if {
 	att := _attestation_with_sboms([_cyclonedx_url_1, _cyclonedx_url_1])
@@ -29,7 +29,7 @@ test_failure_cyclonedx if {
 	att := _attestation_with_sboms([_cyclonedx_url_1, _cyclonedx_url_2])
 
 	expected := {{
-		"code": "policy.release.rpm_packages.unique_version",
+		"code": "rpm_packages.unique_version",
 		"msg": "Multiple versions of the \"spam\" RPM were found: 1.0.0-1, 1.0.0-2",
 		"term": "spam",
 	}}
@@ -44,7 +44,7 @@ test_failure_spdx if {
 	att := _attestation_with_sboms([_spdx_url_1, _spdx_url_2])
 
 	expected := {{
-		"code": "policy.release.rpm_packages.unique_version",
+		"code": "rpm_packages.unique_version",
 		"msg": "Multiple versions of the \"spam\" RPM were found: 1.0.0-1, 1.0.0-2",
 		"term": "spam",
 	}}


### PR DESCRIPTION
The files being fixed here were using the old convention of nested namespace package names, which we used to do, but stopped doing in https://github.com/enterprise-contract/ec-policies/pull/1198 .

The symptom is a little unexpected -- some missing description/solution text in a violation report due to how the the metadata lookup is done by the cli. This could actually could be a separate bug, out of scope in this PR, but possibly in scope for https://issues.redhat.com/browse/EC-945 which I am also looking at currently.

Anyway, this change should be enough to fix EC-1233.

Note: The collection.rhtap_multi_ci change might not have any impact, but I'll change it anyhow so it's consistent with the others.

Ref: https://issues.redhat.com/browse/EC-1233