### PR TITLE
Support configurable SLSA v1 and v0.2 buildType via rule_data

### DIFF
--- a/policy/lib/rule_data/rule_data.rego
+++ b/policy/lib/rule_data/rule_data.rego
@@ -147,6 +147,16 @@ defaults := {
 	# Allowed proxy URL regex patterns per PURL type
 	# e.g., {"maven": ["^https://maven-proxy\\.example\\.com/.*"]}
 	"allowed_proxy_url_patterns": {},
+	#
+	# Used in release/lib/attestations.rego
+	# Allowed provenance buildTypes for PipelineRun attestations (both SLSA v0.2 and v1)
+	"allowed_provenance_build_types": [
+		"tekton.dev/v1/PipelineRun",
+		"tekton.dev/v1beta1/PipelineRun",
+		"https://tekton.dev/attestations/chains/pipelinerun@v2",
+		"https://tekton.dev/chains/v2/slsa",
+		"https://tekton.dev/chains/v2/slsa-tekton",
+	],
 }
 
 # Returns the "first found" of the following:

--- a/policy/release/lib/attestations.rego
+++ b/policy/release/lib/attestations.rego
@@ -2,6 +2,7 @@ package lib
 
 import rego.v1
 
+import data.lib.rule_data
 import data.lib.tekton
 
 slsa_provenance_predicate_type_v1 := "https://slsa.dev/provenance/v1"
@@ -10,18 +11,12 @@ slsa_provenance_predicate_type_v02 := "https://slsa.dev/provenance/v0.2"
 
 tekton_pipeline_run := "tekton.dev/v1/PipelineRun"
 
-pipelinerun_att_build_types := {
-	tekton_pipeline_run,
-	# Legacy build types
-	"tekton.dev/v1beta1/PipelineRun",
-	"https://tekton.dev/attestations/chains/pipelinerun@v2",
-}
-
 tekton_slsav1_pipeline_run := "https://tekton.dev/chains/v2/slsa-tekton"
 
-slsav1_pipelinerun_att_build_types := {
-	"https://tekton.dev/chains/v2/slsa",
-	tekton_slsav1_pipeline_run,
+# All allowed provenance buildTypes, sourced from rule_data. The defaults include
+# all known Tekton buildTypes for both SLSA v0.2 and v1.
+_allowed_provenance_build_types := {t |
+	some t in rule_data.get("allowed_provenance_build_types")
 }
 
 tekton_task_run := "tekton.dev/v1/TaskRun"
@@ -104,7 +99,7 @@ latest_v1_pipelinerun_attestation := [pipelinerun_slsa_provenance_v1[0]] if {
 
 pipelinerun_slsa_provenance02 := [att |
 	some att in input.attestations
-	att.statement.predicate.buildType in pipelinerun_att_build_types
+	att.statement.predicate.buildType in _allowed_provenance_build_types
 ]
 
 # TODO: Make this work with pipelinerun_attestations above so policy rules can be
@@ -113,15 +108,23 @@ pipelinerun_slsa_provenance_v1 := [att |
 	some att in input.attestations
 	att.statement.predicateType == slsa_provenance_predicate_type_v1
 
-	att.statement.predicate.buildDefinition.buildType in slsav1_pipelinerun_att_build_types
+	build_type := att.statement.predicate.buildDefinition.buildType
+	build_type in _allowed_provenance_build_types
 
-	# TODO: Workaround to distinguish between taskrun and pipelinerun attestations
-	spec_keys := object.keys(att.statement.predicate.buildDefinition.externalParameters.runSpec)
-
-	pipeline_keys := {"pipelineRef", "pipelineSpec"}
-
-	count(pipeline_keys - spec_keys) != count(pipeline_keys)
+	# Exclude attestations that are identifiably TaskRun attestations (have runSpec
+	# with task keys but no pipeline keys). Everything else passes through: PipelineRun
+	# attestations (runSpec with pipelineRef/pipelineSpec), non-Tekton attestations
+	# (no runSpec at all), and malformed attestations (caught by downstream rules).
+	_is_pipelinerun_v1(att)
 ]
+
+default _is_pipelinerun_v1(_) := true
+
+_is_pipelinerun_v1(att) := false if {
+	spec_keys := object.keys(att.statement.predicate.buildDefinition.externalParameters.runSpec)
+	pipeline_keys := {"pipelineRef", "pipelineSpec"}
+	count(pipeline_keys - spec_keys) == count(pipeline_keys)
+}
 
 # These ones we don't care about any more
 taskrun_attestations := [att |

--- a/policy/release/lib/attestations_test.rego
+++ b/policy/release/lib/attestations_test.rego
@@ -234,7 +234,15 @@ test_pipelinerun_slsa_provenance_v1 if {
 			"value": {"taskRef": {}},
 		}]),
 	]
-	expected := [provenance_with_pr_spec, provenance_with_pr_ref]
+
+	# Attestations with no runSpec (e.g. empty externalParameters) are included
+	# because the runSpec guard only applies when runSpec exists.
+	provenance_no_run_spec := json.patch(provenance_with_pr_spec, [{
+		"op": "add",
+		"path": "/statement/predicate/buildDefinition/externalParameters",
+		"value": {},
+	}])
+	expected := [provenance_with_pr_spec, provenance_with_pr_ref, provenance_no_run_spec]
 	assertions.assert_equal(expected, lib.pipelinerun_slsa_provenance_v1) with input.attestations as attestations
 }
 
@@ -581,4 +589,58 @@ test_pipelinerun_attestations_v1_single_no_timestamp if {
 	}}
 	expected := [v1_att]
 	assertions.assert_equal(expected, lib.pipelinerun_attestations) with input.attestations as [v1_att]
+}
+
+test_custom_v02_build_type if {
+	# A non-Tekton v0.2 buildType should be recognized when added via rule_data
+	custom_type := "https://pnc.example.com/v1/PipelineRun"
+	att := {"statement": {
+		"predicateType": "https://slsa.dev/provenance/v0.2",
+		"predicate": {
+			"buildType": custom_type,
+			"metadata": {"buildFinishedOn": "2025-01-15T10:30:00Z"},
+		},
+	}}
+
+	# Without rule_data, the custom buildType is not recognized
+	assertions.assert_equal([], lib.pipelinerun_slsa_provenance02) with input.attestations as [att]
+
+	# With rule_data including the custom buildType (along with defaults), it is recognized
+	assertions.assert_equal([att], lib.pipelinerun_slsa_provenance02) with input.attestations as [att]
+		with data.rule_data__configuration__ as {"allowed_provenance_build_types": [custom_type]}
+}
+
+test_custom_v1_build_type if {
+	# A non-Tekton v1 buildType should be recognized when added via rule_data
+	# and should NOT require the runSpec/pipelineRef/pipelineSpec guard
+	custom_type := "https://pnc.example.com/v1/slsa"
+	att := {"statement": {
+		"predicateType": "https://slsa.dev/provenance/v1",
+		"predicate": {"buildDefinition": {
+			"buildType": custom_type,
+			"externalParameters": {"some_param": "some_value"},
+		}},
+	}}
+
+	# Without rule_data, the custom buildType is not recognized
+	assertions.assert_equal([], lib.pipelinerun_slsa_provenance_v1) with input.attestations as [att]
+
+	# With rule_data including the custom buildType, it is recognized and does not
+	# need the runSpec guard
+	assertions.assert_equal([att], lib.pipelinerun_slsa_provenance_v1) with input.attestations as [att]
+		with data.rule_data__configuration__ as {"allowed_provenance_build_types": [custom_type]}
+}
+
+test_custom_v1_build_type_tekton_still_guarded if {
+	# Tekton v1 buildTypes should still require the runSpec guard
+	tekton_att_with_task_ref := {"statement": {
+		"predicateType": "https://slsa.dev/provenance/v1",
+		"predicate": {"buildDefinition": {
+			"buildType": "https://tekton.dev/chains/v2/slsa",
+			"externalParameters": {"runSpec": {"taskRef": {}}},
+		}},
+	}}
+
+	# Tekton buildType with taskRef should still be filtered out
+	assertions.assert_equal([], lib.pipelinerun_slsa_provenance_v1) with input.attestations as [tekton_att_with_task_ref]
 }


### PR DESCRIPTION
Allow users to configure the allowed provenance buildTypes via a single
rule_data key (allowed_provenance_build_types) instead of hardcoding
them. All Tekton buildTypes are included as defaults. Non-Tekton
attestations skip the Tekton-specific runSpec guard entirely based on
the structural presence of runSpec, not the buildType.

Ref: https://issues.redhat.com/browse/EC-1749

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>