### PR TITLE
Add backwards compatibility shim for lib.result_helper functions

### DIFF
--- a/policy/lib/lib.rego
+++ b/policy/lib/lib.rego
@@ -1,0 +1,32 @@
+# Backwards compatibility shim for external users.
+#
+# This package provides deprecated aliases for functions that have been
+# reorganized into domain-specific packages. External demos, documentation,
+# and integrations may still reference the old data.lib.* paths.
+#
+# New code should import from the specific packages directly:
+# - data.lib.metadata.result_helper
+# - data.lib.metadata.result_helper_with_term
+# - data.lib.metadata.result_helper_with_severity
+package lib
+
+import rego.v1
+
+import data.lib.metadata
+
+# Deprecated: Use data.lib.metadata.result_helper instead
+result_helper(chain, failure_sprintf_params) := metadata.result_helper(chain, failure_sprintf_params)
+
+# Deprecated: Use data.lib.metadata.result_helper_with_term instead
+result_helper_with_term(chain, failure_sprintf_params, term) := metadata.result_helper_with_term(
+	chain,
+	failure_sprintf_params,
+	term,
+)
+
+# Deprecated: Use data.lib.metadata.result_helper_with_severity instead
+result_helper_with_severity(chain, failure_sprintf_params, severity) := metadata.result_helper_with_severity(
+	chain,
+	failure_sprintf_params,
+	severity,
+)

--- a/policy/lib/lib_test.rego
+++ b/policy/lib/lib_test.rego
@@ -1,0 +1,53 @@
+package lib_test
+
+import rego.v1
+
+import data.lib
+import data.lib.assertions
+
+# Test backwards compatibility shim works
+test_result_helper_backwards_compat if {
+	mock_chain := [{
+		"annotations": {"custom": {
+			"short_name": "test_rule",
+			"failure_msg": "Test failed with %s",
+		}},
+		"path": ["data", "test", "deny"],
+	}]
+
+	result := lib.result_helper(mock_chain, ["param1"])
+
+	assertions.assert_equal("test.test_rule", result.code)
+	assertions.assert_equal("Test failed with param1", result.msg)
+	result.effective_on # Should exist
+}
+
+test_result_helper_with_term_backwards_compat if {
+	mock_chain := [{
+		"annotations": {"custom": {
+			"short_name": "test_rule",
+			"failure_msg": "Test failed",
+		}},
+		"path": ["data", "test", "deny"],
+	}]
+
+	result := lib.result_helper_with_term(mock_chain, [], "test_term")
+
+	assertions.assert_equal("test.test_rule", result.code)
+	assertions.assert_equal("test_term", result.term)
+}
+
+test_result_helper_with_severity_backwards_compat if {
+	mock_chain := [{
+		"annotations": {"custom": {
+			"short_name": "test_rule",
+			"failure_msg": "Test failed",
+		}},
+		"path": ["data", "test", "deny"],
+	}]
+
+	result := lib.result_helper_with_severity(mock_chain, [], "warning")
+
+	assertions.assert_equal("test.test_rule", result.code)
+	assertions.assert_equal("warning", result.severity)
+}


### PR DESCRIPTION
Re-export result_helper functions at their original data.lib.* paths to maintain compatibility with external demos, documentation, and integrations that reference the old locations after reorganization to data.lib.metadata.*.

Provides deprecated aliases for:
- data.lib.result_helper
- data.lib.result_helper_with_term
- data.lib.result_helper_with_severity

New code should import from data.lib.metadata.* directly.