### PR TITLE
Remove pipeline_intention logic from rego rules

### DIFF
--- a/antora/docs/modules/ROOT/pages/packages/release_olm.adoc
+++ b/antora/docs/modules/ROOT/pages/packages/release_olm.adoc
@@ -43,7 +43,7 @@ Each image referenced by the OLM bundle should match an entry in the list of pre
 * FAILURE message: `The %q CSV image reference is not from an allowed registry.`
 * Code: `olm.allowed_registries`
 * Effective from: `2024-09-01T00:00:00Z`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L304[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L296[Source, window="_blank"]
 
 [#olm__olm_bundle_multi_arch]
 === link:#olm__olm_bundle_multi_arch[OLM bundle images are not multi-arch]
@@ -56,7 +56,7 @@ OLM bundle images should be built for a single architecture. They should not be 
 * FAILURE message: `The %q bundle image is a multi-arch reference.`
 * Code: `olm.olm_bundle_multi_arch`
 * Effective from: `2025-5-01T00:00:00Z`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L337[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L329[Source, window="_blank"]
 
 [#olm__allowed_registries_related]
 === link:#olm__allowed_registries_related[Related images references are from allowed registries]
@@ -69,7 +69,7 @@ Each image indicated as a related image should match an entry in the list of pre
 * FAILURE message: `The %q related image reference is not from an allowed registry.`
 * Code: `olm.allowed_registries_related`
 * Effective from: `2025-04-15T00:00:00Z`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L230[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L224[Source, window="_blank"]
 
 [#olm__required_olm_features_annotations_provided]
 === link:#olm__required_olm_features_annotations_provided[Required OLM feature annotations list provided]
@@ -105,7 +105,7 @@ Check the input image for the presence of related images. Ensure that all images
 * FAILURE message: `The %q related image reference is not accessible.`
 * Code: `olm.inaccessible_related_images`
 * Effective from: `2025-03-10T00:00:00Z`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L196[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L192[Source, window="_blank"]
 
 [#olm__unmapped_references]
 === link:#olm__unmapped_references[Unmapped images in OLM bundle]
@@ -118,7 +118,7 @@ Check the OLM bundle image for the presence of unmapped image references. Unmapp
 * FAILURE message: `The %q CSV image reference is not in the snapshot or accessible.`
 * Code: `olm.unmapped_references`
 * Effective from: `2024-08-15T00:00:00Z`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L260[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L254[Source, window="_blank"]
 
 [#olm__unpinned_references]
 === link:#olm__unpinned_references[Unpinned images in OLM bundle]
@@ -155,4 +155,4 @@ Check the input image for the presence of related images. Ensure all related ima
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%d related images are not pinned with a digest: %s.`
 * Code: `olm.unpinned_related_images`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L160[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L158[Source, window="_blank"]

--- a/antora/docs/modules/ROOT/pages/packages/release_quay_expiration.adoc
+++ b/antora/docs/modules/ROOT/pages/packages/release_quay_expiration.adoc
@@ -11,11 +11,11 @@ Policies to prevent releasing an image to quay that has a quay expiration date. 
 [#quay_expiration__expires_label]
 === link:#quay_expiration__expires_label[Expires label]
 
-Check the image metadata for the presence of a "quay.expires-after" label. If it's present then produce a violation. This check is enforced only for a "release", "production", or "staging" pipeline, as determined by the value of the `pipeline_intention` rule data.
+Check the image metadata for the presence of a "quay.expires-after" label. If it's present then produce a violation.
 
 *Solution*: Make sure the image is built without setting the "quay.expires-after" label. This label is usually set if the container image was built by an "on-pr" pipeline during pre-merge CI.
 
 * Rule type: [rule-type-indicator failure]#FAILURE#
-* FAILURE message: `The label 'quay.expires-after' is not allowed in the released image`
+* FAILURE message: `The label 'quay.expires-after' is not allowed`
 * Code: `quay_expiration.expires_label`
 * https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/quay_expiration/quay_expiration.rego#L16[Source, window="_blank"]

--- a/antora/docs/modules/ROOT/pages/packages/release_schedule.adoc
+++ b/antora/docs/modules/ROOT/pages/packages/release_schedule.adoc
@@ -11,14 +11,14 @@ Rules that verify the current date conform to a given schedule.
 [#schedule__date_restriction]
 === link:#schedule__date_restriction[Date Restriction]
 
-Check if the current date is not allowed based on the rule data value from the key `disallowed_dates`. By default, the list is empty in which case *any* day is allowed. This check is enforced only for a "release" or "production" pipeline, as determined by the value of the `pipeline_intention` rule data.
+Check if the current date is not allowed based on the rule data value from the key `disallowed_dates`. By default, the list is empty in which case *any* day is allowed.
 
 *Solution*: Try again on a different day.
 
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s is a disallowed date: %s`
 * Code: `schedule.date_restriction`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/schedule/schedule.rego#L41[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/schedule/schedule.rego#L39[Source, window="_blank"]
 
 [#schedule__rule_data_provided]
 === link:#schedule__rule_data_provided[Rule data provided]
@@ -30,12 +30,12 @@ Confirm the expected rule data keys have been provided in the expected format. T
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `schedule.rule_data_provided`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/schedule/schedule.rego#L68[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/schedule/schedule.rego#L63[Source, window="_blank"]
 
 [#schedule__weekday_restriction]
 === link:#schedule__weekday_restriction[Weekday Restriction]
 
-Check if the current weekday is allowed based on the rule data value from the key `disallowed_weekdays`. By default, the list is empty in which case *any* weekday is allowed. This check is enforced only for a "release" or "production" pipeline, as determined by the value of the `pipeline_intention` rule data.
+Check if the current weekday is allowed based on the rule data value from the key `disallowed_weekdays`. By default, the list is empty in which case *any* weekday is allowed.
 
 *Solution*: Try again on a different weekday.
 

--- a/policy/lib/metadata_helper.rego
+++ b/policy/lib/metadata_helper.rego
@@ -10,10 +10,6 @@ import data.lib.time as time_lib
 # custom.short_name must be present.
 _rule_annotations(chain) := chain[0].annotations
 
-pipeline_intention_match(chain) if {
-	rule_data("pipeline_intention") in _rule_annotations(chain).custom.pipeline_intention
-} else := false
-
 result_helper(chain, failure_sprintf_params) := result if {
 	with_collections := {"collections": _rule_annotations(chain).custom.collections}
 	result := object.union(_basic_result(chain, failure_sprintf_params), with_collections)

--- a/policy/lib/metadata_helper_test.rego
+++ b/policy/lib/metadata_helper_test.rego
@@ -8,7 +8,6 @@ test_rule_annotations_with_annotations if {
 	rule_annotations := {"custom": {
 		"short_name": "TestRule",
 		"failure_msg": "Test failure message",
-		"pipeline_intention": ["build", "test"],
 	}}
 
 	chain := [
@@ -49,100 +48,6 @@ test_rule_annotations_single_entry_chain if {
 	chain := [{"annotations": rule_annotations, "path": ["data", "single", "deny"]}]
 
 	lib.assert_equal(rule_annotations, lib._rule_annotations(chain))
-}
-
-test_pipeline_intention_match_with_matching_intention if {
-	rule_annotations := {"custom": {
-		"short_name": "TestRule",
-		"pipeline_intention": ["build", "release", "test"],
-	}}
-
-	chain := [{"annotations": rule_annotations, "path": ["data", "test", "deny"]}]
-
-	# When rule_data("pipeline_intention") matches one of the pipeline_intention values
-	lib.assert_equal(true, lib.pipeline_intention_match(chain)) with data.rule_data.pipeline_intention as "release"
-}
-
-test_pipeline_intention_match_with_non_matching_intention if {
-	rule_annotations := {"custom": {
-		"short_name": "TestRule",
-		"pipeline_intention": ["build", "test"],
-	}}
-
-	chain := [{"annotations": rule_annotations, "path": ["data", "test", "deny"]}]
-
-	# When rule_data("pipeline_intention") doesn't match any of the pipeline_intention values
-	lib.assert_equal(false, lib.pipeline_intention_match(chain)) with data.rule_data.pipeline_intention as "release"
-}
-
-test_pipeline_intention_match_with_empty_pipeline_intention if {
-	rule_annotations := {"custom": {
-		"short_name": "TestRule",
-		"pipeline_intention": [],
-	}}
-
-	chain := [{"annotations": rule_annotations, "path": ["data", "test", "deny"]}]
-
-	# When pipeline_intention is an empty list, should return false
-	lib.assert_equal(false, lib.pipeline_intention_match(chain)) with data.rule_data.pipeline_intention as "release"
-}
-
-test_pipeline_intention_match_without_pipeline_intention_field if {
-	rule_annotations := {"custom": {
-		"short_name": "TestRule",
-		"failure_msg": "Some failure message",
-	}}
-
-	chain := [{"annotations": rule_annotations, "path": ["data", "test", "deny"]}]
-
-	# When pipeline_intention field is missing, should return false
-	lib.assert_equal(false, lib.pipeline_intention_match(chain)) with data.rule_data.pipeline_intention as "release"
-}
-
-test_pipeline_intention_match_without_custom_field if {
-	rule_annotations := {"other": {"some_field": "value"}}
-
-	chain := [{"annotations": rule_annotations, "path": ["data", "test", "deny"]}]
-
-	# When custom field is missing, should return false
-	lib.assert_equal(false, lib.pipeline_intention_match(chain)) with data.rule_data.pipeline_intention as "release"
-}
-
-test_pipeline_intention_match_with_null_rule_data if {
-	rule_annotations := {"custom": {
-		"short_name": "TestRule",
-		"pipeline_intention": ["build", "release", "test"],
-	}}
-
-	chain := [{"annotations": rule_annotations, "path": ["data", "test", "deny"]}]
-
-	# When rule_data("pipeline_intention") is null, should return false
-	lib.assert_equal(false, lib.pipeline_intention_match(chain)) with data.rule_data.pipeline_intention as null
-}
-
-test_pipeline_intention_match_with_multiple_matching_intentions if {
-	rule_annotations := {"custom": {
-		"short_name": "TestRule",
-		"pipeline_intention": ["build", "release", "production", "test"],
-	}}
-
-	chain := [{"annotations": rule_annotations, "path": ["data", "test", "deny"]}]
-
-	# When rule_data("pipeline_intention") matches one of multiple pipeline_intention values
-	lib.assert_equal(true, lib.pipeline_intention_match(chain)) with data.rule_data.pipeline_intention as "production"
-}
-
-test_pipeline_intention_match_case_sensitivity if {
-	rule_annotations := {"custom": {
-		"short_name": "TestRule",
-		"pipeline_intention": ["Build", "Release"],
-	}}
-
-	chain := [{"annotations": rule_annotations, "path": ["data", "test", "deny"]}]
-
-	# Case sensitivity should be preserved
-	lib.assert_equal(false, lib.pipeline_intention_match(chain)) with data.rule_data.pipeline_intention as "release"
-	lib.assert_equal(true, lib.pipeline_intention_match(chain)) with data.rule_data.pipeline_intention as "Release"
 }
 
 test_result_helper if {

--- a/policy/lib/rule_data.rego
+++ b/policy/lib/rule_data.rego
@@ -95,11 +95,6 @@ rule_data_defaults := {
 		"buildah",
 		"run-script-oci-ta",
 	],
-	# This will be set to "release" in Konflux release pipelines defined at
-	# https://github.com/konflux-ci/release-service-catalog/tree/development/pipelines
-	# Some checks are influenced by this value. Let's use null as a default instead
-	# of the usual empty list.
-	"pipeline_intention": null,
 	# The big list of trusted_tasks (from the acceptable tasks bundle) is at
 	# data.trusted_tasks but we want to allow people to add their own trusted_tasks
 	# using the ruleData key. Make this default to an empty dict so we can conveniently

--- a/policy/release/olm/olm.rego
+++ b/policy/release/olm/olm.rego
@@ -145,8 +145,6 @@ deny contains result if {
 #   effective_on: 2024-08-15T00:00:00Z
 #
 deny contains result if {
-	lib.pipeline_intention_match(rego.metadata.chain())
-
 	input_image = image.parse(input.image.ref)
 	components := input.snapshot.components
 	some component in components
@@ -176,8 +174,6 @@ deny contains result if {
 #   - redhat
 #
 deny contains result if {
-	lib.pipeline_intention_match(rego.metadata.chain())
-
 	unpinned_related_images := [related |
 		some related in _related_images_not_in_snapshot
 
@@ -214,8 +210,6 @@ deny contains result if {
 #   effective_on: 2025-03-10T00:00:00Z
 #
 deny contains result if {
-	lib.pipeline_intention_match(rego.metadata.chain())
-
 	some unmatched_image in _related_images_not_in_snapshot
 	unmatched_ref := _image_ref(unmatched_image)
 
@@ -279,8 +273,6 @@ deny contains result if {
 #   - redhat
 #   effective_on: 2024-08-15T00:00:00Z
 deny contains result if {
-	lib.pipeline_intention_match(rego.metadata.chain())
-
 	snapshot_components := input.snapshot.components
 	component_images_digests := [component_image.digest |
 		some component in snapshot_components

--- a/policy/release/olm/olm_test.rego
+++ b/policy/release/olm/olm_test.rego
@@ -349,7 +349,6 @@ test_unpinned_snapshot_references_operator if {
 		"term": "registry.io/repo/msd:no_digest",
 	}}
 	lib.assert_equal_results(olm.deny, expected) with input.snapshot.components as [unpinned_component, component1]
-		with data.rule_data.pipeline_intention as "release"
 		with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.io"]
 		with ec.oci.image_manifest as `{"config": {"digest": "sha256:goat"}}`
 		with input.image.ref as unpinned_component.containerImage
@@ -357,7 +356,6 @@ test_unpinned_snapshot_references_operator if {
 
 test_unpinned_snapshot_references_different_input if {
 	lib.assert_empty(olm.deny) with input.snapshot.components as [unpinned_component]
-		with data.rule_data.pipeline_intention as "release"
 		with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.io"]
 		with ec.oci.image_manifest as `{"config": {"digest": "sha256:goat"}}`
 		with input.image.ref as pinned2
@@ -372,7 +370,7 @@ test_unmapped_references_in_operator if {
 
 	lib.assert_equal_results(olm.deny, expected) with input.snapshot.components as [component1]
 		with input.image.files as {"manifests/csv.yaml": manifest}
-		with data.rule_data as {"pipeline_intention": "release", "allowed_olm_image_registry_prefixes": ["registry.io"]}
+		with data.rule_data as {"allowed_olm_image_registry_prefixes": ["registry.io"]}
 		with ec.oci.image_manifest as _mock_image_partial
 		with ec.oci.descriptor as mock_ec_oci_image_descriptor
 		with input.image.config.Labels as {olm.manifestv1: "manifests/"}
@@ -384,8 +382,7 @@ test_unpinned_related_images if {
 		"msg": "2 related images are not pinned with a digest: registry.io/repo/msd:latest, registry.io/repo/msd:latest.",
 	}}
 
-	lib.assert_equal_results(olm.deny, expected_deny) with data.rule_data.pipeline_intention as "release"
-		with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.io"]
+	lib.assert_equal_results(olm.deny, expected_deny) with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.io"] # regal ignore:line-length
 		with input.snapshot.components as [component0]
 		with input.attestations as _with_related_images
 		with input.image.ref as "registry.io/repository/image@sha256:image_digest"
@@ -401,8 +398,7 @@ test_inaccessible_related_images if {
 		"term": "registry.io/repository/image2@sha256:tea",
 	}}
 
-	lib.assert_equal_results(olm.deny, expected_deny) with data.rule_data.pipeline_intention as "release"
-		with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.io"]
+	lib.assert_equal_results(olm.deny, expected_deny) with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.io"] # regal ignore:line-length
 		with input.snapshot.components as [component1]
 		with input.attestations as _with_related_images
 		with input.image.ref as "registry.io/repository/image@sha256:image_digest"
@@ -419,12 +415,6 @@ mock_ec_oci_image_descriptor("registry.io/repository/image2@sha256:tea") := fals
 
 mock_ec_oci_image_descriptor("registry.io/repo/msd:latest") := `{"config": {"digest": ""}}`
 
-test_olm_ci_pipeline if {
-	# Make sure no violations are thrown if it isn't a release pipeline
-	# regal ignore:line-length
-	lib.assert_equal(false, lib.pipeline_intention_match(rego.metadata.chain())) with data.rule_data as {"pipeline_intention": null}
-}
-
 test_mock_cafe_descriptor if {
 	# Test case that uses the mock_ec_oci_image_descriptor for cafe image
 	expected := `{"config": {"digest": "sha256:cafe"}}`
@@ -440,8 +430,7 @@ test_unmapped_references_none_found if {
 
 test_allowed_registries if {
 	# This should pass since registry.io is a member of allowed_olm_image_registry_prefixes
-	lib.assert_empty(olm.deny) with data.rule_data.pipeline_intention as "release"
-		with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.io", "registry.redhat.io"]
+	lib.assert_empty(olm.deny) with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.io", "registry.redhat.io"] # regal ignore:line-length
 		with input.image.config.Labels as {olm.manifestv1: "manifests/"}
 		with input.image.files as {"manifests/csv.yaml": manifest}
 }
@@ -455,8 +444,7 @@ test_bundle_image_index if {
 		"term": "registry.io/repository/image@sha256:cafe",
 	}}
 
-	lib.assert_equal_results(olm.deny, expected_deny) with data.rule_data.pipeline_intention as "release"
-		with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.io", "registry.redhat.io"]
+	lib.assert_equal_results(olm.deny, expected_deny) with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.io", "registry.redhat.io"] # regal ignore:line-length
 		with input.image.config.Labels as {olm.manifestv1: "manifests/"}
 		with input.image.files as {"manifests/csv.yaml": manifest}
 		with input.image.ref as pinned1
@@ -480,8 +468,7 @@ test_unallowed_registries if {
 	}
 
 	# This expects failure as registry.io is not a member of allowed_olm_image_registry_prefixes
-	lib.assert_equal_results(olm.deny, expected) with data.rule_data.pipeline_intention as "release"
-		with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.access.redhat.com", "registry.redhat.io"]
+	lib.assert_equal_results(olm.deny, expected) with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.access.redhat.com", "registry.redhat.io"] # regal ignore:line-length
 		with input.image.config.Labels as {olm.manifestv1: "manifests/"}
 		with input.image.files as {"manifests/csv.yaml": manifest}
 }
@@ -506,8 +493,7 @@ test_allowed_registries_related if {
 		},
 	}
 
-	lib.assert_equal_results(olm.deny, expected_deny) with data.rule_data.pipeline_intention as "release"
-		with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.access.redhat.com", "registry.redhat.io"]
+	lib.assert_equal_results(olm.deny, expected_deny) with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.access.redhat.com", "registry.redhat.io"] # regal ignore:line-length
 		with input.snapshot.components as [component1, component2, component3]
 		with input.attestations as _with_related_images
 		with input.image.ref as "registry.io/repository/image@sha256:image_digest"

--- a/policy/release/quay_expiration/quay_expiration.rego
+++ b/policy/release/quay_expiration/quay_expiration.rego
@@ -17,16 +17,14 @@ import data.lib
 # title: Expires label
 # description: >-
 #   Check the image metadata for the presence of a "quay.expires-after"
-#   label. If it's present then produce a violation. This check is enforced
-#   only for a "release", "production", or "staging" pipeline, as determined by
-#   the value of the `pipeline_intention` rule data.
+#   label. If it's present then produce a violation.
 # custom:
 #   short_name: expires_label
 #   pipeline_intention:
 #   - release
 #   - production
 #   - staging
-#   failure_msg: The label 'quay.expires-after' is not allowed in the released image
+#   failure_msg: The label 'quay.expires-after' is not allowed
 #   solution: >-
 #     Make sure the image is built without setting the "quay.expires-after" label. This
 #     label is usually set if the container image was built by an "on-pr" pipeline
@@ -35,8 +33,6 @@ import data.lib
 #   - redhat
 #
 deny contains result if {
-	lib.pipeline_intention_match(rego.metadata.chain())
-
 	# This is where we can access the image labels
 	some label_name, label_value in input.image.config.Labels
 

--- a/policy/release/quay_expiration/quay_expiration_test.rego
+++ b/policy/release/quay_expiration/quay_expiration_test.rego
@@ -5,31 +5,17 @@ import rego.v1
 import data.lib
 import data.quay_expiration
 
-test_ci_pipeline if {
+test_quay_expiration if {
 	lib.assert_empty(quay_expiration.deny) with input.image as _image_expires_none
-		with data.rule_data as _rule_data_for_ci
-
-	lib.assert_empty(quay_expiration.deny) with input.image as _image_expires_blank
-		with data.rule_data as _rule_data_for_ci
-
-	lib.assert_empty(quay_expiration.deny) with input.image as _image_expires_5d
-		with data.rule_data as _rule_data_for_ci
-}
-
-test_release_pipeline if {
-	lib.assert_empty(quay_expiration.deny) with input.image as _image_expires_none
-		with data.rule_data as _rule_data_for_release
 
 	expected := {{
 		"code": "quay_expiration.expires_label",
-		"msg": "The label 'quay.expires-after' is not allowed in the released image",
+		"msg": "The label 'quay.expires-after' is not allowed",
 	}}
 
 	lib.assert_equal_results(expected, quay_expiration.deny) with input.image as _image_expires_blank
-		with data.rule_data as _rule_data_for_release
 
 	lib.assert_equal_results(expected, quay_expiration.deny) with input.image as _image_expires_5d
-		with data.rule_data as _rule_data_for_release
 }
 
 _image_expires_5d := {"config": {"Labels": {
@@ -43,7 +29,3 @@ _image_expires_blank := {"config": {"Labels": {
 }}}
 
 _image_expires_none := {"config": {"Labels": {"foo": "bar"}}}
-
-_rule_data_for_ci := {}
-
-_rule_data_for_release := {"pipeline_intention": "release"}

--- a/policy/release/schedule/schedule.rego
+++ b/policy/release/schedule/schedule.rego
@@ -16,8 +16,7 @@ import data.lib.json as j
 # description: >-
 #   Check if the current weekday is allowed based on the rule data value from the key
 #   `disallowed_weekdays`. By default, the list is empty in which case *any* weekday is
-#   allowed. This check is enforced only for a "release" or "production"
-#   pipeline, as determined by the value of the `pipeline_intention` rule data.
+#   allowed.
 # custom:
 #   short_name: weekday_restriction
 #   pipeline_intention:
@@ -30,7 +29,6 @@ import data.lib.json as j
 #   - redhat_rpms
 #
 deny contains result if {
-	lib.pipeline_intention_match(rego.metadata.chain())
 	today := lower(time.weekday(lib.time.effective_current_time_ns))
 	disallowed := {lower(w) | some w in lib.rule_data("disallowed_weekdays")}
 	count(disallowed) > 0
@@ -43,9 +41,7 @@ deny contains result if {
 # description: >-
 #   Check if the current date is not allowed based on the rule data value
 #   from the key `disallowed_dates`. By default, the list is empty in which
-#   case *any* day is allowed. This check is enforced only for a "release" or
-#   "production" pipeline, as determined by the value of the
-#   `pipeline_intention` rule data.
+#   case *any* day is allowed.
 # custom:
 #   short_name: date_restriction
 #   pipeline_intention:
@@ -58,7 +54,6 @@ deny contains result if {
 #   - redhat_rpms
 #
 deny contains result if {
-	lib.pipeline_intention_match(rego.metadata.chain())
 	today := time.format([lib.time.effective_current_time_ns, "UTC", "2006-01-02"])
 	disallowed := lib.rule_data("disallowed_dates")
 	today in disallowed

--- a/policy/release/schedule/schedule_test.rego
+++ b/policy/release/schedule/schedule_test.rego
@@ -81,8 +81,7 @@ test_date_restriction if {
 		with data.config.policy.when_ns as time.parse_rfc3339_ns("2024-02-03T00:00:00Z")
 }
 
-test_pipeline_intention if {
-	# With pipeline intention set to "release" we get a violation
+test_schedule_restriction if {
 	release_weekday_data := weekday_rule_data(["monday"])
 	monday_violation := {{
 		"code": "schedule.weekday_restriction",
@@ -98,23 +97,6 @@ test_pipeline_intention if {
 		"msg": "2024-05-12 is a disallowed date: 2024-05-12",
 	}}
 	lib.assert_equal_results(schedule.deny, violation) with data.rule_data as release_date_data
-		with data.config.policy.when_ns as rfc_date
-
-	# Without pipeline intention set to "release" we do not get a violation
-	build_weekday_data := object.union(release_weekday_data, {"pipeline_intention": null})
-	lib.assert_empty(schedule.deny) with data.rule_data as build_weekday_data
-		with data.config.policy.when_ns as monday
-
-	spam_weekday_data := object.union(release_weekday_data, {"pipeline_intention": "spam"})
-	lib.assert_empty(schedule.deny) with data.rule_data as spam_weekday_data
-		with data.config.policy.when_ns as monday
-
-	build_date_data := object.union(release_date_data, {"pipeline_intention": null})
-	lib.assert_empty(schedule.deny) with data.rule_data as build_date_data
-		with data.config.policy.when_ns as rfc_date
-
-	spam_date_data := object.union(release_date_data, {"pipeline_intention": "spam"})
-	lib.assert_empty(schedule.deny) with data.rule_data as spam_date_data
 		with data.config.policy.when_ns as rfc_date
 }
 
@@ -219,11 +201,8 @@ saturday := _rfc_time_helper("2023-01-07")
 
 _rfc_time_helper(date_string) := time.parse_rfc3339_ns(sprintf("%sT00:00:00Z", [date_string]))
 
-weekday_rule_data(disallowed_weekdays) := _rule_data_helper("disallowed_weekdays", disallowed_weekdays, "release")
+weekday_rule_data(disallowed_weekdays) := _rule_data_helper("disallowed_weekdays", disallowed_weekdays)
 
-date_rule_data(disallowed_dates) := _rule_data_helper("disallowed_dates", disallowed_dates, "release")
+date_rule_data(disallowed_dates) := _rule_data_helper("disallowed_dates", disallowed_dates)
 
-_rule_data_helper(disallowed_key, disallowed_values, pipeline_intention) := {
-	"pipeline_intention": pipeline_intention,
-	disallowed_key: disallowed_values,
-}
+_rule_data_helper(disallowed_key, disallowed_values) := {disallowed_key: disallowed_values}


### PR DESCRIPTION
This commit removes all the conditional logic that is based on pipeline intention information.
From now on, the pipeline intention will be managed by the Conforma CLI, based on the rego rules metadata.

Ref: https://issues.redhat.com/browse/EC-1341