### PR TITLE
feat(ci): support pushing bundles to multiple organizations

### DIFF
--- a/.github/workflows/push-bundles.yaml
+++ b/.github/workflows/push-bundles.yaml
@@ -54,16 +54,14 @@ jobs:
         go-version-file: go.mod
         cache: true
 
-    - name: Docker login (quay.io/enterprise-contract)
-      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-      with:
-        # See also BUNDLE_REPO defined in Makefile
-        registry: quay.io
-        username: ${{ secrets.BUNDLE_PUSH_USER_EC }}
-        password: ${{ secrets.BUNDLE_PUSH_PASS_EC }}
-
-    - name: Push bundles (quay.io/enterprise-contract)
+    - name: Push bundles
       env:
         EC_AUTOMATION_KEY: ${{ secrets.EC_AUTOMATION_KEY }}
         APP_INSTALL_ID: 32872589
-      run: hack/update-bundles.sh
+        # Enterprise Contract credentials
+        EC_REGISTRY_USER: ${{ secrets.BUNDLE_PUSH_USER_EC }}
+        EC_REGISTRY_PASS: ${{ secrets.BUNDLE_PUSH_PASS_EC }}
+        # Conforma credentials  
+        CONFORMA_REGISTRY_USER: ${{ secrets.BUNDLE_PUSH_USER_CONFORMA }}
+        CONFORMA_REGISTRY_PASS: ${{ secrets.BUNDLE_PUSH_PASS_CONFORMA }}
+      run: hack/update-bundles.sh "quay.io/enterprise-contract/" "quay.io/conforma/"

--- a/hack/update-bundles.sh
+++ b/hack/update-bundles.sh
@@ -18,11 +18,32 @@
 # Pushes policy bundles to quay.io, but only if anything changed since
 # the last bundle was pushed.
 #
+# Usage: ./update-bundles.sh [repo-prefix1] [repo-prefix2] ...
+# Example: ./update-bundles.sh "quay.io/enterprise-contract/" "quay.io/conforma/"
+#
+# If no arguments provided, uses REPO_PREFIXES environment variable
+# If no arguments and no REPO_PREFIXES environment variable, defaults to "quay.io/conforma/"
+# Secrets must be provided via environment variables for security
+#
 set -o errexit
 set -o pipefail
 set -o nounset
 
-REPO_PREFIX="${REPO_PREFIX-quay.io/enterprise-contract/}"
+# Get repository prefixes from arguments or environment variable
+if [[ $# -gt 0 ]]; then
+  REPO_PREFIXES="$*"
+  echo "Using repository prefixes from arguments: $REPO_PREFIXES"
+else
+  REPO_PREFIXES="${REPO_PREFIXES-quay.io/conforma/}"
+  echo "Using repository prefixes from environment: $REPO_PREFIXES"
+fi
+
+# Validate repository prefixes
+for prefix in $REPO_PREFIXES; do
+  if [[ "$prefix" != *"enterprise-contract"* && "$prefix" != *"conforma"* ]]; then
+    echo "WARNING: Unknown repository prefix: $prefix" >&2
+  fi
+done
 ROOT_DIR=$( git rev-parse --show-toplevel )
 BUNDLES="release pipeline task build_task"
 OPA="go run github.com/conforma/cli opa"
@@ -31,6 +52,21 @@ ORAS="go run oras.land/oras/cmd/oras"
 DRY_RUN=${DRY_RUN:-""}
 DRY_RUN_ECHO=""
 [ "$DRY_RUN" == "1" ] && DRY_RUN_ECHO="echo #"
+
+# Check required environment variables for multi-org setup
+if [[ "$REPO_PREFIXES" == *"enterprise-contract"* ]]; then
+  if [[ -z "${EC_REGISTRY_USER:-}" || -z "${EC_REGISTRY_PASS:-}" ]]; then
+    echo "ERROR: EC_REGISTRY_USER and EC_REGISTRY_PASS must be set for enterprise-contract repositories" >&2
+    exit 1
+  fi
+fi
+
+if [[ "$REPO_PREFIXES" == *"conforma"* ]]; then
+  if [[ -z "${CONFORMA_REGISTRY_USER:-}" || -z "${CONFORMA_REGISTRY_PASS:-}" ]]; then
+    echo "ERROR: CONFORMA_REGISTRY_USER and CONFORMA_REGISTRY_PASS must be set for conforma repositories" >&2
+    exit 1
+  fi
+fi
 
 function bundle_src_dirs() {
   echo policy/lib
@@ -55,36 +91,61 @@ function cleanup() {
 }
 trap cleanup EXIT
 
+function ec_registry_login() {
+  echo "$EC_REGISTRY_PASS" | docker login quay.io --username "$EC_REGISTRY_USER" --password-stdin
+}
+
+function conforma_registry_login() {
+  echo "$CONFORMA_REGISTRY_PASS" | docker login quay.io --username "$CONFORMA_REGISTRY_USER" --password-stdin
+}
 
 for b in $BUNDLES; do
   # Find the git sha where the source files were last updated
   mapfile -t src_dirs < <(bundle_src_dirs "$b")
   last_update_sha=$(git log -n 1 --pretty=format:%h -- "${src_dirs[@]}")
 
-  # Check if the bundle for that git sha exists already
   repo=$(repo_name "$b")
   tag=git-$last_update_sha
-  push_repo="${REPO_PREFIX}$repo"
 
-  skopeo_args=()
-  skopeo_cp_args=()
-  if [[ $push_repo == *'localhost:'* ]]; then
-    skopeo_args+=(--tls-verify=false)
-    skopeo_cp_args+=(--dest-tls-verify=false --src-tls-verify=false)
-  fi
+  # Check all repositories to see if any need the bundle
+  repos_needing_push=()
+  all_repos_have_bundle=true
 
-  tag_found="$(
-    {
-      skopeo list-tags "${skopeo_args[@]}" "docker://${push_repo}" |
-      jq --arg tag "${tag}" -r 'any(.Tags[]; . == $tag)';
-    } || echo false
-  )"
-  if [[ "$tag_found" == 'true' ]]; then
-    # No push needed
-    echo "Policy bundle $push_repo:$tag exists already, no push needed"
+  for repo_prefix in $REPO_PREFIXES; do
+    push_repo="${repo_prefix}$repo"
+    
+    # Login with correct credentials for tag checking
+    if [[ "$push_repo" == *"enterprise-contract"* ]]; then
+      ec_registry_login
+    elif [[ "$push_repo" == *"conforma"* ]]; then
+      conforma_registry_login
+    fi
+    
+    skopeo_args=()
+    if [[ $push_repo == *'localhost:'* ]]; then
+      skopeo_args+=(--tls-verify=false)
+    fi
+
+    tag_found="$(
+      {
+        skopeo list-tags "${skopeo_args[@]}" "docker://${push_repo}" |
+        jq --arg tag "${tag}" -r 'any(.Tags[]; . == $tag)';
+      } || echo false
+    )"
+    
+    if [[ "$tag_found" == 'true' ]]; then
+      echo "Policy bundle $push_repo:$tag exists already"
+    else
+      echo "Policy bundle $push_repo:$tag needs to be pushed"
+      repos_needing_push+=("$push_repo")
+      all_repos_have_bundle=false
+    fi
+  done
+
+  if [[ "$all_repos_have_bundle" == 'true' ]]; then
+    echo "All repositories have bundle $repo:$tag, no push needed"
   else
-    # Push needed
-    echo "Pushing policy bundle $push_repo:$tag now"
+    echo "Building and pushing policy bundle $repo:$tag to ${#repos_needing_push[@]} repositories"
 
     # Prepare a temp dir with the bundle's content
     tmp_dir=$(mktemp -d -t "ec-bundle-$b.XXXXXXXXXX")
@@ -111,12 +172,27 @@ for b in $BUNDLES; do
     # Verify the selected sources can be compiled as one unit, e.g. "policy/lib" is included
     ${OPA} build "${src_dirs[@]}" --output /dev/null
 
-    # Now push
-    ${ORAS} push "$push_repo:$tag" "${src_dirs[@]}" \
-      --annotation "org.opencontainers.image.revision=${last_update_sha}"
+    # Push to all repositories that need it
+    for push_repo in "${repos_needing_push[@]}"; do
+      echo "Pushing to $push_repo:$tag"
+      
+      # Login with the correct credentials for this repository
+      if [[ "$push_repo" == *"enterprise-contract"* ]]; then
+        ec_registry_login
+      elif [[ "$push_repo" == *"conforma"* ]]; then
+        conforma_registry_login
+      fi
+      
+      ${ORAS} push "$push_repo:$tag" "${src_dirs[@]}" \
+        --annotation "org.opencontainers.image.revision=${last_update_sha}"
 
-    # Set the 'latest' tag
-    $DRY_RUN_ECHO skopeo copy --quiet "docker://$push_repo:$tag" "docker://$push_repo:latest" "${skopeo_cp_args[@]}"
+      # Set the 'latest' tag
+      skopeo_cp_args=()
+      if [[ $push_repo == *'localhost:'* ]]; then
+        skopeo_cp_args+=(--dest-tls-verify=false --src-tls-verify=false)
+      fi
+      $DRY_RUN_ECHO skopeo copy --quiet "docker://$push_repo:$tag" "docker://$push_repo:latest" "${skopeo_cp_args[@]}"
+    done
 
     cd "${ROOT_DIR}"
   fi


### PR DESCRIPTION
Update GitHub workflow and bundle push script to support pushing the same bundles to both enterprise-contract and conforma organizations. This enables a smooth transition between organizations while ensuring identical bundle content across both.

Changes:
- Modify workflow to pass repository prefixes as script arguments
- Update script to accept multiple repository prefixes via arguments
- Add support for organization-specific credentials
- Change default organization from enterprise-contract to conforma

Assisted-by: ChatGPT
Ref: EC-1184, EC-1185, EC-1187, EC-1189