### PR TITLE
Remove collection metadata from task/results pkg

### DIFF
--- a/acceptance/features/task.feature
+++ b/acceptance/features/task.feature
@@ -16,7 +16,7 @@ Feature: Task Definition
                         ],
                         "config": {
                             "include": [
-                                "@redhat"
+                                "results.*"
                             ]
                         }
                     }

--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -87,7 +87,6 @@ Rules included:
 * xref:release_policy.adoc#sbom_spdx__disallowed_package_external_references[SPDX SBOM: Disallowed package external references]
 * xref:release_policy.adoc#schedule__rule_data_provided[Schedule related checks: Rule data provided]
 * xref:release_policy.adoc#tasks__data_provided[Tasks: Data provided]
-* xref:release_policy.adoc#results__rule_data_provided[Tekton Task result: Rule data provided]
 * xref:release_policy.adoc#test__rule_data_provided[Test: Rule data provided]
 * xref:release_policy.adoc#trusted_task__data_format[Trusted Task checks: Data format]
 
@@ -190,7 +189,6 @@ Rules included:
 * xref:release_policy.adoc#tasks__required_tasks_list_provided[Tasks: Required tasks list was provided]
 * xref:release_policy.adoc#tasks__successful_pipeline_tasks[Tasks: Successful pipeline tasks]
 * xref:release_policy.adoc#tasks__unsupported[Tasks: Task version unsupported]
-* xref:release_policy.adoc#results__rule_data_provided[Tekton Task result: Rule data provided]
 * xref:release_policy.adoc#test__test_all_images[Test: Image digest is present in IMAGES_PROCESSED result]
 * xref:release_policy.adoc#test__no_failed_informative_tests[Test: No informative tests failed]
 * xref:release_policy.adoc#test__no_erred_tests[Test: No tests erred]

--- a/policy/task/results/results.rego
+++ b/policy/task/results/results.rego
@@ -33,9 +33,6 @@ deny contains result if {
 #   short_name: rule_data_provided
 #   failure_msg: '%s'
 #   solution: If provided, ensure the rule data is in the expected format.
-#   collections:
-#   - redhat
-#   - policy_data
 #
 deny contains result if {
 	some e in _rule_data_errors


### PR DESCRIPTION
Discussed in RH internal slack thread here:
https://redhat-internal.slack.com/archives/C031J4KBFME/p1749498678630749

I'm not certain, but I don't think these were added intentionally.

Additionally, the docs rendering, e.g. see
https://conforma.dev/docs/policy/release_policy.html currently doesn't handle collections well if they're not under policy/release.

We should fix that, but in the short term, this will fix a broken we've had for a while.

See also #1408 which revealed this problem, and which goes some way towards fixing it.

Semi-related to...
Ref: https://issues.redhat.com/browse/EC-984