### PR TITLE
Make quay_expiration.expires_label rule stricter

### DIFF
--- a/antora/docs/modules/ROOT/pages/packages/release_quay_expiration.adoc
+++ b/antora/docs/modules/ROOT/pages/packages/release_quay_expiration.adoc
@@ -16,6 +16,6 @@ Check the image metadata for the presence of a "quay.expires-after" label. If it
 *Solution*: Make sure the image is built without setting the "quay.expires-after" label. This label is usually set if the container image was built by an "on-pr" pipeline during pre-merge CI.
 
 * Rule type: [rule-type-indicator failure]#FAILURE#
-* FAILURE message: `The image has a 'quay.expires-after' label set to '%s'`
+* FAILURE message: `The label 'quay.expires-after' is not allowed in the released image`
 * Code: `quay_expiration.expires_label`
 * https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/quay_expiration/quay_expiration.rego#L16[Source, window="_blank"]

--- a/policy/release/quay_expiration/quay_expiration.rego
+++ b/policy/release/quay_expiration/quay_expiration.rego
@@ -26,7 +26,7 @@ import data.lib
 #   - release
 #   - production
 #   - staging
-#   failure_msg: The image has a 'quay.expires-after' label set to '%s'
+#   failure_msg: The label 'quay.expires-after' is not allowed in the released image
 #   solution: >-
 #     Make sure the image is built without setting the "quay.expires-after" label. This
 #     label is usually set if the container image was built by an "on-pr" pipeline
@@ -43,11 +43,6 @@ deny contains result if {
 	# The quay.expires-after label is present
 	label_name == "quay.expires-after"
 
-	# This is an edge case that may never happen, but let's assume that if
-	# the value is an empty string then it is not an expiration and therefore
-	# can be permitted
-	count(label_value) > 0
-
 	# Send up the violation the details
-	result := lib.result_helper(rego.metadata.chain(), [label_value])
+	result := lib.result_helper(rego.metadata.chain(), [])
 }

--- a/policy/release/quay_expiration/quay_expiration_test.rego
+++ b/policy/release/quay_expiration/quay_expiration_test.rego
@@ -20,13 +20,14 @@ test_release_pipeline if {
 	lib.assert_empty(quay_expiration.deny) with input.image as _image_expires_none
 		with data.rule_data as _rule_data_for_release
 
-	lib.assert_empty(quay_expiration.deny) with input.image as _image_expires_blank
-		with data.rule_data as _rule_data_for_release
-
 	expected := {{
 		"code": "quay_expiration.expires_label",
-		"msg": "The image has a 'quay.expires-after' label set to '5d'",
+		"msg": "The label 'quay.expires-after' is not allowed in the released image",
 	}}
+
+	lib.assert_equal_results(expected, quay_expiration.deny) with input.image as _image_expires_blank
+		with data.rule_data as _rule_data_for_release
+
 	lib.assert_equal_results(expected, quay_expiration.deny) with input.image as _image_expires_5d
 		with data.rule_data as _rule_data_for_release
 }


### PR DESCRIPTION
This change completely removes the possibility of having the 'quay.expires-after' label in the released image, since it might cause unexpected behaviors when an image is pushed to a repository.

It also makes the error message clearer.

Ref: https://issues.redhat.com/browse/KONFLUX-9448