### PR TITLE
Use image manifest to resolve tag-based SBOM refs

### DIFF
--- a/policy/lib/oci/oci.rego
+++ b/policy/lib/oci/oci.rego
@@ -1,0 +1,16 @@
+package lib.oci
+
+import data.lib.image
+import rego.v1
+
+# blob_from_image fetches the blob content of the first layer from an OCI
+# image manifest identified by ref. This is useful when ref is a tag-based
+# reference where ec.oci.blob cannot be used directly because it requires
+# digest-based references.
+blob_from_image(ref) := blob if {
+	parsed := image.parse(ref)
+	manifest := ec.oci.image_manifest(ref)
+	layer := manifest.layers[0]
+	blob_ref := image.str({"repo": parsed.repo, "digest": layer.digest})
+	blob := ec.oci.blob(blob_ref)
+}

--- a/policy/lib/oci/oci_test.rego
+++ b/policy/lib/oci/oci_test.rego
@@ -1,0 +1,67 @@
+package lib.oci_test
+
+import rego.v1
+
+import data.lib.oci
+
+test_blob_from_image if {
+	ref := "registry.io/repository/image:some-tag"
+	manifest := {"layers": [{
+		"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+		"digest": "sha256:abc123",
+		"size": 42,
+	}]}
+
+	result := oci.blob_from_image(ref) with ec.oci.image_manifest as manifest
+		with ec.oci.blob as _mock_blob
+
+	result == "blob content"
+}
+
+test_blob_from_image_with_digest_ref if {
+	ref := "registry.io/repository/image@sha256:def456"
+	manifest := {"layers": [{
+		"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+		"digest": "sha256:abc123",
+		"size": 42,
+	}]}
+
+	result := oci.blob_from_image(ref) with ec.oci.image_manifest as manifest
+		with ec.oci.blob as _mock_blob
+
+	result == "blob content"
+}
+
+test_blob_from_image_empty_layers if {
+	manifest := {"layers": []}
+
+	not oci.blob_from_image("registry.io/repository/image:tag") with ec.oci.image_manifest as manifest
+		with ec.oci.blob as _mock_blob
+}
+
+# Verify the helper selects the first layer, not an arbitrary one.
+test_blob_from_image_multi_layer if {
+	manifest := {"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:first",
+			"size": 10,
+		},
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:second",
+			"size": 20,
+		},
+	]}
+
+	result := oci.blob_from_image("registry.io/repo/img:tag") with ec.oci.image_manifest as manifest
+		with ec.oci.blob as _mock_blob_multi
+
+	result == "first blob"
+}
+
+# Mock that only returns a value for the expected digest ref, verifying
+# that blob_from_image constructs the correct ref from the layer digest.
+_mock_blob("registry.io/repository/image@sha256:abc123") := "blob content"
+
+_mock_blob_multi("registry.io/repo/img@sha256:first") := "first blob"

--- a/policy/lib/sbom/sbom.rego
+++ b/policy/lib/sbom/sbom.rego
@@ -5,6 +5,7 @@ import data.lib.rule_data
 
 import data.lib.image
 import data.lib.json as j
+import data.lib.oci
 import data.lib.tekton
 import rego.v1
 
@@ -91,10 +92,12 @@ _sboms_from_referrers contains sbom if {
 }
 
 # Discover SBOMs via legacy cosign tag-based conventions (.sbom suffix).
+# Tag refs point to OCI images, so we fetch the manifest and extract the
+# blob from its first layer using blob_from_image.
 _sboms_from_tag_refs contains sbom if {
 	some ref in ec.oci.image_tag_refs(input.image.ref)
 	endswith(ref, ".sbom")
-	blob := ec.oci.blob(ref)
+	blob := oci.blob_from_image(ref)
 	sbom := json.unmarshal(blob)
 }
 

--- a/policy/lib/sbom/sbom_test.rego
+++ b/policy/lib/sbom/sbom_test.rego
@@ -235,6 +235,7 @@ test_cyclonedx_sboms_from_tag_refs if {
 		with input.image as _cyclonedx_image
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as mock_tag_refs
+		with ec.oci.image_manifest as _mock_sbom_manifest
 		with ec.oci.blob as mock_ec_oci_cyclonedx_blob
 }
 
@@ -246,6 +247,7 @@ test_spdx_sboms_from_tag_refs if {
 		with input.image as _spdx_image
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as mock_tag_refs
+		with ec.oci.image_manifest as _mock_sbom_manifest
 		with ec.oci.blob as mock_ec_oci_spdx_blob
 }
 
@@ -277,3 +279,9 @@ test_no_sboms_from_non_sbom_tag_refs if {
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as mock_tag_refs
 }
+
+_mock_sbom_manifest := {"layers": [{
+	"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+	"digest": "sha256:f0cacc1a000000000000000000000000000000000000000000000000f0cacc1a",
+	"size": 100,
+}]}


### PR DESCRIPTION
Tag-based references from ec.oci.image_tag_refs (e.g. repo:sha256-abc.sbom)
cannot be passed directly to ec.oci.blob, which only accepts digest refs.
This adds a lib.oci.blob_from_image helper that fetches the image manifest
and extracts blob content from its first layer, then updates
_sboms_from_tag_refs to use it.

This follows the existing pattern in cve.rego and aligns with reviewer
feedback on https://github.com/conforma/cli/pull/3214 (@lcarva, @simonbaird) to keep ec.oci.blob digest-only and
compose at the Rego level instead.

Ref: https://issues.redhat.com/browse/EC-1748

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>