### PR TITLE
Ignore tag on pre-build sbom ref comparison

### DIFF
--- a/policy/release/pre_build_script_task/pre_build_script_task.rego
+++ b/policy/release/pre_build_script_task/pre_build_script_task.rego
@@ -130,10 +130,11 @@ _script_runner_image_refs := [image_ref |
 
 _pre_build_run_script_runner_image_result := "SCRIPT_RUNNER_IMAGE_REFERENCE"
 
-_is_image_in_sbom(image) if {
+_is_image_in_sbom(image_ref) if {
 	some s in sbom.all_sboms
 	some purl in _purls_from_sbom(s)
-	sbom.image_ref_from_purl(purl) == image
+	image_ref_from_purl := sbom.image_ref_from_purl(purl)
+	image.equal_ref(image_ref_from_purl, image_ref)
 }
 
 _purls_from_sbom(s) := purls if {

--- a/policy/release/pre_build_script_task/pre_build_script_task_test.rego
+++ b/policy/release/pre_build_script_task/pre_build_script_task_test.rego
@@ -55,6 +55,30 @@ test_pre_build_image_in_sbom if {
 		with data.rule_data.allowed_registry_prefixes as _allowed_registries
 }
 
+test_pre_build_image_in_sbom_ignoring_tag if {
+	# Add a tag into the image refs as well as the digest, "some-tag" and "latest".
+	good_attestation_with_tag_in_image_ref := json.patch(_good_attestation, [
+		{
+			"op": "replace",
+			"path": "/statement/predicate/buildConfig/tasks/0/results/0/value",
+			"value": "registry.redhat.io/ubi7:some-tag@sha256:bcd",
+		},
+		{
+			"op": "replace",
+			"path": "/statement/predicate/buildConfig/tasks/1/results/0/value",
+			"value": "quay.io/konflux-ci/bazel6-ubi9:latest@sha256:def",
+		},
+	])
+
+	# regal ignore:line-length
+	lib.assert_empty(pre_build_script_task.deny) with input.attestations as [good_attestation_with_tag_in_image_ref, _cyclonedx_sbom_attestation]
+		with data.rule_data.allowed_registry_prefixes as _allowed_registries
+
+	# regal ignore:line-length
+	lib.assert_empty(pre_build_script_task.deny) with input.attestations as [good_attestation_with_tag_in_image_ref, _spdx_sbom_attestation]
+		with data.rule_data.allowed_registry_prefixes as _allowed_registries
+}
+
 test_pre_build_image_not_in_sbom if {
 	expected := {{
 		"code": "pre_build_script_task.pre_build_script_task_runner_image_in_sbom",


### PR DESCRIPTION
We're expecting the value of SCRIPT_RUNNER_IMAGE_REFERENCE to be an image ref, the policy check is to make sure that image ref appears in the SBOM. It was doing a direct string comparison, and because the sbom purl doesn't include the tag, the comparison was failing.

For example, "quay.io/foo/bar:latest@sha256:abc" compared to "quay.io/foo/bar@sha256:abc" in the SBOM.

After this change, those will be considered equal, and the pre_build_script_task.pre_build_script_task_runner_image_in_sbom violation will not be produced.

Note: It would be reasonable to not do this and suggest that the tag should be removed from the image ref before it gets added to the SCRIPT_RUNNER_IMAGE_REFERENCE, but I figured let's adhere to the princple of least surprise and make Conforma handle it the way someone might expect it to.

See also: https://issues.redhat.com/browse/EC-1242

Ref: https://issues.redhat.com/browse/KFLUXSPRT-3853