### PR TITLE
feat(buildah_build_task): add INCLUDE_PREFETCH_SBOM and INCLUDE_SOURCE_SBOM policy rules

### DIFF
--- a/antora/docs/modules/ROOT/pages/packages/release_buildah_build_task.adoc
+++ b/antora/docs/modules/ROOT/pages/packages/release_buildah_build_task.adoc
@@ -33,6 +33,30 @@ Verify the Dockerfile used in the buildah task was not fetched from an external 
 * Code: `buildah_build_task.buildah_uses_local_dockerfile`
 * https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/buildah_build_task/buildah_build_task.rego#L14[Source, window="_blank"]
 
+[#buildah_build_task__include_prefetch_sbom_param]
+=== link:#buildah_build_task__include_prefetch_sbom_param[INCLUDE_PREFETCH_SBOM parameter]
+
+Verify the INCLUDE_PREFETCH_SBOM parameter of a builder Task was not set to `false`. Prefetch SBOM inclusion is required by default to ensure hermetic builds produce accurate SBOMs. Pipelines that need to exclude prefetch SBOM content (e.g. due to Yarn workspace monorepo limitations) must obtain a policy exception.
+
+*Solution*: Set the INCLUDE_PREFETCH_SBOM parameter to 'true', or obtain a policy exception if excluding prefetch SBOM content is justified (e.g. monorepo Yarn workspace scenarios where the prefetch SBOM is inaccurate for the specific image).
+
+* Rule type: [rule-type-indicator failure]#FAILURE#
+* FAILURE message: `INCLUDE_PREFETCH_SBOM is set to 'false', which excludes prefetched dependency data from the SBOM. A policy exception is required for this configuration.`
+* Code: `buildah_build_task.include_prefetch_sbom_param`
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/buildah_build_task/buildah_build_task.rego#L119[Source, window="_blank"]
+
+[#buildah_build_task__include_source_sbom_param]
+=== link:#buildah_build_task__include_source_sbom_param[INCLUDE_SOURCE_SBOM parameter]
+
+Verify the INCLUDE_SOURCE_SBOM parameter of a builder Task was not set to `false`. Source SBOM inclusion is required by default to ensure builds produce comprehensive SBOMs. Pipelines that need to exclude source SBOM content must obtain a policy exception.
+
+*Solution*: Set the INCLUDE_SOURCE_SBOM parameter to 'true', or obtain a policy exception if excluding source SBOM content is justified.
+
+* Rule type: [rule-type-indicator failure]#FAILURE#
+* FAILURE message: `INCLUDE_SOURCE_SBOM is set to 'false', which excludes source-scanned dependency data from the SBOM. A policy exception is required for this configuration.`
+* Code: `buildah_build_task.include_source_sbom_param`
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/buildah_build_task/buildah_build_task.rego#L146[Source, window="_blank"]
+
 [#buildah_build_task__platform_param]
 === link:#buildah_build_task__platform_param[PLATFORM parameter]
 

--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -109,6 +109,8 @@ Rules included:
 * xref:packages/release_base_image_registries.adoc#base_image_registries__base_image_info_found[Base image checks: Base images provided]        
 * xref:packages/release_buildah_build_task.adoc#buildah_build_task__add_capabilities_param[Buildah build task: ADD_CAPABILITIES parameter]        
 * xref:packages/release_buildah_build_task.adoc#buildah_build_task__buildah_uses_local_dockerfile[Buildah build task: Buildah task uses a local Dockerfile]        
+* xref:packages/release_buildah_build_task.adoc#buildah_build_task__include_prefetch_sbom_param[Buildah build task: INCLUDE_PREFETCH_SBOM parameter]        
+* xref:packages/release_buildah_build_task.adoc#buildah_build_task__include_source_sbom_param[Buildah build task: INCLUDE_SOURCE_SBOM parameter]        
 * xref:packages/release_buildah_build_task.adoc#buildah_build_task__platform_param[Buildah build task: PLATFORM parameter]        
 * xref:packages/release_buildah_build_task.adoc#buildah_build_task__privileged_nested_param[Buildah build task: PRIVILEGED_NESTED parameter]        
 * xref:packages/release_buildah_build_task.adoc#buildah_build_task__disallowed_platform_patterns_pattern[Buildah build task: disallowed_platform_patterns format]        

--- a/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
+++ b/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
@@ -20,6 +20,8 @@
 *** xref:packages/release_buildah_build_task.adoc[Buildah build task]
 **** xref:packages/release_buildah_build_task.adoc#buildah_build_task__add_capabilities_param[ADD_CAPABILITIES parameter]
 **** xref:packages/release_buildah_build_task.adoc#buildah_build_task__buildah_uses_local_dockerfile[Buildah task uses a local Dockerfile]
+**** xref:packages/release_buildah_build_task.adoc#buildah_build_task__include_prefetch_sbom_param[INCLUDE_PREFETCH_SBOM parameter]
+**** xref:packages/release_buildah_build_task.adoc#buildah_build_task__include_source_sbom_param[INCLUDE_SOURCE_SBOM parameter]
 **** xref:packages/release_buildah_build_task.adoc#buildah_build_task__platform_param[PLATFORM parameter]
 **** xref:packages/release_buildah_build_task.adoc#buildah_build_task__privileged_nested_param[PRIVILEGED_NESTED parameter]
 **** xref:packages/release_buildah_build_task.adoc#buildah_build_task__disallowed_platform_patterns_pattern[disallowed_platform_patterns format]

--- a/policy/release/buildah_build_task/buildah_build_task.rego
+++ b/policy/release/buildah_build_task/buildah_build_task.rego
@@ -116,6 +116,59 @@ deny contains result if {
 	result := lib.result_helper(rego.metadata.chain(), [])
 }
 
+# METADATA
+# title: INCLUDE_PREFETCH_SBOM parameter
+# description: >-
+#   Verify the INCLUDE_PREFETCH_SBOM parameter of a builder Task was not set to `false`.
+#   Prefetch SBOM inclusion is required by default to ensure hermetic builds produce
+#   accurate SBOMs. Pipelines that need to exclude prefetch SBOM content (e.g. due to
+#   Yarn workspace monorepo limitations) must obtain a policy exception.
+# custom:
+#   short_name: include_prefetch_sbom_param
+#   failure_msg: >-
+#     INCLUDE_PREFETCH_SBOM is set to 'false', which excludes prefetched dependency
+#     data from the SBOM. A policy exception is required for this configuration.
+#   solution: >-
+#     Set the INCLUDE_PREFETCH_SBOM parameter to 'true', or obtain a policy exception
+#     if excluding prefetch SBOM content is justified (e.g. monorepo Yarn workspace
+#     scenarios where the prefetch SBOM is inaccurate for the specific image).
+#   collections:
+#   - redhat
+#   depends_on:
+#   - attestation_type.known_attestation_type
+#
+deny contains result if {
+	some param in _include_prefetch_sbom_params
+	trim_space(param) == "false"
+	result := lib.result_helper(rego.metadata.chain(), [])
+}
+
+# METADATA
+# title: INCLUDE_SOURCE_SBOM parameter
+# description: >-
+#   Verify the INCLUDE_SOURCE_SBOM parameter of a builder Task was not set to `false`.
+#   Source SBOM inclusion is required by default to ensure builds produce comprehensive
+#   SBOMs. Pipelines that need to exclude source SBOM content must obtain a policy
+#   exception.
+# custom:
+#   short_name: include_source_sbom_param
+#   failure_msg: >-
+#     INCLUDE_SOURCE_SBOM is set to 'false', which excludes source-scanned dependency
+#     data from the SBOM. A policy exception is required for this configuration.
+#   solution: >-
+#     Set the INCLUDE_SOURCE_SBOM parameter to 'true', or obtain a policy exception
+#     if excluding source SBOM content is justified.
+#   collections:
+#   - redhat
+#   depends_on:
+#   - attestation_type.known_attestation_type
+#
+deny contains result if {
+	some param in _include_source_sbom_params
+	trim_space(param) == "false"
+	result := lib.result_helper(rego.metadata.chain(), [])
+}
+
 _not_allowed_prefix(search) if {
 	not_allowed_prefixes := ["http://", "https://"]
 	some not_allowed_prefix in not_allowed_prefixes
@@ -177,59 +230,6 @@ _rule_data_errors contains error if {
 }
 
 _plat_patterns_rule_data_key := "disallowed_platform_patterns"
-
-# METADATA
-# title: INCLUDE_PREFETCH_SBOM parameter
-# description: >-
-#   Verify the INCLUDE_PREFETCH_SBOM parameter of a builder Task was not set to `false`.
-#   Prefetch SBOM inclusion is required by default to ensure hermetic builds produce
-#   accurate SBOMs. Pipelines that need to exclude prefetch SBOM content (e.g. due to
-#   Yarn workspace monorepo limitations) must obtain a policy exception.
-# custom:
-#   short_name: include_prefetch_sbom_param
-#   failure_msg: >-
-#     INCLUDE_PREFETCH_SBOM is set to 'false', which excludes prefetched dependency
-#     data from the SBOM. A policy exception is required for this configuration.
-#   solution: >-
-#     Set the INCLUDE_PREFETCH_SBOM parameter to 'true', or obtain a policy exception
-#     if excluding prefetch SBOM content is justified (e.g. monorepo Yarn workspace
-#     scenarios where the prefetch SBOM is inaccurate for the specific image).
-#   collections:
-#   - redhat
-#   depends_on:
-#   - attestation_type.known_attestation_type
-#
-deny contains result if {
-	some param in _include_prefetch_sbom_params
-	trim_space(param) == "false"
-	result := lib.result_helper(rego.metadata.chain(), [])
-}
-
-# METADATA
-# title: INCLUDE_SOURCE_SBOM parameter
-# description: >-
-#   Verify the INCLUDE_SOURCE_SBOM parameter of a builder Task was not set to `false`.
-#   Source SBOM inclusion is required by default to ensure builds produce comprehensive
-#   SBOMs. Pipelines that need to exclude source SBOM content must obtain a policy
-#   exception.
-# custom:
-#   short_name: include_source_sbom_param
-#   failure_msg: >-
-#     INCLUDE_SOURCE_SBOM is set to 'false', which excludes source-scanned dependency
-#     data from the SBOM. A policy exception is required for this configuration.
-#   solution: >-
-#     Set the INCLUDE_SOURCE_SBOM parameter to 'true', or obtain a policy exception
-#     if excluding source SBOM content is justified.
-#   collections:
-#   - redhat
-#   depends_on:
-#   - attestation_type.known_attestation_type
-#
-deny contains result if {
-	some param in _include_source_sbom_params
-	trim_space(param) == "false"
-	result := lib.result_helper(rego.metadata.chain(), [])
-}
 
 _include_prefetch_sbom_params contains param if {
 	some buildah_task in _buildah_tasks

--- a/policy/release/buildah_build_task/buildah_build_task.rego
+++ b/policy/release/buildah_build_task/buildah_build_task.rego
@@ -177,3 +177,66 @@ _rule_data_errors contains error if {
 }
 
 _plat_patterns_rule_data_key := "disallowed_platform_patterns"
+
+# METADATA
+# title: INCLUDE_PREFETCH_SBOM parameter
+# description: >-
+#   Verify the INCLUDE_PREFETCH_SBOM parameter of a builder Task was not set to `false`.
+#   Prefetch SBOM inclusion is required by default to ensure hermetic builds produce
+#   accurate SBOMs. Pipelines that need to exclude prefetch SBOM content (e.g. due to
+#   Yarn workspace monorepo limitations) must obtain a policy exception.
+# custom:
+#   short_name: include_prefetch_sbom_param
+#   failure_msg: >-
+#     INCLUDE_PREFETCH_SBOM is set to 'false', which excludes prefetched dependency
+#     data from the SBOM. A policy exception is required for this configuration.
+#   solution: >-
+#     Set the INCLUDE_PREFETCH_SBOM parameter to 'true', or obtain a policy exception
+#     if excluding prefetch SBOM content is justified (e.g. monorepo Yarn workspace
+#     scenarios where the prefetch SBOM is inaccurate for the specific image).
+#   collections:
+#   - redhat
+#   depends_on:
+#   - attestation_type.known_attestation_type
+#
+deny contains result if {
+	some param in _include_prefetch_sbom_params
+	trim_space(param) == "false"
+	result := lib.result_helper(rego.metadata.chain(), [])
+}
+
+# METADATA
+# title: INCLUDE_SOURCE_SBOM parameter
+# description: >-
+#   Verify the INCLUDE_SOURCE_SBOM parameter of a builder Task was not set to `false`.
+#   Source SBOM inclusion is required by default to ensure builds produce comprehensive
+#   SBOMs. Pipelines that need to exclude source SBOM content must obtain a policy
+#   exception.
+# custom:
+#   short_name: include_source_sbom_param
+#   failure_msg: >-
+#     INCLUDE_SOURCE_SBOM is set to 'false', which excludes source-scanned dependency
+#     data from the SBOM. A policy exception is required for this configuration.
+#   solution: >-
+#     Set the INCLUDE_SOURCE_SBOM parameter to 'true', or obtain a policy exception
+#     if excluding source SBOM content is justified.
+#   collections:
+#   - redhat
+#   depends_on:
+#   - attestation_type.known_attestation_type
+#
+deny contains result if {
+	some param in _include_source_sbom_params
+	trim_space(param) == "false"
+	result := lib.result_helper(rego.metadata.chain(), [])
+}
+
+_include_prefetch_sbom_params contains param if {
+	some buildah_task in _buildah_tasks
+	param := lib.tekton.task_param(buildah_task, "INCLUDE_PREFETCH_SBOM")
+}
+
+_include_source_sbom_params contains param if {
+	some buildah_task in _buildah_tasks
+	param := lib.tekton.task_param(buildah_task, "INCLUDE_SOURCE_SBOM")
+}

--- a/policy/release/buildah_build_task/buildah_build_task_test.rego
+++ b/policy/release/buildah_build_task/buildah_build_task_test.rego
@@ -413,6 +413,161 @@ test_privileged_nested_param if {
 	lib.assert_empty(buildah_build_task.deny) with input.attestations as [attestation_false]
 }
 
+test_include_prefetch_sbom_false if {
+	expected := {{
+		"code": "buildah_build_task.include_prefetch_sbom_param",
+		"msg": "INCLUDE_PREFETCH_SBOM is set to 'false', which excludes prefetched dependency data from the SBOM. A policy exception is required for this configuration.",
+	}}
+
+	_task_base := tekton_test.slsav1_task("buildah")
+	_task_w_params = tekton_test.with_params(
+		_task_base,
+		[
+			{
+				"name": "IMAGE",
+				"value": "quay.io/jstuart/hacbs-docker-build",
+			},
+			{
+				"name": "DOCKERFILE",
+				"value": "./image_with_labels/Dockerfile",
+			},
+			{
+				"name": "INCLUDE_PREFETCH_SBOM",
+				"value": "false",
+			},
+		],
+	)
+	task = tekton_test.with_results(_task_w_params, _results)
+
+	attestation := tekton_test.slsav1_attestation([task])
+	lib.assert_equal_results(expected, buildah_build_task.deny) with input.attestations as [attestation]
+}
+
+test_include_prefetch_sbom_true if {
+	_task_base := tekton_test.slsav1_task("buildah")
+	_task_w_params = tekton_test.with_params(
+		_task_base,
+		[
+			{
+				"name": "IMAGE",
+				"value": "quay.io/jstuart/hacbs-docker-build",
+			},
+			{
+				"name": "DOCKERFILE",
+				"value": "./image_with_labels/Dockerfile",
+			},
+			{
+				"name": "INCLUDE_PREFETCH_SBOM",
+				"value": "true",
+			},
+		],
+	)
+	task = tekton_test.with_results(_task_w_params, _results)
+
+	attestation := tekton_test.slsav1_attestation([task])
+	lib.assert_empty(buildah_build_task.deny) with input.attestations as [attestation]
+}
+
+test_include_prefetch_sbom_missing if {
+	attestation := tekton_test.slsav1_attestation([_buildah_task("buildah")])
+	lib.assert_empty(buildah_build_task.deny) with input.attestations as [attestation]
+}
+
+test_include_source_sbom_false if {
+	expected := {{
+		"code": "buildah_build_task.include_source_sbom_param",
+		"msg": "INCLUDE_SOURCE_SBOM is set to 'false', which excludes source-scanned dependency data from the SBOM. A policy exception is required for this configuration.",
+	}}
+
+	_task_base := tekton_test.slsav1_task("buildah")
+	_task_w_params = tekton_test.with_params(
+		_task_base,
+		[
+			{
+				"name": "IMAGE",
+				"value": "quay.io/jstuart/hacbs-docker-build",
+			},
+			{
+				"name": "DOCKERFILE",
+				"value": "./image_with_labels/Dockerfile",
+			},
+			{
+				"name": "INCLUDE_SOURCE_SBOM",
+				"value": "false",
+			},
+		],
+	)
+	task = tekton_test.with_results(_task_w_params, _results)
+
+	attestation := tekton_test.slsav1_attestation([task])
+	lib.assert_equal_results(expected, buildah_build_task.deny) with input.attestations as [attestation]
+}
+
+test_include_source_sbom_true if {
+	_task_base := tekton_test.slsav1_task("buildah")
+	_task_w_params = tekton_test.with_params(
+		_task_base,
+		[
+			{
+				"name": "IMAGE",
+				"value": "quay.io/jstuart/hacbs-docker-build",
+			},
+			{
+				"name": "DOCKERFILE",
+				"value": "./image_with_labels/Dockerfile",
+			},
+			{
+				"name": "INCLUDE_SOURCE_SBOM",
+				"value": "true",
+			},
+		],
+	)
+	task = tekton_test.with_results(_task_w_params, _results)
+
+	attestation := tekton_test.slsav1_attestation([task])
+	lib.assert_empty(buildah_build_task.deny) with input.attestations as [attestation]
+}
+
+test_include_both_sbom_false if {
+	expected := {
+		{
+			"code": "buildah_build_task.include_prefetch_sbom_param",
+			"msg": "INCLUDE_PREFETCH_SBOM is set to 'false', which excludes prefetched dependency data from the SBOM. A policy exception is required for this configuration.",
+		},
+		{
+			"code": "buildah_build_task.include_source_sbom_param",
+			"msg": "INCLUDE_SOURCE_SBOM is set to 'false', which excludes source-scanned dependency data from the SBOM. A policy exception is required for this configuration.",
+		},
+	}
+
+	_task_base := tekton_test.slsav1_task("buildah")
+	_task_w_params = tekton_test.with_params(
+		_task_base,
+		[
+			{
+				"name": "IMAGE",
+				"value": "quay.io/jstuart/hacbs-docker-build",
+			},
+			{
+				"name": "DOCKERFILE",
+				"value": "./image_with_labels/Dockerfile",
+			},
+			{
+				"name": "INCLUDE_PREFETCH_SBOM",
+				"value": "false",
+			},
+			{
+				"name": "INCLUDE_SOURCE_SBOM",
+				"value": "false",
+			},
+		],
+	)
+	task = tekton_test.with_results(_task_w_params, _results)
+
+	attestation := tekton_test.slsav1_attestation([task])
+	lib.assert_equal_results(expected, buildah_build_task.deny) with input.attestations as [attestation]
+}
+
 _attestation(task_name, params, results) := {"statement": {
 	"predicateType": "https://slsa.dev/provenance/v0.2",
 	"predicate": {

--- a/policy/release/buildah_build_task/buildah_build_task_test.rego
+++ b/policy/release/buildah_build_task/buildah_build_task_test.rego
@@ -416,6 +416,7 @@ test_privileged_nested_param if {
 test_include_prefetch_sbom_false if {
 	expected := {{
 		"code": "buildah_build_task.include_prefetch_sbom_param",
+		# regal ignore:line-length
 		"msg": "INCLUDE_PREFETCH_SBOM is set to 'false', which excludes prefetched dependency data from the SBOM. A policy exception is required for this configuration.",
 	}}
 
@@ -476,6 +477,7 @@ test_include_prefetch_sbom_missing if {
 test_include_source_sbom_false if {
 	expected := {{
 		"code": "buildah_build_task.include_source_sbom_param",
+		# regal ignore:line-length
 		"msg": "INCLUDE_SOURCE_SBOM is set to 'false', which excludes source-scanned dependency data from the SBOM. A policy exception is required for this configuration.",
 	}}
 
@@ -532,10 +534,12 @@ test_include_both_sbom_false if {
 	expected := {
 		{
 			"code": "buildah_build_task.include_prefetch_sbom_param",
+			# regal ignore:line-length
 			"msg": "INCLUDE_PREFETCH_SBOM is set to 'false', which excludes prefetched dependency data from the SBOM. A policy exception is required for this configuration.",
 		},
 		{
 			"code": "buildah_build_task.include_source_sbom_param",
+			# regal ignore:line-length
 			"msg": "INCLUDE_SOURCE_SBOM is set to 'false', which excludes source-scanned dependency data from the SBOM. A policy exception is required for this configuration.",
 		},
 	}


### PR DESCRIPTION
## Summary

Add Conforma policy rules to the `buildah_build_task` package that deny release when `INCLUDE_PREFETCH_SBOM` or `INCLUDE_SOURCE_SBOM` is set to `"false"` on a buildah builder task.

This ensures pipelines cannot silently exclude prefetch or source SBOM content from a hermetic build without an explicit policy exception.

## Context

[konflux-ci/build-definitions#3259](https://github.com/konflux-ci/build-definitions/pull/3259) proposes adding `INCLUDE_PREFETCH_SBOM` and `INCLUDE_SOURCE_SBOM` optional params to the `buildah-oci-ta` task. Both default to `"true"` for backward compatibility.

During review, @chmeliik [noted](https://github.com/konflux-ci/build-definitions/pull/3259#issuecomment-2661613827) that:

> the usage of these parameters would absolutely have to be blocked by Conforma policies, and those would have to be in place first before we merge this.

This PR provides that policy gate.

## Why these params exist

In Yarn workspace monorepos, Hermeto/Cachi2 resolves the root `yarn.lock` when prefetching for any workspace path, producing a prefetch SBOM that covers **all** workspaces — not just the target. This is a known limitation of Yarn workspace resolution in Hermeto (not a general monorepo behavior). Each plugin image ends up with dependencies from sibling workspaces in its SBOM, causing:

- ~16x CVE duplication across plugin images
- SBOM noise and inflated package counts
- Unnecessary ProdSec ticket churn

The params allow pipelines to opt out of prefetch/source SBOM merging while **preserving hermetic build guarantees**. The hermetic build still runs — only the SBOM merge step is affected.

## Design

Follows the exact same pattern as existing `buildah_build_task` rules (`PRIVILEGED_NESTED`, `ADD_CAPABILITIES`, `PLATFORM`):

- Scans all buildah build tasks in the PipelineRun attestation
- Denies if `INCLUDE_PREFETCH_SBOM == "false"` or `INCLUDE_SOURCE_SBOM == "false"`
- If the param is missing or set to `"true"`, no violation is raised
- Part of the `redhat` collection

Pipelines that legitimately need `false` (e.g. RHDH's Yarn monorepo) must configure a policy exception.

## Tests

- `test_include_prefetch_sbom_false` — denies when param is `"false"`
- `test_include_prefetch_sbom_true` — passes when param is `"true"`
- `test_include_prefetch_sbom_missing` — passes when param is absent
- `test_include_source_sbom_false` — denies when param is `"false"`
- `test_include_source_sbom_true` — passes when param is `"true"`
- `test_include_both_sbom_false` — denies both violations simultaneously

Related: [konflux-ci/build-definitions#3259](https://github.com/konflux-ci/build-definitions/pull/3259), RHIDP-11640

Made with [Cursor](https://cursor.com)