### PR TITLE
Add policy rules to verify test_results att

### DIFF
--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -2049,6 +2049,23 @@ Each test result is expected to have a `results` key. Verify that the `results` 
 * Code: `test.test_results_found`
 * https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/test/test.rego#L88[Source, window="_blank"]
 
+[#test_results_package]
+== link:#test_results_package[Test Results Attestation]
+
+Rules that verify the test results attestations associated with the image being verified.
+
+* Package name: `test_results`
+
+[#test_results__valid]
+=== link:#test_results__valid[Test Results Attestation]
+
+Verify that the image has at least one valid test results attestation with a passing result. By default the same sigstore options used to verify the image are also used to verify the test results attestations. Any test results attestations signed with a different key, or identity, will be ignored. Use the `test_result_sigstore_opts` rule_data to configure alternate sigstore options for the test results attestations.
+
+* Rule type: [rule-type-indicator failure]#FAILURE#
+* FAILURE message: `%s`
+* Code: `test_results.valid`
+* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/test_results/test_results.rego#L14[Source, window="_blank"]
+
 [#trusted_task_package]
 == link:#trusted_task_package[Trusted Task checks]
 

--- a/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
+++ b/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
@@ -162,6 +162,8 @@
 **** xref:release_policy.adoc#test__rule_data_provided[Rule data provided]
 **** xref:release_policy.adoc#test__test_data_found[Test data found in task results]
 **** xref:release_policy.adoc#test__test_results_found[Test data includes results key]
+*** xref:release_policy.adoc#test_results_package[Test Results Attestation]
+**** xref:release_policy.adoc#test_results__valid[Test Results Attestation]
 *** xref:release_policy.adoc#trusted_task_package[Trusted Task checks]
 **** xref:release_policy.adoc#trusted_task__data_format[Data format]
 **** xref:release_policy.adoc#trusted_task__pinned[Task references are pinned]

--- a/policy/release/test_results/test_results.rego
+++ b/policy/release/test_results/test_results.rego
@@ -1,0 +1,125 @@
+#
+# METADATA
+# title: Test Results Attestation
+# description: >-
+#   Rules that verify the test results attestations associated with the image being verified.
+#
+package test_results
+
+import rego.v1
+
+import data.lib
+import data.lib.json as j
+
+# METADATA
+# title: Test Results Attestation
+# description: >-
+#   Verify that the image has at least one valid test results attestation with a passing result.
+#   By default the same sigstore options used to verify the image are also used to verify the test
+#   results attestations. Any test results attestations signed with a different key, or identity,
+#   will be ignored. Use the `test_result_sigstore_opts` rule_data to configure alternate sigstore
+#   options for the test results attestations.
+# custom:
+#   short_name: valid
+#   failure_msg: "%s"
+#
+deny contains result if {
+	some error in _errors
+	result := object.union(
+		lib.result_helper(rego.metadata.chain(), [error.message]),
+		{"severity": error.severity},
+	)
+}
+
+_errors contains error if {
+	some raw_error in _verification_result.errors
+	error := {
+		"message": sprintf("Attestation verification failed: %s", [raw_error]),
+		"severity": "failure",
+	}
+}
+
+_errors contains error if {
+	count(_test_results) == 0
+	error := {
+		"message": "No test result attestations found",
+		"severity": "failure",
+	}
+}
+
+_errors contains error if {
+	some test_result in _test_results
+	some e in j.validate_schema(test_result, _test_result_predicate_schema)
+	error := {
+		"message": sprintf("Test result has unexpected format: %s", [e.message]),
+		"severity": e.severity,
+	}
+}
+
+_errors contains error if {
+	some test_result in _test_results
+	test_result.result == "FAILED"
+	error := {
+		"message": "Test result is FAILED",
+		"severity": "failure",
+	}
+}
+
+_errors contains error if {
+	some test_result in _test_results
+	test_result.result == "WARNED"
+	error := {
+		"message": "Test result is WARNED",
+		"severity": "warning",
+	}
+}
+
+_verification_result := ec.sigstore.verify_attestation(input.image.ref, _test_result_sigstore_opts)
+
+_test_result_sigstore_opts := opts if {
+	opts := lib.rule_data("test_result_sigstore_opts")
+
+	# Ignore the default rule_data value.
+	opts != []
+} else := lib.sigstore_opts
+
+_test_results contains test_result if {
+	some att in _verification_result.attestations
+	att.statement.predicateType == _test_result_predicate_type
+	test_result := att.statement.predicate
+}
+
+_test_result_predicate_type := "https://in-toto.io/attestation/test-result/v0.1"
+
+_test_result_predicate_schema := {
+	"type": "object",
+	"required": ["result"],
+	"properties": {
+		"result": {
+			"type": "string",
+			"enum": ["PASSED", "WARNED", "FAILED"],
+		},
+		# Configuration is a ResourceDescriptor. See full definition at
+		# https://github.com/in-toto/attestation/blob/main/spec/v1/resource_descriptor.md
+		"configuration": {
+			"type": "array",
+			"items": {"type": "object"},
+		},
+		"url": {
+			"type": "string",
+			"format": "uri",
+		},
+		"passedTests": {
+			"type": "array",
+			"items": {"type": "string"},
+		},
+		"failedTests": {
+			"type": "array",
+			"items": {"type": "string"},
+		},
+		"warnedTests": {
+			"type": "array",
+			"items": {"type": "string"},
+		},
+	},
+}

--- a/policy/release/test_results/test_results_test.rego
+++ b/policy/release/test_results/test_results_test.rego
@@ -1,0 +1,161 @@
+package test_results_test
+
+import rego.v1
+
+import data.lib
+import data.test_results
+
+test_success if {
+	lib.assert_empty(test_results.deny) with input as mock_input
+		with ec.sigstore.verify_attestation as {"attestations": [mock_valid_attestation]}
+}
+
+test_failing_verification if {
+	mock_verification_result := {
+		"errors": ["invalid signature"],
+		"attestations": [],
+	}
+
+	# TODO: Remove duplicated error?
+	expected := {
+		{
+			"code": "test_results.valid",
+			"msg": "Attestation verification failed: invalid signature",
+			"severity": "failure",
+		},
+		{
+			"code": "test_results.valid",
+			"msg": "No test result attestations found",
+			"severity": "failure",
+		},
+	}
+
+	lib.assert_equal_results(expected, test_results.deny) with input as mock_input
+		with ec.sigstore.verify_attestation as mock_verification_result
+}
+
+test_no_test_results if {
+	expected := {{
+		"code": "test_results.valid",
+		"msg": "No test result attestations found",
+		"severity": "failure",
+	}}
+
+	lib.assert_equal_results(expected, test_results.deny) with input as mock_input
+		with ec.sigstore.verify_attestation as {"attestations": []}
+}
+
+test_invalid_schema if {
+	expected := {{
+		"code": "test_results.valid",
+		# regal ignore:line-length
+		"msg": `Test result has unexpected format: result: result must be one of the following: "PASSED", "WARNED", "FAILED"`,
+		"severity": "failure",
+	}}
+
+	lib.assert_equal_results(expected, test_results.deny) with input as mock_input
+		with ec.sigstore.verify_attestation as {"attestations": [mock_invalid_schema_attestation]}
+}
+
+test_failed_result if {
+	expected := {{
+		"code": "test_results.valid",
+		"msg": "Test result is FAILED",
+		"severity": "failure",
+	}}
+
+	lib.assert_equal_results(expected, test_results.deny) with input as mock_input
+		with ec.sigstore.verify_attestation as {"attestations": [mock_failed_attestation]}
+}
+
+test_warning_result if {
+	expected := {{
+		"code": "test_results.valid",
+		"msg": "Test result is WARNED",
+		"severity": "warning",
+	}}
+
+	lib.assert_equal_results(expected, test_results.deny) with input as mock_input
+		with ec.sigstore.verify_attestation as {"attestations": [mock_warned_attestation]}
+}
+
+test_default_sigstore_opts if {
+	expected := {{
+		"code": "test_results.valid",
+		"msg": sprintf("Attestation verification failed: opts: %v", [lib.sigstore_opts]),
+		"severity": "failure",
+	}}
+	lib.assert_equal_results(expected, test_results.deny) with input as mock_input
+		with ec.sigstore.verify_attestation as mock_sigstore_opts
+}
+
+test_custom_sigstore_opts if {
+	expected := {{
+		"code": "test_results.valid",
+		"msg": sprintf("Attestation verification failed: opts: %v", [custom_sigstore_opts]),
+		"severity": "failure",
+	}}
+	lib.assert_equal_results(expected, test_results.deny) with input as mock_input
+		with ec.sigstore.verify_attestation as mock_sigstore_opts
+		with data.rule_data.test_result_sigstore_opts as custom_sigstore_opts
+}
+
+# The mock function always produces an error which includes the opts used. It can be used to verify
+# the expected opts are used. It also produces a valid attestation to avoid duplicated errors.
+mock_sigstore_opts(_, opts) := {
+	"errors": [sprintf("opts: %v", [opts])],
+	"attestations": [mock_valid_attestation],
+}
+
+custom_sigstore_opts := {
+	"certificate_identity": "custom-certificate-identity",
+	"certificate_identity_regexp": "custom-certificate-identity-regexp",
+	"certificate_oidc_issuer": "custom-oidc-issuer",
+	"certificate_oidc_issuer_regexp": "custom-oidc-issuer-regexp",
+	"ignore_rekor": true,
+	"public_key": "custom-public-key",
+	"rekor_url": "custom-rekor-url",
+}
+
+mock_input := {"image": {"ref": "example.com/image:tag"}}
+
+mock_valid_attestation := {"statement": {
+	"predicateType": "https://in-toto.io/attestation/test-result/v0.1",
+	"predicate": {
+		"result": "PASSED",
+		"url": "https://example.com/test-results",
+		"passedTests": ["test1", "test2"],
+		"failedTests": [],
+		"warnedTests": [],
+	},
+}}
+
+mock_failed_attestation := {"statement": {
+	"predicateType": "https://in-toto.io/attestation/test-result/v0.1",
+	"predicate": {
+		"result": "FAILED",
+		"url": "https://example.com/test-results",
+		"passedTests": ["test1"],
+		"failedTests": ["test2"],
+		"warnedTests": [],
+	},
+}}
+
+mock_warned_attestation := {"statement": {
+	"predicateType": "https://in-toto.io/attestation/test-result/v0.1",
+	"predicate": {
+		"result": "WARNED",
+		"url": "https://example.com/test-results",
+		"passedTests": ["test1"],
+		"failedTests": [],
+		"warnedTests": ["test2"],
+	},
+}}
+
+mock_invalid_schema_attestation := {"statement": {
+	"predicateType": "https://in-toto.io/attestation/test-result/v0.1",
+	"predicate": {
+		"result": "UNKNOWN", # Invalid enum value
+		"url": "https://example.com/test-results",
+	},
+}}


### PR DESCRIPTION
Introduce a new package, `test_results` that is used to validate associated attestations with
[test tesults](https://github.com/in-toto/attestation/blob/main/spec/predicates/test-result.md) predicate type.