### PR TITLE
Remove inaccessible_snapshot_references due to performance concerns

### DIFF
--- a/antora/docs/modules/ROOT/pages/packages/release_olm.adoc
+++ b/antora/docs/modules/ROOT/pages/packages/release_olm.adoc
@@ -43,7 +43,7 @@ Each image referenced by the OLM bundle should match an entry in the list of pre
 * FAILURE message: `The %q CSV image reference is not from an allowed registry.`
 * Code: `olm.allowed_registries`
 * Effective from: `2024-09-01T00:00:00Z`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L287[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L265[Source, window="_blank"]
 
 [#olm__olm_bundle_multi_arch]
 === link:#olm__olm_bundle_multi_arch[OLM bundle images are not multi-arch]
@@ -56,7 +56,7 @@ OLM bundle images should be built for a single architecture. They should not be 
 * FAILURE message: `The %q bundle image is a multi-arch reference.`
 * Code: `olm.olm_bundle_multi_arch`
 * Effective from: `2025-5-01T00:00:00Z`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L320[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L298[Source, window="_blank"]
 
 [#olm__allowed_registries_related]
 === link:#olm__allowed_registries_related[Related images references are from allowed registries]
@@ -69,7 +69,7 @@ Each image indicated as a related image should match an entry in the list of pre
 * FAILURE message: `The %q related image reference is not from an allowed registry.`
 * Code: `olm.allowed_registries_related`
 * Effective from: `2025-04-15T00:00:00Z`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L217[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L195[Source, window="_blank"]
 
 [#olm__required_olm_features_annotations_provided]
 === link:#olm__required_olm_features_annotations_provided[Required OLM feature annotations list provided]
@@ -94,19 +94,6 @@ Check the value of the operators.openshift.io/valid-subscription annotation from
 * Effective from: `2024-04-18T00:00:00Z`
 * https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L88[Source, window="_blank"]
 
-[#olm__inaccessible_snapshot_references]
-=== link:#olm__inaccessible_snapshot_references[Unable to access images in the input snapshot]
-
-Check the input snapshot and make sure all the images are accessible.
-
-*Solution*: Ensure all images in the input snapshot are valid.
-
-* Rule type: [rule-type-indicator failure]#FAILURE#
-* FAILURE message: `The %q image reference is not accessible in the input snapshot.`
-* Code: `olm.inaccessible_snapshot_references`
-* Effective from: `2024-08-15T00:00:00Z`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L156[Source, window="_blank"]
-
 [#olm__inaccessible_related_images]
 === link:#olm__inaccessible_related_images[Unable to access related images for a component]
 
@@ -118,7 +105,7 @@ Check the input image for the presence of related images. Ensure that all images
 * FAILURE message: `The %q related image reference is not accessible.`
 * Code: `olm.inaccessible_related_images`
 * Effective from: `2025-03-10T00:00:00Z`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L178[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L156[Source, window="_blank"]
 
 [#olm__unmapped_references]
 === link:#olm__unmapped_references[Unmapped images in OLM bundle]
@@ -131,7 +118,7 @@ Check the OLM bundle image for the presence of unmapped image references. Unmapp
 * FAILURE message: `The %q CSV image reference is not in the snapshot or accessible.`
 * Code: `olm.unmapped_references`
 * Effective from: `2024-08-15T00:00:00Z`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L247[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L225[Source, window="_blank"]
 
 [#olm__unpinned_references]
 === link:#olm__unpinned_references[Unpinned images in OLM bundle]

--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -130,7 +130,6 @@ Rules included:
 * xref:packages/release_olm.adoc#olm__allowed_registries_related[OLM: Related images references are from allowed registries]        
 * xref:packages/release_olm.adoc#olm__required_olm_features_annotations_provided[OLM: Required OLM feature annotations list provided]        
 * xref:packages/release_olm.adoc#olm__subscriptions_annotation_format[OLM: Subscription annotation has expected value]        
-* xref:packages/release_olm.adoc#olm__inaccessible_snapshot_references[OLM: Unable to access images in the input snapshot]        
 * xref:packages/release_olm.adoc#olm__inaccessible_related_images[OLM: Unable to access related images for a component]        
 * xref:packages/release_olm.adoc#olm__unmapped_references[OLM: Unmapped images in OLM bundle]        
 * xref:packages/release_olm.adoc#olm__unpinned_references[OLM: Unpinned images in OLM bundle]        

--- a/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
+++ b/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
@@ -63,7 +63,6 @@
 **** xref:packages/release_olm.adoc#olm__allowed_registries_related[Related images references are from allowed registries]
 **** xref:packages/release_olm.adoc#olm__required_olm_features_annotations_provided[Required OLM feature annotations list provided]
 **** xref:packages/release_olm.adoc#olm__subscriptions_annotation_format[Subscription annotation has expected value]
-**** xref:packages/release_olm.adoc#olm__inaccessible_snapshot_references[Unable to access images in the input snapshot]
 **** xref:packages/release_olm.adoc#olm__inaccessible_related_images[Unable to access related images for a component]
 **** xref:packages/release_olm.adoc#olm__unmapped_references[Unmapped images in OLM bundle]
 **** xref:packages/release_olm.adoc#olm__unpinned_references[Unpinned images in OLM bundle]

--- a/policy/release/olm/olm.rego
+++ b/policy/release/olm/olm.rego
@@ -154,28 +154,6 @@ deny contains result if {
 }
 
 # METADATA
-# title: Unable to access images in the input snapshot
-# description: >-
-#   Check the input snapshot and make sure all the images are accessible.
-# custom:
-#   short_name: inaccessible_snapshot_references
-#   failure_msg: The %q image reference is not accessible in the input snapshot.
-#   solution: >-
-#     Ensure all images in the input snapshot are valid.
-#   collections:
-#   - redhat
-#   effective_on: 2024-08-15T00:00:00Z
-#
-deny contains result if {
-	_release_restrictions_apply
-
-	components := input.snapshot.components
-	some component in components
-	not ec.oci.image_manifest(component.containerImage)
-	result := lib.result_helper_with_term(rego.metadata.chain(), [component.containerImage], component.containerImage)
-}
-
-# METADATA
 # title: Unable to access related images for a component
 # description: >-
 #   Check the input image for the presence of related images.

--- a/policy/release/olm/olm_test.rego
+++ b/policy/release/olm/olm_test.rego
@@ -366,19 +366,6 @@ test_unpinned_snapshot_references_different_input if {
 		with input.image.ref as pinned2
 }
 
-test_inaccessible_snapshot_references if {
-	expected := {{
-		"code": "olm.inaccessible_snapshot_references",
-		"msg": "The \"registry.io/repository/image@sha256:cafe\" image reference is not accessible in the input snapshot.",
-		"term": "registry.io/repository/image@sha256:cafe",
-	}}
-
-	lib.assert_equal_results(olm.deny, expected) with input.snapshot.components as [component1]
-		with data.rule_data.pipeline_intention as "release"
-		with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.io"]
-		with ec.oci.image_manifest as false
-}
-
 test_unmapped_references_in_operator if {
 	expected := {{
 		"code": "olm.unmapped_references",


### PR DESCRIPTION
Removing this rule due to performance concerns. It checks each snapshot component for each component, resulting in O(N²) behavior.

Some comments on it
https://issues.redhat.com/browse/EC-1281