### PR TITLE
Check for TEST_OUTPUT in RPM build tasks

### DIFF
--- a/policy/release/test/test.rego
+++ b/policy/release/test/test.rego
@@ -88,6 +88,30 @@ deny contains result if {
 }
 
 # METADATA
+# title: RPM Test data found in task results
+# description: >-
+#   This is a temporary duplicate of test_data_found. The RPM build pipeline
+#   will also require TEST_OUTPUT, but initially use a warning until we are certain
+#   everything works without breaking the build pipeline.
+# custom:
+#   short_name: rpm_test_data_found
+#   failure_msg: No RPM test data found
+#   solution: >-
+#     Confirm at least one task in the RPM build pipeline contains a result named TEST_OUTPUT.
+#   collections:
+#   - redhat_rpms
+#   depends_on:
+#   - attestation_type.known_attestation_type
+#
+warn contains result if {
+	count(lib.pipelinerun_attestations) > 0 # make sure we're looking at a PipelineRun attestation
+	results := lib.results_from_tests
+	count(results) == 0 # there are none at all
+
+	result := metadata.result_helper(rego.metadata.chain(), [])
+}
+
+# METADATA
 # title: Test data includes results key
 # description: >-
 #   Each test result is expected to have a `results` key. Verify that the `results`

--- a/policy/release/test/test_test.rego
+++ b/policy/release/test/test_test.rego
@@ -26,6 +26,24 @@ test_needs_non_empty_data if {
 	}}) with input.attestations as attestations
 }
 
+# Because TEST_OUTPUT isn't in the task results, the lib.results_from_tests will be empty
+test_rpm_needs_non_empty_data if {
+	_task_base := tekton_test.slsav1_task("task2")
+	slsav1_task = tekton_test.with_results(
+		_task_base,
+		[{"name": "NOT_TEST_OUTPUT", "type": "string", "value": {}}],
+	)
+
+	attestations := [
+		lib_test.att_mock_helper_ref("NOT_TEST_OUTPUT", {}, "task1", _bundle),
+		tekton_test.slsav1_attestation([slsav1_task]),
+	]
+	assertions.assert_equal_results(test.warn, {{
+		"code": "test.rpm_test_data_found",
+		"msg": "No RPM test data found",
+	}}) with input.attestations as attestations
+}
+
 # There is a test result, but the data inside it doesn't include the "result" key
 test_needs_tests_with_results if {
 	_task_base := tekton_test.slsav1_task("task2")


### PR DESCRIPTION
As with container builds, we want to verify that there's at least one
test run. This is a temporary duplicate set to warn, which will be removed
when we verify this change will not break the rpm build pipleline using the original
deny test.

JIRA: ROK-1119
