### PR TITLE
Exclude test rego from bundles

### DIFF
--- a/hack/update-bundles.sh
+++ b/hack/update-bundles.sh
@@ -79,6 +79,7 @@ function bundle_subdir() {
 
 function exclusions() {
   echo "artifacthub-pkg.yml"
+  echo "*_test.rego"
 }
 
 function repo_name() {


### PR DESCRIPTION
Benefits:
* Smaller bundles will be faster to download.
* Less work for the evaluator since it won't have to parse and compile all these files.
* Less work for the cli since it won't have to opa inspect all these test files when looking for `deny` and `warn` metadata.

Ref: https://issues.redhat.com/browse/EC-1350