### PR TITLE
Make 'inaccessible_parent_*' rules logic clearer

### DIFF
--- a/antora/docs/modules/ROOT/pages/packages/release_labels.adoc
+++ b/antora/docs/modules/ROOT/pages/packages/release_labels.adoc
@@ -66,7 +66,7 @@ The parent image config is not accessible.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Image config of the image %q, parent of image %q is inaccessible`
 * Code: `labels.inaccessible_parent_config`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/labels/labels.rego#L199[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/labels/labels.rego#L200[Source, window="_blank"]
 
 [#labels__inaccessible_parent_manifest]
 === link:#labels__inaccessible_parent_manifest[Inaccessible parent image manifest]

--- a/policy/release/labels/labels_test.rego
+++ b/policy/release/labels/labels_test.rego
@@ -403,7 +403,7 @@ test_parent_image_manifest_inaccessible if {
 	ref := _test_ref_patches(array.concat(
 		_add_annotations({
 			"org.opencontainers.image.base.name": "fail",
-			"org.opencontainers.image.base.digest": "",
+			"org.opencontainers.image.base.digest": "fake_digest",
 		}),
 		[_config(_add_labels({
 			"name": "test-image",
@@ -415,7 +415,7 @@ test_parent_image_manifest_inaccessible if {
 
 	expected := {{
 		"code": "labels.inaccessible_parent_manifest",
-		"msg": sprintf(`Manifest of the image "fail@", parent of image %q is inaccessible`, [ref]),
+		"msg": sprintf(`Manifest of the image "fail@fake_digest", parent of image %q is inaccessible`, [ref]),
 	}}
 
 	lib.assert_equal_results(labels.deny, expected) with input.image.ref as ref


### PR DESCRIPTION
This commit adds the helper function 'labels._has_parent', that checks
if a parent image is specified in the base image annotations.

This helper function is used to make the
'labels.inaccessible_parent_manifest' and
'labels.inaccessible_parent_config' clearer: these rules will only be
evaluated if a parent is actually specified, otherwise they will be
skipped.

This prevents a bug that called builtin oci functions with invalid
parameters (that caused an obscure error, like the one in the linked
support ticket).

Note: we considered adding a rule that checks that the parent image
annotations are always specified in the base image, but it turns out
this is not always the case: bundle image manifests are usually built
'FROM scratch', meaning that they will have empty parent annotations.
Also common image manifests might have the same 'FROM scratch' build.

Ref: https://issues.redhat.com/browse/EC-1402
Ref: https://issues.redhat.com/browse/KFLUXSPRT-4327