### PR TITLE
feat(EC-1722): add policy rule to verify hermetic builds enable Sonatype proxy

### DIFF
--- a/acceptance/samples/policy-input-golden-container.json
+++ b/acceptance/samples/policy-input-golden-container.json
@@ -476,6 +476,7 @@
                     "HERMETIC": "true",
                     "IMAGE": "quay.io/redhat-user-workloads/rhtap-contract-tenant/golden-container/golden-container:d11c0ada39f18f631ff4f54beafa72a9b62dcd7c-amd64",
                     "IMAGE_EXPIRES_AFTER": "",
+                    "enable-hermeto-proxy": "true",
                     "LABELS": [],
                     "PREFETCH_INPUT": "",
                     "PRIVILEGED_NESTED": "false",

--- a/antora/docs/modules/ROOT/pages/packages/release_hermetic_task.adoc
+++ b/antora/docs/modules/ROOT/pages/packages/release_hermetic_task.adoc
@@ -1,12 +1,25 @@
 = Hermetic task Package
 
-This package verifies that all the tasks in the attestation that are required to be hermetic were invoked with the proper parameters to perform a hermetic execution.
+This package verifies that all the tasks in the attestation that are required to be hermetic were invoked with the proper parameters to perform a hermetic execution, including enabling the Sonatype proxy when required.
 
 == Package Name
 
 * `hermetic_task`
 
 == Rules Included
+
+[#hermetic_task__hermeto_proxy_enabled]
+=== link:#hermetic_task__hermeto_proxy_enabled[Hermetic build task has Sonatype proxy enabled]
+
+Verify that hermetic build tasks have the enable-hermeto-proxy parameter set to true. This ensures that hermetic builds use the Sonatype proxy for dependency resolution.
+
+*Solution*: Make sure the task has the input parameter 'enable-hermeto-proxy' set to 'true'.
+
+* Rule type: [rule-type-indicator failure]#FAILURE#
+* FAILURE message: `Task '%s' is hermetic but does not have the enable-hermeto-proxy parameter set to true`
+* Code: `hermetic_task.hermeto_proxy_enabled`
+* Effective from: `2026-06-01T00:00:00Z`
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/hermetic_task/hermetic_task.rego#L59[Source, window="_blank"]
 
 [#hermetic_task__hermetic]
 === link:#hermetic_task__hermetic[Task called with hermetic param set]
@@ -18,7 +31,7 @@ Verify the task in the PipelineRun attestation was invoked with the proper param
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Task '%s' was not invoked with the hermetic parameter set`
 * Code: `hermetic_task.hermetic`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/hermetic_task/hermetic_task.rego#L19[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/hermetic_task/hermetic_task.rego#L20[Source, window="_blank"]
 
 [#hermetic_task__proxy_rule_data_format]
 === link:#hermetic_task__proxy_rule_data_format[proxy_enabled_purl_types format]
@@ -28,4 +41,4 @@ Confirm the `proxy_enabled_purl_types` and `allowed_proxy_url_patterns` rule dat
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `hermetic_task.proxy_rule_data_format`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/hermetic_task/hermetic_task.rego#L41[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/hermetic_task/hermetic_task.rego#L42[Source, window="_blank"]

--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -122,6 +122,7 @@ Rules included:
 * xref:packages/release_cve.adoc#cve__cve_warnings[CVE checks: Non-blocking CVE check]        
 * xref:packages/release_cve.adoc#cve__unpatched_cve_warnings[CVE checks: Non-blocking unpatched CVE check]        
 * xref:packages/release_cve.adoc#cve__rule_data_provided[CVE checks: Rule data provided]        
+* xref:packages/release_hermetic_task.adoc#hermetic_task__hermeto_proxy_enabled[Hermetic task: Hermetic build task has Sonatype proxy enabled]        
 * xref:packages/release_hermetic_task.adoc#hermetic_task__hermetic[Hermetic task: Task called with hermetic param set]        
 * xref:packages/release_hermetic_task.adoc#hermetic_task__proxy_rule_data_format[Hermetic task: proxy_enabled_purl_types format]        
 * xref:packages/release_labels.adoc#labels__deprecated_labels[Labels: Deprecated labels]        
@@ -383,7 +384,7 @@ a| Check that the build has an expected target git branch. The specific branches
 a| Verify attributes on the certificate involved in the image signature when using slsa-github-generator on GitHub Actions with Sigstore Fulcio
 
 | xref:packages/release_hermetic_task.adoc[hermetic_task]
-a| This package verifies that all the tasks in the attestation that are required to be hermetic were invoked with the proper parameters to perform a hermetic execution.
+a| This package verifies that all the tasks in the attestation that are required to be hermetic were invoked with the proper parameters to perform a hermetic execution, including enabling the Sonatype proxy when required.
 
 | xref:packages/release_labels.adoc[labels]
 a| Check if the image has the expected labels set. The rules in this package distinguish file-based catalog (FBC) images from all other images. When checking an FBC image, a policy rule may use a different set of rule data. An FBC image is detected by the presence of the operators.operatorframework.io.index.configs.v1 label.

--- a/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
+++ b/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
@@ -44,6 +44,7 @@
 **** xref:packages/release_github_certificate.adoc#github_certificate__gh_workflow_trigger[GitHub Workflow Trigger]
 **** xref:packages/release_github_certificate.adoc#github_certificate__rule_data_provided[Rule data provided]
 *** xref:packages/release_hermetic_task.adoc[Hermetic task]
+**** xref:packages/release_hermetic_task.adoc#hermetic_task__hermeto_proxy_enabled[Hermetic build task has Sonatype proxy enabled]
 **** xref:packages/release_hermetic_task.adoc#hermetic_task__hermetic[Task called with hermetic param set]
 **** xref:packages/release_hermetic_task.adoc#hermetic_task__proxy_rule_data_format[proxy_enabled_purl_types format]
 *** xref:packages/release_labels.adoc[Labels]

--- a/policy/release/hermetic_task/hermetic_task.rego
+++ b/policy/release/hermetic_task/hermetic_task.rego
@@ -4,7 +4,8 @@
 # description: >-
 #   This package verifies that all the tasks in the attestation that
 #   are required to be hermetic were invoked with the proper
-#   parameters to perform a hermetic execution.
+#   parameters to perform a hermetic execution, including enabling
+#   the Sonatype proxy when required.
 #
 package hermetic_task
 
@@ -55,18 +56,56 @@ deny contains result if {
 	result := metadata.result_helper_with_severity(rego.metadata.chain(), [error.message], error.severity)
 }
 
+# METADATA
+# title: Hermetic build task has Sonatype proxy enabled
+# description: >-
+#   Verify that hermetic build tasks have the enable-hermeto-proxy
+#   parameter set to true. This ensures that hermetic builds use
+#   the Sonatype proxy for dependency resolution.
+# custom:
+#   short_name: hermeto_proxy_enabled
+#   failure_msg: >-
+#     Task '%s' is hermetic but does not have the enable-hermeto-proxy parameter set to true
+#   solution: >-
+#     Make sure the task has the input parameter 'enable-hermeto-proxy'
+#     set to 'true'.
+#   collections:
+#   - redhat
+#   depends_on:
+#   - attestation_type.known_attestation_type
+#   effective_on: 2026-06-01T00:00:00Z
+#
+deny contains result if {
+	some task in _hermetic_tasks_without_proxy
+	result := metadata.result_helper(rego.metadata.chain(), [tekton.task_name(task)])
+}
+
 _not_hermetic_tasks contains task if {
+	some task in _required_hermetic_tasks
+	not _task_is_hermetic(task)
+}
+
+_hermetic_tasks_without_proxy contains task if {
+	some task in _required_hermetic_tasks
+	_task_is_hermetic(task)
+	not _task_has_proxy_enabled(task)
+}
+
+_required_hermetic_tasks contains task if {
 	required_hermetic_tasks := rule_data.get("required_hermetic_tasks")
 	some attestation in lib.pipelinerun_attestations
 	some task in tekton.tasks(attestation)
 	some required_hermetic_task in required_hermetic_tasks
 	tekton.task_name(task) == required_hermetic_task
-	not _task_is_hermetic(task)
 }
 
 _task_is_hermetic(task) if {
 	tekton.task_param(task, "HERMETIC")
 	tekton.task_param(task, "HERMETIC") == "true"
+}
+
+_task_has_proxy_enabled(task) if {
+	tekton.task_param(task, "enable-hermeto-proxy") == "true"
 }
 
 # Verify proxy_enabled_purl_types is a list of unique strings.

--- a/policy/release/hermetic_task/hermetic_task_test.rego
+++ b/policy/release/hermetic_task/hermetic_task_test.rego
@@ -15,10 +15,10 @@ test_hermetic_task if {
 	_task_base := tekton_test.slsav1_task("buildah")
 	slsav1_task = tekton_test.with_params(
 		_task_base,
-		[{
-			"name": "HERMETIC",
-			"value": "true",
-		}],
+		[
+			{"name": "HERMETIC", "value": "true"},
+			{"name": "enable-hermeto-proxy", "value": "true"},
+		],
 	)
 
 	slsav1_attestation := tekton_test.slsav1_attestation([slsav1_task])
@@ -72,7 +72,7 @@ test_many_hermetic_tasks if {
 		],
 		# regal ignore:line-length
 		"ref": {"kind": "Task", "name": "buildah", "bundle": "reg.img/spam@sha256:abc0000000000000000000000000000000000000000000000000000000000abc"},
-		"invocation": {"parameters": {"HERMETIC": "true"}},
+		"invocation": {"parameters": {"HERMETIC": "true", "enable-hermeto-proxy": "true"}},
 	}
 
 	task2 := {
@@ -82,7 +82,7 @@ test_many_hermetic_tasks if {
 		],
 		# regal ignore:line-length
 		"ref": {"kind": "Task", "name": "run-script-oci-ta", "bundle": "reg.img/spam@sha256:abc0000000000000000000000000000000000000000000000000000000000abc"},
-		"invocation": {"parameters": {"HERMETIC": "true"}},
+		"invocation": {"parameters": {"HERMETIC": "true", "enable-hermeto-proxy": "true"}},
 	}
 
 	attestation := {"statement": {
@@ -98,19 +98,19 @@ test_many_hermetic_tasks if {
 	_task_base_1 := tekton_test.slsav1_task("buildah")
 	slsav1_task1 = tekton_test.with_params(
 		_task_base_1,
-		[{
-			"name": "HERMETIC",
-			"value": "true",
-		}],
+		[
+			{"name": "HERMETIC", "value": "true"},
+			{"name": "enable-hermeto-proxy", "value": "true"},
+		],
 	)
 
 	_task_base_2 := tekton_test.slsav1_task("run-script-oci-ta")
 	slsav1_task2 = tekton_test.with_params(
 		_task_base_2,
-		[{
-			"name": "HERMETIC",
-			"value": "true",
-		}],
+		[
+			{"name": "HERMETIC", "value": "true"},
+			{"name": "enable-hermeto-proxy", "value": "true"},
+		],
 	)
 
 	slsav1_attestation := tekton_test.slsav1_attestation([slsav1_task1, slsav1_task2])
@@ -166,10 +166,10 @@ test_many_hermetic_tasks if {
 	_base_mixed_1 := tekton_test.slsav1_task("buildah")
 	slsav1_task1_mixed = tekton_test.with_params(
 		_base_mixed_1,
-		[{
-			"name": "HERMETIC",
-			"value": "true",
-		}],
+		[
+			{"name": "HERMETIC", "value": "true"},
+			{"name": "enable-hermeto-proxy", "value": "true"},
+		],
 	)
 
 	_base_mixed_2 := tekton_test.slsav1_task("run-script-oci-ta")
@@ -323,6 +323,121 @@ test_proxy_rule_data_validation if {
 	assertions.assert_equal_results(expected_bad_regex, hermetic_task.deny) with data.rule_data as d_bad_regex
 }
 
+test_hermetic_task_with_proxy_enabled if {
+	# Hermetic task with proxy enabled - should pass
+	_task_base := tekton_test.slsav1_task("buildah")
+	slsav1_task = tekton_test.with_params(
+		_task_base,
+		[
+			{"name": "HERMETIC", "value": "true"},
+			{"name": "enable-hermeto-proxy", "value": "true"},
+		],
+	)
+
+	slsav1_attestation := tekton_test.slsav1_attestation([slsav1_task])
+	assertions.assert_empty(hermetic_task.deny) with input.attestations as [slsav1_attestation]
+		with data.rule_data.required_hermetic_tasks as ["buildah"]
+
+	# v0.2 attestation
+	assertions.assert_empty(hermetic_task.deny) with input.attestations as [_good_attestation]
+		with data.rule_data.required_hermetic_tasks as ["buildah"]
+}
+
+test_hermetic_task_without_proxy if {
+	expected := {{
+		"code": "hermetic_task.hermeto_proxy_enabled",
+		"msg": "Task 'buildah' is hermetic but does not have the enable-hermeto-proxy parameter set to true",
+	}}
+
+	# v0.2: hermetic but no proxy param
+	# regal ignore:line-length
+	no_proxy := json.remove(_good_attestation, ["/statement/predicate/buildConfig/tasks/0/invocation/parameters/enable-hermeto-proxy"])
+	assertions.assert_equal_results(expected, hermetic_task.deny) with input.attestations as [no_proxy]
+		with data.rule_data.required_hermetic_tasks as ["buildah"]
+
+	# v0.2: hermetic with proxy set to false
+	proxy_false := json.patch(_good_attestation, [{
+		"op": "replace",
+		"path": "/statement/predicate/buildConfig/tasks/0/invocation/parameters/enable-hermeto-proxy",
+		"value": "false",
+	}])
+	assertions.assert_equal_results(expected, hermetic_task.deny) with input.attestations as [proxy_false]
+		with data.rule_data.required_hermetic_tasks as ["buildah"]
+
+	# slsa v1: hermetic but no proxy param
+	_task_base := tekton_test.slsav1_task("buildah")
+	slsav1_task = tekton_test.with_params(
+		_task_base,
+		[{"name": "HERMETIC", "value": "true"}],
+	)
+	slsav1_attestation := tekton_test.slsav1_attestation([slsav1_task])
+	assertions.assert_equal_results(expected, hermetic_task.deny) with input.attestations as [slsav1_attestation]
+		with data.rule_data.required_hermetic_tasks as ["buildah"]
+
+	# slsa v1: hermetic with proxy set to false
+	slsav1_task_proxy_false = tekton_test.with_params(
+		_task_base,
+		[
+			{"name": "HERMETIC", "value": "true"},
+			{"name": "enable-hermeto-proxy", "value": "false"},
+		],
+	)
+	slsav1_att_proxy_false := tekton_test.slsav1_attestation([slsav1_task_proxy_false])
+	assertions.assert_equal_results(expected, hermetic_task.deny) with input.attestations as [slsav1_att_proxy_false]
+		with data.rule_data.required_hermetic_tasks as ["buildah"]
+}
+
+test_non_hermetic_task_no_proxy_required if {
+	# Non-hermetic task without proxy - should pass (no proxy violation)
+	_task_base := tekton_test.slsav1_task("buildah")
+	slsav1_task_not_hermetic = tekton_test.with_params(
+		_task_base,
+		[{"name": "HERMETIC", "value": "false"}],
+	)
+	slsav1_attestation := tekton_test.slsav1_attestation([slsav1_task_not_hermetic])
+
+	# The hermetic rule will fire, but the proxy rule should not
+	results_no_proxy := hermetic_task.deny with input.attestations as [slsav1_attestation]
+		with data.rule_data.required_hermetic_tasks as ["buildah"]
+
+	not _has_proxy_violation(results_no_proxy)
+
+	# Hermetic task without proxy - proxy violation should be present
+	slsav1_task_hermetic = tekton_test.with_params(
+		_task_base,
+		[{"name": "HERMETIC", "value": "true"}],
+	)
+	slsav1_attestation_hermetic := tekton_test.slsav1_attestation([slsav1_task_hermetic])
+	results_with_proxy := hermetic_task.deny with input.attestations as [slsav1_attestation_hermetic]
+		with data.rule_data.required_hermetic_tasks as ["buildah"]
+
+	_has_proxy_violation(results_with_proxy)
+}
+
+test_task_has_proxy_enabled if {
+	task_with_proxy := tekton_test.resolved_slsav1_task(
+		"some-task",
+		[{"name": "enable-hermeto-proxy", "value": "true"}],
+		[],
+	)
+	hermetic_task._task_has_proxy_enabled(task_with_proxy)
+
+	task_proxy_false := tekton_test.resolved_slsav1_task(
+		"some-task",
+		[{"name": "enable-hermeto-proxy", "value": "false"}],
+		[],
+	)
+	not hermetic_task._task_has_proxy_enabled(task_proxy_false)
+
+	task_no_proxy := tekton_test.resolved_slsav1_task("some-task", [], [])
+	not hermetic_task._task_has_proxy_enabled(task_no_proxy)
+}
+
+_has_proxy_violation(results) if {
+	some result in results
+	result.code == "hermetic_task.hermeto_proxy_enabled"
+}
+
 _good_attestation := {"statement": {
 	"predicateType": "https://slsa.dev/provenance/v0.2",
 	"predicate": {
@@ -334,7 +449,7 @@ _good_attestation := {"statement": {
 			],
 			# regal ignore:line-length
 			"ref": {"kind": "Task", "name": "buildah", "bundle": "reg.img/spam@sha256:abc0000000000000000000000000000000000000000000000000000000000abc"},
-			"invocation": {"parameters": {"HERMETIC": "true"}},
+			"invocation": {"parameters": {"HERMETIC": "true", "enable-hermeto-proxy": "true"}},
 		}]},
 	},
 }}


### PR DESCRIPTION
## Summary
  - Adds `hermeto_proxy_enabled` rule to the `hermetic_task` package that denies when a hermetic build task does not have `enable-hermeto-proxy` set to `true`


  ## Jira
  https://redhat.atlassian.net/browse/EC-1722