### PR TITLE
trusted_task_rules: Add per-allow-rule signature verification

### DIFF
--- a/policy/lib/tekton/trusted.rego
+++ b/policy/lib/tekton/trusted.rego
@@ -423,17 +423,15 @@ _task_matches_allow_rule_pattern_version(ref, rule, bundle_manifests) if {
 }
 
 # Build sigstore opts object from a rule's signature_verification config.
+# Only includes keys that are explicitly set to non-default values to avoid
+# empty strings being interpreted as "no constraint" by Sigstore.
 _sigstore_opts_for_rule(rule) := opts if {
 	sv := rule.signature_verification
 	is_object(sv)
-	opts := {
-		"certificate_identity": object.get(sv, "certificate_identity", ""),
-		"certificate_identity_regexp": object.get(sv, "certificate_identity_regexp", ""),
-		"certificate_oidc_issuer": object.get(sv, "certificate_oidc_issuer", ""),
-		"certificate_oidc_issuer_regexp": object.get(sv, "certificate_oidc_issuer_regexp", ""),
-		"ignore_rekor": object.get(sv, "ignore_rekor", false),
-		"public_key": object.get(sv, "public_key", ""),
-		"rekor_url": object.get(sv, "rekor_url", ""),
+	opts := {k: v |
+		some k, v in sv
+		v != ""
+		v != false
 	}
 }
 
@@ -498,15 +496,21 @@ _trusted_task_rule_entry_schema := {
 			# regal ignore:line-length
 			"description": "Sigstore verification options. When present, bundles matching this allow rule must also have a verified signature.",
 			"properties": {
-				"certificate_identity": {"type": "string"},
-				"certificate_identity_regexp": {"type": "string"},
-				"certificate_oidc_issuer": {"type": "string"},
-				"certificate_oidc_issuer_regexp": {"type": "string"},
+				"certificate_identity": {"type": "string", "minLength": 1},
+				"certificate_identity_regexp": {"type": "string", "minLength": 1},
+				"certificate_oidc_issuer": {"type": "string", "minLength": 1},
+				"certificate_oidc_issuer_regexp": {"type": "string", "minLength": 1},
 				"ignore_rekor": {"type": "boolean"},
-				"public_key": {"type": "string"},
-				"rekor_url": {"type": "string"},
+				"public_key": {"type": "string", "minLength": 1},
+				"rekor_url": {"type": "string", "minLength": 1},
 			},
 			"additionalProperties": false,
+			# regal ignore:line-length
+			"anyOf": [
+				{"required": ["certificate_identity"]},
+				{"required": ["certificate_identity_regexp"]},
+				{"required": ["public_key"]},
+			],
 		},
 	},
 	"additionalProperties": true,

--- a/policy/lib/tekton/trusted.rego
+++ b/policy/lib/tekton/trusted.rego
@@ -357,8 +357,7 @@ denial_reason(task, bundle_manifests) := reason if {
 	not _task_matches_deny_rule(ref, bundle_manifests)
 
 	some rule in _effective_allow_rules
-	_pattern_matches(ref.key, rule.pattern)
-	_version_satisfies_all_rule_constraints(ref, rule, bundle_manifests)
+	_task_matches_allow_rule_pattern_version(ref, rule, bundle_manifests)
 
 	# But no allow rule passes signature verification
 	not _task_matches_allow_rule(ref, bundle_manifests)
@@ -414,9 +413,13 @@ _denying_rules_info(task, bundle_manifests) := {"patterns": patterns, "messages"
 # bundle_manifests is a map of bundle_ref -> manifest from ec.oci.image_manifests
 _task_matches_allow_rule(ref, bundle_manifests) if {
 	some rule in _effective_allow_rules
+	_task_matches_allow_rule_pattern_version(ref, rule, bundle_manifests)
+	_signature_verified_for_rule(ref, rule)
+}
+
+_task_matches_allow_rule_pattern_version(ref, rule, bundle_manifests) if {
 	_pattern_matches(ref.key, rule.pattern)
 	_version_satisfies_all_rule_constraints(ref, rule, bundle_manifests)
-	_signature_verified_for_rule(ref, rule)
 }
 
 # Build sigstore opts object from a rule's signature_verification config.

--- a/policy/lib/tekton/trusted.rego
+++ b/policy/lib/tekton/trusted.rego
@@ -352,6 +352,23 @@ denial_reason(task, bundle_manifests) := reason if {
 		"messages": deny_info.messages,
 	}
 } else := reason if {
+	# Case: Matches pattern+version on an allow rule but fails signature verification
+	ref := task_ref(task)
+	not _task_matches_deny_rule(ref, bundle_manifests)
+
+	some rule in _effective_allow_rules
+	_pattern_matches(ref.key, rule.pattern)
+	_version_satisfies_all_rule_constraints(ref, rule, bundle_manifests)
+
+	# But no allow rule passes signature verification
+	not _task_matches_allow_rule(ref, bundle_manifests)
+
+	reason := {
+		"type": "signature_verification_failed",
+		"pattern": [],
+		"messages": [sprintf("Task bundle %s failed signature verification", [ref.bundle])],
+	}
+} else := reason if {
 	# Case 2: Doesn't match any allow rule
 	# Only applies if there are effective allow rules defined
 	ref := task_ref(task)
@@ -399,6 +416,45 @@ _task_matches_allow_rule(ref, bundle_manifests) if {
 	some rule in _effective_allow_rules
 	_pattern_matches(ref.key, rule.pattern)
 	_version_satisfies_all_rule_constraints(ref, rule, bundle_manifests)
+	_signature_verified_for_rule(ref, rule)
+}
+
+# Build sigstore opts object from a rule's signature_verification config.
+_sigstore_opts_for_rule(rule) := opts if {
+	sv := rule.signature_verification
+	is_object(sv)
+	opts := {
+		"certificate_identity": object.get(sv, "certificate_identity", ""),
+		"certificate_identity_regexp": object.get(sv, "certificate_identity_regexp", ""),
+		"certificate_oidc_issuer": object.get(sv, "certificate_oidc_issuer", ""),
+		"certificate_oidc_issuer_regexp": object.get(sv, "certificate_oidc_issuer_regexp", ""),
+		"ignore_rekor": object.get(sv, "ignore_rekor", false),
+		"public_key": object.get(sv, "public_key", ""),
+		"rekor_url": object.get(sv, "rekor_url", ""),
+	}
+}
+
+# A ref is signature-verified for a given rule if:
+# 1. The rule has no signature_verification config (pass through), OR
+# 2. The ref is not an OCI bundle (git tasks are exempt), OR
+# 3. The bundle passes sigstore verification with the rule's opts
+_signature_verified_for_rule(_, rule) if {
+	not rule.signature_verification
+}
+
+_signature_verified_for_rule(ref, _) if {
+	not ref.bundle
+}
+
+_signature_verified_for_rule(ref, rule) if {
+	ref.bundle
+	opts := _sigstore_opts_for_rule(rule)
+	not _sigstore_verify_has_errors(ref.bundle, opts)
+}
+
+_sigstore_verify_has_errors(bundle, opts) if {
+	info := ec.sigstore.verify_image(bundle, opts)
+	some _ in info.errors
 }
 
 # Converts a wildcard pattern to a regex pattern and checks if the key matches
@@ -433,6 +489,21 @@ _trusted_task_rule_entry_schema := {
 			"type": "array",
 			"description": "List of version constraints",
 			"items": {"type": "string"},
+		},
+		"signature_verification": {
+			"type": "object",
+			# regal ignore:line-length
+			"description": "Sigstore verification options. When present, bundles matching this allow rule must also have a verified signature.",
+			"properties": {
+				"certificate_identity": {"type": "string"},
+				"certificate_identity_regexp": {"type": "string"},
+				"certificate_oidc_issuer": {"type": "string"},
+				"certificate_oidc_issuer_regexp": {"type": "string"},
+				"ignore_rekor": {"type": "boolean"},
+				"public_key": {"type": "string"},
+				"rekor_url": {"type": "string"},
+			},
+			"additionalProperties": false,
 		},
 	},
 	"additionalProperties": true,

--- a/policy/lib/tekton/trusted.rego
+++ b/policy/lib/tekton/trusted.rego
@@ -125,14 +125,18 @@ untrusted_task_refs_rules(tasks, bundle_manifests) := {task |
 }
 
 # Returns true if the task uses a trusted Task reference according to trusted_task_rules.
-# 1. If task matches a deny rule, it's not trusted
-# 2. If task matches an allow rule, it's trusted
-# 3. Otherwise, it's not trusted
+# To be trusted, a task should:
+# 1. Match at least one allow rule
+# 2. Not match any deny rule
+# 3. If a matched allow rule specifies signature details, the
+#    task bundle must successfully pass a signature check
+# Otherwise, it's not trusted.
 # bundle_manifests is a map of bundle_ref -> manifest from ec.oci.image_manifests
 is_trusted_task_rules(task, bundle_manifests) if {
 	ref := task_ref(task)
 	not _task_matches_deny_rule(ref, bundle_manifests)
 	_task_matches_allow_rule(ref, bundle_manifests)
+	_task_bundle_sig_check_okay(ref, bundle_manifests)
 }
 
 # Merging in the trusted_task_rules rule data
@@ -400,6 +404,33 @@ denial_reason(task, bundle_manifests) := reason if {
 		"messages": deny_info.messages,
 	}
 } else := reason if {
+	# Case: Matches allow rule but fails signature verification
+	ref := task_ref(task)
+	not _task_matches_deny_rule(ref, bundle_manifests)
+	_task_matches_allow_rule(ref, bundle_manifests)
+	not _task_bundle_sig_check_okay(ref, bundle_manifests)
+
+	sig_rules := [rule |
+		some rule in _effective_allow_rules
+		_pattern_matches(ref.key, rule.pattern)
+		_version_satisfies_all_rule_constraints(ref, rule, bundle_manifests)
+		rule.signing_identity
+	]
+	messages := [msg |
+		some rule in sig_rules
+		opts := _sigstore_opts_for_rule(rule)
+		msg := sprintf(
+			"Task bundle %s failed signature verification for pattern %s with options %v",
+			[ref.bundle, rule.pattern, opts],
+		)
+	]
+
+	reason := {
+		"type": "signing_identity_failed",
+		"pattern": [rule.pattern | some rule in sig_rules],
+		"messages": messages,
+	}
+} else := reason if {
 	# Case 2: Doesn't match any allow rule
 	# Only applies if there are effective allow rules defined
 	ref := task_ref(task)
@@ -449,6 +480,59 @@ _task_matches_allow_rule(ref, bundle_manifests) if {
 	_version_satisfies_all_rule_constraints(ref, rule, bundle_manifests)
 }
 
+# Returns true if the task's signature is verified against all matching allow rules
+# that require signature verification. True when:
+# - No matching allow rule has a signing_identity config, OR
+# - The ref is not an OCI bundle (git tasks are exempt), OR
+# - At least one matching allow rule's signature verification passes
+_task_bundle_sig_check_okay(ref, bundle_manifests) if {
+	matching_rules := [rule |
+		some rule in _effective_allow_rules
+		_pattern_matches(ref.key, rule.pattern)
+		_version_satisfies_all_rule_constraints(ref, rule, bundle_manifests)
+	]
+	_signature_verified_for_rules(ref, matching_rules)
+}
+
+_signature_verified_for_rules(_, matching_rules) if {
+	some rule in matching_rules
+	not rule.signing_identity
+}
+
+_signature_verified_for_rules(ref, _) if {
+	not ref.bundle
+}
+
+_signature_verified_for_rules(ref, matching_rules) if {
+	ref.bundle
+	some rule in matching_rules
+	rule.signing_identity
+	opts := _sigstore_opts_for_rule(rule)
+	not _sigstore_verify_has_errors(ref.bundle, opts)
+}
+
+# Omit empty/false values so Sigstore doesn't treat them as "no constraint".
+_sigstore_opts_for_rule(rule) := opts if {
+	sv := rule.signing_identity
+	is_object(sv)
+	opts := {k: v |
+		some k, v in sv
+		v != ""
+		v != false
+	}
+}
+
+# Todo: This gets "called" first to check if the task is trusted and
+# then again when generating a denial reason text. Generally OPA memoizes
+# everything so it would not be re-run when called the second time, but
+# I'm not sure if the call to ec.sigstore.verify_image makes OPA think it
+# can't memoize it. If we are really calling the (possibly expensive)
+# sigstore verify twice then we might want to refactor and try to avoid that.
+_sigstore_verify_has_errors(bundle, opts) if {
+	info := ec.sigstore.verify_image(bundle, opts)
+	some _ in info.errors
+}
+
 # Checks if the key matches the wildcard pattern using glob matching.
 # Wildcards (*) match any sequence of characters. Patterns without a
 # wildcard also match keys that have a :tag suffix appended (e.g.
@@ -487,6 +571,27 @@ _trusted_task_rule_entry_schema := {
 			"type": "array",
 			"description": "List of version constraints",
 			"items": {"type": "string"},
+		},
+		"signing_identity": {
+			"type": "object",
+			# regal ignore:line-length
+			"description": "Sigstore verification options. When present, bundles matching this allow rule must also have a verified signature.",
+			"properties": {
+				"certificate_identity": {"type": "string", "minLength": 1},
+				"certificate_identity_regexp": {"type": "string", "minLength": 1},
+				"certificate_oidc_issuer": {"type": "string", "minLength": 1},
+				"certificate_oidc_issuer_regexp": {"type": "string", "minLength": 1},
+				"ignore_rekor": {"type": "boolean"},
+				"public_key": {"type": "string", "minLength": 1},
+				"rekor_url": {"type": "string", "minLength": 1},
+			},
+			"additionalProperties": false,
+			# regal ignore:line-length
+			"anyOf": [
+				{"required": ["certificate_identity"]},
+				{"required": ["certificate_identity_regexp"]},
+				{"required": ["public_key"]},
+			],
 		},
 	},
 	"additionalProperties": true,

--- a/policy/lib/tekton/trusted_test.rego
+++ b/policy/lib/tekton/trusted_test.rego
@@ -883,6 +883,118 @@ untrusted_git_task := {
 }
 
 # =============================================================================
+# SIGNATURE VERIFICATION TESTS
+# =============================================================================
+
+# Test: Allow rule without signature_verification works as before (backward compat)
+test_allow_rule_without_signature_verification if {
+	rules := {"allow": {"test-group": [{"pattern": "oci://registry.local/trusty*"}]}}
+
+	tekton.is_trusted_task(trusted_bundle_task, _empty_bundle_manifests) with data.trusted_task_rules as rules
+}
+
+# Test: Allow rule with signature_verification passes when signature is valid
+test_allow_rule_with_valid_signature if {
+	rules := {"allow": {"signed-catalog": [{
+		"pattern": "oci://registry.local/trusty*",
+		"signature_verification": {
+			"certificate_identity_regexp": "https://tekton.dev/chains/.*",
+			"certificate_oidc_issuer": "https://accounts.google.com",
+		},
+	}]}}
+
+	tekton.is_trusted_task(trusted_bundle_task, _empty_bundle_manifests) with data.trusted_task_rules as rules
+		with ec.sigstore.verify_image as _mock_verify_image_success
+}
+
+# Test: Allow rule with signature_verification fails when signature is invalid
+test_allow_rule_with_invalid_signature if {
+	rules := {"allow": {"signed-catalog": [{
+		"pattern": "oci://registry.local/trusty*",
+		"signature_verification": {
+			"certificate_identity_regexp": "https://tekton.dev/chains/.*",
+			"certificate_oidc_issuer": "https://accounts.google.com",
+		},
+	}]}}
+
+	not tekton.is_trusted_task(trusted_bundle_task, _empty_bundle_manifests) with data.trusted_task_rules as rules
+		with ec.sigstore.verify_image as _mock_verify_image_failure
+}
+
+# Test: Multiple allow rules - task passes if any rule's pattern+signature match
+test_multiple_allow_rules_different_sig_configs if {
+	rules := {"allow": {
+		"signed-catalog": [{
+			"pattern": "oci://registry.local/trusty*",
+			"signature_verification": {
+				"certificate_identity_regexp": "https://tekton.dev/chains/.*",
+				"certificate_oidc_issuer": "https://accounts.google.com",
+			},
+		}],
+		"unsigned-catalog": [{"pattern": "oci://registry.local/trusty*"}],
+	}}
+
+	# Passes because the unsigned-catalog rule has no sig verification requirement
+	tekton.is_trusted_task(trusted_bundle_task, _empty_bundle_manifests) with data.trusted_task_rules as rules
+		with ec.sigstore.verify_image as _mock_verify_image_failure
+}
+
+# Test: Git-resolved tasks are exempt from signature verification
+test_git_tasks_exempt_from_signature_verification if {
+	rules := {"allow": {"signed-catalog": [{
+		"pattern": "git\\+git\\.local/repo\\.git//*",
+		"signature_verification": {
+			"certificate_identity_regexp": "https://tekton.dev/chains/.*",
+			"certificate_oidc_issuer": "https://accounts.google.com",
+		},
+	}]}}
+
+	# Git task should pass even though ec.sigstore.verify_image would fail,
+	# because git tasks are exempt from signature verification
+	tekton.is_trusted_task(trusted_git_task, _empty_bundle_manifests) with data.trusted_task_rules as rules
+		with ec.sigstore.verify_image as _mock_verify_image_failure
+}
+
+# Test: denial_reason returns signature_verification_failed when pattern matches but sig fails
+test_denial_reason_signature_verification_failed if {
+	rules := {"allow": {"signed-catalog": [{
+		"pattern": "oci://registry.local/trusty*",
+		"signature_verification": {
+			"certificate_identity_regexp": "https://tekton.dev/chains/.*",
+			"certificate_oidc_issuer": "https://accounts.google.com",
+		},
+	}]}}
+
+	reason := tekton.denial_reason(trusted_bundle_task, _empty_bundle_manifests) with data.trusted_task_rules as rules
+		with ec.sigstore.verify_image as _mock_verify_image_failure
+
+	assertions.assert_equal("signature_verification_failed", reason.type)
+	assertions.assert_equal([], reason.pattern)
+	count(reason.messages) == 1
+	contains(reason.messages[0], "failed signature verification")
+}
+
+# Test: Schema validation accepts valid signature_verification on allow rules
+test_schema_accepts_signature_verification if {
+	rules := {"allow": {"signed-catalog": [{
+		"pattern": "oci://registry.local/trusty*",
+		"signature_verification": {
+			"certificate_identity_regexp": "https://tekton.dev/chains/.*",
+			"certificate_oidc_issuer": "https://accounts.google.com",
+			"ignore_rekor": true,
+		},
+	}]}}
+
+	# No data errors should be produced for valid signature_verification
+	assertions.assert_empty(tekton.data_errors) with data.rule_data.trusted_task_rules as rules
+}
+
+# Mock helpers for signature verification tests
+_mock_verify_image_success(_, _) := {"success": true, "errors": []}
+
+_mock_verify_image_failure(_, _) := {"success": false, "errors": ["signature verification failed"]}
+
+# =============================================================================
 # BEGIN LEGACY TEST DATA (trusted_tasks)
 # DELETE THIS SECTION when removing legacy support.
 # =============================================================================

--- a/policy/lib/tekton/trusted_test.rego
+++ b/policy/lib/tekton/trusted_test.rego
@@ -989,6 +989,26 @@ test_schema_accepts_signature_verification if {
 	assertions.assert_empty(tekton.data_errors) with data.rule_data.trusted_task_rules as rules
 }
 
+# Test: Schema validation rejects empty signature_verification (would be silently permissive)
+test_schema_rejects_empty_signature_verification if {
+	rules := {"allow": {"signed-catalog": [{
+		"pattern": "oci://registry.local/trusty*",
+		"signature_verification": {},
+	}]}}
+
+	count(tekton.data_errors) > 0 with data.rule_data.trusted_task_rules as rules
+}
+
+# Test: Schema validation rejects signature_verification with only non-identity fields
+test_schema_rejects_signature_verification_without_identity if {
+	rules := {"allow": {"signed-catalog": [{
+		"pattern": "oci://registry.local/trusty*",
+		"signature_verification": {"ignore_rekor": true},
+	}]}}
+
+	count(tekton.data_errors) > 0 with data.rule_data.trusted_task_rules as rules
+}
+
 # Mock helpers for signature verification tests
 _mock_verify_image_success(_, _) := {"success": true, "errors": []}
 

--- a/policy/lib/tekton/trusted_test.rego
+++ b/policy/lib/tekton/trusted_test.rego
@@ -1189,6 +1189,146 @@ untrusted_git_task := {
 }
 
 # =============================================================================
+# SIGNATURE VERIFICATION TESTS
+# =============================================================================
+
+# Test: Allow rule without signing_identity works as before (backward compat)
+test_allow_rule_without_signing_identity if {
+	rules := {"allow": {"test-group": [{"pattern": "oci://registry.local/trusty*"}]}}
+
+	tekton.is_trusted_task(trusted_bundle_task, _empty_bundle_manifests) with data.trusted_task_rules as rules
+		with data.rule_data.trusted_task_rules_enabled as true
+}
+
+# Test: Allow rule with signing_identity passes when signature is valid
+test_allow_rule_with_valid_signature if {
+	rules := {"allow": {"signed-catalog": [{
+		"pattern": "oci://registry.local/trusty*",
+		"signing_identity": {
+			"certificate_identity_regexp": "https://tekton.dev/chains/.*",
+			"certificate_oidc_issuer": "https://accounts.google.com",
+		},
+	}]}}
+
+	tekton.is_trusted_task(trusted_bundle_task, _empty_bundle_manifests) with data.trusted_task_rules as rules
+		with data.rule_data.trusted_task_rules_enabled as true
+		with ec.sigstore.verify_image as _mock_verify_image_success
+}
+
+# Test: Allow rule with signing_identity fails when signature is invalid
+test_allow_rule_with_invalid_signature if {
+	rules := {"allow": {"signed-catalog": [{
+		"pattern": "oci://registry.local/trusty*",
+		"signing_identity": {
+			"certificate_identity_regexp": "https://tekton.dev/chains/.*",
+			"certificate_oidc_issuer": "https://accounts.google.com",
+		},
+	}]}}
+
+	not tekton.is_trusted_task(trusted_bundle_task, _empty_bundle_manifests) with data.trusted_task_rules as rules
+		with data.rule_data.trusted_task_rules_enabled as true
+		with ec.sigstore.verify_image as _mock_verify_image_failure
+}
+
+# Test: Multiple allow rules - task passes if any rule's pattern+signature match
+test_multiple_allow_rules_different_sig_configs if {
+	rules := {"allow": {
+		"signed-catalog": [{
+			"pattern": "oci://registry.local/trusty*",
+			"signing_identity": {
+				"certificate_identity_regexp": "https://tekton.dev/chains/.*",
+				"certificate_oidc_issuer": "https://accounts.google.com",
+			},
+		}],
+		"unsigned-catalog": [{"pattern": "oci://registry.local/trusty*"}],
+	}}
+
+	# Passes because the unsigned-catalog rule has no sig verification requirement
+	tekton.is_trusted_task(trusted_bundle_task, _empty_bundle_manifests) with data.trusted_task_rules as rules
+		with data.rule_data.trusted_task_rules_enabled as true
+		with ec.sigstore.verify_image as _mock_verify_image_failure
+}
+
+# Test: Git-resolved tasks are exempt from signature verification
+test_git_tasks_exempt_from_signing_identity if {
+	rules := {"allow": {"signed-catalog": [{
+		"pattern": "git\\+git\\.local/repo\\.git//*",
+		"signing_identity": {
+			"certificate_identity_regexp": "https://tekton.dev/chains/.*",
+			"certificate_oidc_issuer": "https://accounts.google.com",
+		},
+	}]}}
+
+	# Git task should pass even though ec.sigstore.verify_image would fail,
+	# because git tasks are exempt from signature verification
+	tekton.is_trusted_task(trusted_git_task, _empty_bundle_manifests) with data.trusted_task_rules as rules
+		with data.rule_data.trusted_task_rules_enabled as true
+		with ec.sigstore.verify_image as _mock_verify_image_failure
+}
+
+# Test: denial_reason returns signing_identity_failed when pattern matches but sig fails
+test_denial_reason_signing_identity_failed if {
+	rules := {"allow": {"signed-catalog": [{
+		"pattern": "oci://registry.local/trusty*",
+		"signing_identity": {
+			"certificate_identity_regexp": "https://tekton.dev/chains/.*",
+			"certificate_oidc_issuer": "https://accounts.google.com",
+		},
+	}]}}
+
+	reason := tekton.denial_reason(trusted_bundle_task, _empty_bundle_manifests) with data.trusted_task_rules as rules
+		with data.rule_data.trusted_task_rules_enabled as true
+		with ec.sigstore.verify_image as _mock_verify_image_failure
+
+	assertions.assert_equal("signing_identity_failed", reason.type)
+	assertions.assert_equal(["oci://registry.local/trusty*"], reason.pattern)
+	count(reason.messages) == 1
+	contains(reason.messages[0], "failed signature verification")
+	contains(reason.messages[0], "oci://registry.local/trusty*")
+	contains(reason.messages[0], "certificate_identity_regexp")
+}
+
+# Test: Schema validation accepts valid signing_identity on allow rules
+test_schema_accepts_signing_identity if {
+	rules := {"allow": {"signed-catalog": [{
+		"pattern": "oci://registry.local/trusty*",
+		"signing_identity": {
+			"certificate_identity_regexp": "https://tekton.dev/chains/.*",
+			"certificate_oidc_issuer": "https://accounts.google.com",
+			"ignore_rekor": true,
+		},
+	}]}}
+
+	# No data errors should be produced for valid signing_identity
+	assertions.assert_empty(tekton.data_errors) with data.rule_data.trusted_task_rules as rules
+}
+
+# Test: Schema validation rejects empty signing_identity (would be silently permissive)
+test_schema_rejects_empty_signing_identity if {
+	rules := {"allow": {"signed-catalog": [{
+		"pattern": "oci://registry.local/trusty*",
+		"signing_identity": {},
+	}]}}
+
+	count(tekton.data_errors) > 0 with data.rule_data.trusted_task_rules as rules
+}
+
+# Test: Schema validation rejects signing_identity with only non-identity fields
+test_schema_rejects_signing_identity_without_identity if {
+	rules := {"allow": {"signed-catalog": [{
+		"pattern": "oci://registry.local/trusty*",
+		"signing_identity": {"ignore_rekor": true},
+	}]}}
+
+	count(tekton.data_errors) > 0 with data.rule_data.trusted_task_rules as rules
+}
+
+# Mock helpers for signature verification tests
+_mock_verify_image_success(_, _) := {"success": true, "errors": []}
+
+_mock_verify_image_failure(_, _) := {"success": false, "errors": ["signature verification failed"]}
+
+# =============================================================================
 # BEGIN LEGACY TEST DATA (trusted_tasks)
 # DELETE THIS SECTION when removing legacy support.
 # =============================================================================

--- a/policy/release/trusted_task/trusted_task.rego
+++ b/policy/release/trusted_task/trusted_task.rego
@@ -455,6 +455,11 @@ _format_denial_reason(reason) := msg if {
 
 	pattern_lines := [sprintf("  - %s", [pattern]) | some pattern in reason.pattern]
 	msg := sprintf("%s\n%s", [reason.type, concat("\n", pattern_lines)])
+} else := msg if {
+	reason.type == "signature_verification_failed"
+	count(reason.messages) > 0
+	message_lines := [sprintf("  - %s", [m]) | some m in reason.messages]
+	msg := sprintf("%s\n%s", [reason.type, concat("\n", message_lines)])
 } else := reason.type
 
 # Format error for rules system with Trusted Artifacts

--- a/policy/release/trusted_task/trusted_task_test.rego
+++ b/policy/release/trusted_task/trusted_task_test.rego
@@ -1340,6 +1340,37 @@ test_mixed_trusted_and_untrusted_tasks if {
 		with ec.oci.image_manifest as _mock_image_manifest
 }
 
+test_signature_verification_failed_error_rules if {
+	att := {"statement": {
+		"predicateType": "https://slsa.dev/provenance/v0.2",
+		"predicate": {
+			"buildType": lib.tekton_pipeline_run,
+			"buildConfig": {"tasks": [trusted_bundle_pipeline_task]},
+		},
+	}}
+
+	rules := {"allow": {"signed-catalog": [{
+		"pattern": "oci://registry.local/trusty*",
+		"signature_verification": {
+			"certificate_identity_regexp": "https://tekton.dev/chains/.*",
+			"certificate_oidc_issuer": "https://accounts.google.com",
+		},
+	}]}}
+
+	results := trusted_task.deny with input.attestations as [att]
+		with data.trusted_task_rules as rules
+		with ec.sigstore.verify_image as _mock_verify_image_failure
+		with ec.oci.image_manifests as _mock_empty_manifests
+
+	count(results) > 0
+	some result in results
+	contains(result.msg, "signature_verification_failed")
+}
+
+_mock_verify_image_failure(_, _) := {"success": false, "errors": ["signature verification failed"]}
+
+_mock_empty_manifests(_) := {}
+
 #####################################################
 # Helper Functions for trusted_task_rules tests
 #####################################################

--- a/policy/release/trusted_task/trusted_task_test.rego
+++ b/policy/release/trusted_task/trusted_task_test.rego
@@ -1358,6 +1358,38 @@ test_mixed_trusted_and_untrusted_tasks if {
 		with ec.oci.image_manifest as _mock_image_manifest
 }
 
+test_signing_identity_failed_error_rules if {
+	att := {"statement": {
+		"predicateType": "https://slsa.dev/provenance/v0.2",
+		"predicate": {
+			"buildType": lib.tekton_pipeline_run,
+			"buildConfig": {"tasks": [trusted_bundle_pipeline_task]},
+		},
+	}}
+
+	rules := {"allow": {"signed-catalog": [{
+		"pattern": "oci://registry.local/trusty*",
+		"signing_identity": {
+			"certificate_identity_regexp": "https://tekton.dev/chains/.*",
+			"certificate_oidc_issuer": "https://accounts.google.com",
+		},
+	}]}}
+
+	results := trusted_task.deny with input.attestations as [att]
+		with data.trusted_task_rules as rules
+		with data.rule_data.trusted_task_rules_enabled as true
+		with ec.sigstore.verify_image as _mock_verify_image_failure
+		with ec.oci.image_manifests as _mock_empty_manifests
+
+	count(results) > 0
+	some result in results
+	contains(result.msg, "signing_identity_failed")
+}
+
+_mock_verify_image_failure(_, _) := {"success": false, "errors": ["signature verification failed"]}
+
+_mock_empty_manifests(_) := {}
+
 #####################################################
 # Helper Functions for trusted_task_rules tests
 #####################################################


### PR DESCRIPTION
## Summary

Today, `trusted_task_rules` trusts task bundles based solely on URL pattern matching — if the bundle ref matches `oci://quay.io/konflux-ci/tekton-catalog/*`, it's trusted. This PR adds an optional `signature_verification` field on allow rules so that matching bundles must also have a verified sigstore signature from a specific identity.

This is per-allow-rule because different catalogs may be signed by different parties (e.g., Konflux catalog vs. a third-party catalog). Rules without the field work exactly as before.

Changes:
- Add optional `signature_verification` config to allow rules in `trusted_task_rules`
- Git-resolved tasks are exempt (`ec.sigstore.verify_image` only works on OCI refs)
- New `signature_verification_failed` denial reason type with proper error formatting

Companion CLI PR: conforma/cli#3136 (caches `ec.sigstore.verify_image` results across component evaluations for performance).

Ref: EC-1545

## Test plan

- [x] All tests pass (868/868, 100% coverage)
- [ ] Manual testing with real signed/unsigned task bundles
- [ ] Verify backward compatibility with existing policy configurations