### PR TITLE
Fix sbom purl matching for rpms (again)

### DIFF
--- a/policy/lib/sbom/rpm.rego
+++ b/policy/lib/sbom/rpm.rego
@@ -25,7 +25,7 @@ rpms_from_sbom(s) := entities if {
 		some pkg in s.packages
 		some ref in pkg.externalRefs
 		ref.referenceType == "purl"
-		ref.referenceCategory == "PACKAGE-MANAGER"
+		ref.referenceCategory in {"PACKAGE_MANAGER", "PACKAGE-MANAGER"}
 		purl := ref.referenceLocator
 		_is_rpmish(purl)
 		entity := {

--- a/policy/lib/sbom/rpm_test.rego
+++ b/policy/lib/sbom/rpm_test.rego
@@ -103,7 +103,7 @@ _spdx_package(purl, annotations) := {
 	"annotations": annotations,
 	"externalRefs": [{
 		"referenceType": "purl",
-		"referenceCategory": "PACKAGE-MANAGER",
+		"referenceCategory": "PACKAGE_MANAGER",
 		"referenceLocator": purl,
 	}],
 }

--- a/policy/release/pre_build_script_task/pre_build_script_task.rego
+++ b/policy/release/pre_build_script_task/pre_build_script_task.rego
@@ -152,7 +152,7 @@ _purls_from_sbom(s) := purls if {
 		some pkg in s.packages
 		some ref in pkg.externalRefs
 		ref.referenceType == "purl"
-		ref.referenceCategory in {"PACKAGE-MANAGER", "PACKAGE_MANAGER"}
+		ref.referenceCategory in {"PACKAGE_MANAGER", "PACKAGE-MANAGER"}
 	}
 	count(purls) > 0
 }

--- a/policy/release/rpm_packages/rpm_packages_test.rego
+++ b/policy/release/rpm_packages/rpm_packages_test.rego
@@ -120,16 +120,17 @@ _mock_blob(`"registry.local/cyclonedx-2@sha256:cyclonedx-2-digest"`) := json.mar
 _mock_blob(`"registry.local/spdx-1@sha256:spdx-1-digest"`) := json.marshal({"packages": [
 	{"externalRefs": [{
 		"referenceType": "purl",
-		"referenceCategory": "PACKAGE-MANAGER",
+		"referenceCategory": "PACKAGE_MANAGER",
 		"referenceLocator": "pkg:rpm/redhat/spam@1.0.0-1",
 	}]},
 	{"externalRefs": [{
 		"referenceType": "purl",
-		"referenceCategory": "PACKAGE-MANAGER",
+		"referenceCategory": "PACKAGE_MANAGER",
 		"referenceLocator": "pkg:rpm/redhat/bacon@1.0.0-2",
 	}]},
 	{"externalRefs": [{
 		"referenceType": "purl",
+		# Intentionally different since we match both PACKAGE_MANAGER and PACKAGE-MANAGER
 		"referenceCategory": "PACKAGE-MANAGER",
 		"referenceLocator": "pkg:rpm/redhat/ham@4.2.0-0",
 	}]},
@@ -138,16 +139,17 @@ _mock_blob(`"registry.local/spdx-1@sha256:spdx-1-digest"`) := json.marshal({"pac
 _mock_blob(`"registry.local/spdx-2@sha256:spdx-2-digest"`) := json.marshal({"packages": [
 	{"externalRefs": [{
 		"referenceType": "purl",
-		"referenceCategory": "PACKAGE-MANAGER",
+		"referenceCategory": "PACKAGE_MANAGER",
 		"referenceLocator": "pkg:rpm/redhat/spam@1.0.0-2",
 	}]},
 	{"externalRefs": [{
 		"referenceType": "purl",
-		"referenceCategory": "PACKAGE-MANAGER",
+		"referenceCategory": "PACKAGE_MANAGER",
 		"referenceLocator": "pkg:rpm/redhat/bacon@1.0.0-2",
 	}]},
 	{"externalRefs": [{
 		"referenceType": "purl",
+		# Intentionally different since we match both PACKAGE_MANAGER and PACKAGE-MANAGER
 		"referenceCategory": "PACKAGE-MANAGER",
 		"referenceLocator": "pkg:rpm/redhat/eggs@4.2.0-0",
 	}]},


### PR DESCRIPTION
This is the same bug already fixed in PR #1457 but in a different place.

The impact here is the rego doesn't see any of the rpms in the SPDX SBOM, so it potentially doesn't produce rpm related violations that it should produce.

Found this while working on...
Ref: https://issues.redhat.com/browse/EC-1354