### PR TITLE
Extend CVE policy to accept TPA scan reports

### DIFF
--- a/antora/docs/modules/ROOT/pages/packages/release_cve.adoc
+++ b/antora/docs/modules/ROOT/pages/packages/release_cve.adoc
@@ -58,12 +58,12 @@ The SLSA Provenance attestation for the image is inspected to ensure CVEs that d
 [#cve__cve_results_found]
 === link:#cve__cve_results_found[CVE scan results found]
 
-Confirm that clair-scan task results are present in the SLSA Provenance attestation of the build pipeline.
+Confirm that CVE scan task results (Clair or TPA) are present in the SLSA Provenance attestation of the build pipeline.
 
-*Solution*: Make sure there is a successful task in the build pipeline that runs a Clair scan.
+*Solution*: Make sure there is a successful task in the build pipeline that runs a CVE scan (Clair or TPA).
 
 * Rule type: [rule-type-indicator failure]#FAILURE#
-* FAILURE message: `Clair CVE scan results were not found`
+* FAILURE message: `CVE scan results were not found`
 * Code: `cve.cve_results_found`
 * https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/cve/cve.rego#L185[Source, window="_blank"]
 

--- a/policy/release/cve/cve.rego
+++ b/policy/release/cve/cve.rego
@@ -185,14 +185,14 @@ deny contains result if {
 # METADATA
 # title: CVE scan results found
 # description: >-
-#   Confirm that clair-scan task results are present in the SLSA Provenance
+#   Confirm that CVE scan task results (Clair or TPA) are present in the SLSA Provenance
 #   attestation of the build pipeline.
 # custom:
 #   short_name: cve_results_found
-#   failure_msg: Clair CVE scan results were not found
+#   failure_msg: CVE scan results were not found
 #   solution: >-
 #     Make sure there is a successful task in the build pipeline that runs a
-#     Clair scan.
+#     CVE scan (Clair or TPA).
 #   collections:
 #   - minimal
 #   - redhat
@@ -277,7 +277,7 @@ _clair_report := report if {
 	report_manifest := ec.oci.image_manifest(report_ref)
 
 	some layer in report_manifest.layers
-	layer.mediaType == _report_oci_mime_type
+	layer.mediaType in _report_oci_mime_types
 	report_blob := object.union(input_image, {"digest": layer.digest})
 	report_blob_ref := image.str(report_blob)
 
@@ -288,7 +288,10 @@ _name(vuln) := object.get(vuln, "name", "UNKNOWN")
 
 _reports_result_name := "REPORTS"
 
-_report_oci_mime_type := "application/vnd.redhat.clair-report+json"
+_report_oci_mime_types := {
+	"application/vnd.redhat.clair-report+json",
+	"application/vnd.redhat.tpa-report+json",
+}
 
 _with_effective_on(result, effective_on) := object.union(
 	result,

--- a/policy/release/cve/cve_test.rego
+++ b/policy/release/cve/cve_test.rego
@@ -302,7 +302,7 @@ test_full_report_fetch_issue if {
 
 	expected := {{
 		"code": "cve.cve_results_found",
-		"msg": "Clair CVE scan results were not found",
+		"msg": "CVE scan results were not found",
 	}}
 
 	assertions.assert_equal_results(cve.deny, expected) with input.image.ref as ref
@@ -469,11 +469,11 @@ _clair_report := {"vulnerabilities": object.union(vulnerabilities, unpatched_vul
 
 _manifests := {
 	"registry.io/repository/image@sha256:report_digest": {"layers": [{
-		"mediaType": cve._report_oci_mime_type,
+		"mediaType": "application/vnd.redhat.clair-report+json",
 		"digest": "sha256:report_blob_digest",
 	}]},
 	"registry.io/repository/image@sha256:no_vulnerabilities_report_digest": {"layers": [{
-		"mediaType": cve._report_oci_mime_type,
+		"mediaType": "application/vnd.redhat.clair-report+json",
 		"digest": "sha256:no_vulnerabilities_report_blob_digest",
 	}]},
 }
@@ -511,3 +511,57 @@ _attestations_with_reports(reports) := attestations if {
 	att2 := tekton_test.slsav1_attestation([task_with_bundle])
 	attestations := [att1, att2]
 }
+
+test_success_with_tpa_report if {
+	assertions.assert_empty(cve.deny | cve.warn) with input.attestations as _no_vuln_attestations_tpa
+		with input.image.ref as "registry.io/repository/image@sha256:image_digest"
+		with ec.oci.image_manifest as _mock_image_manifest_tpa
+		with ec.oci.blob as _mock_blob
+}
+
+test_success_with_both_clair_and_tpa_reports if {
+	assertions.assert_empty(cve.deny | cve.warn) with input.attestations as _no_vuln_attestations
+		with input.image.ref as "registry.io/repository/image@sha256:image_digest"
+		with ec.oci.image_manifest as _mock_image_manifest_both
+		with ec.oci.blob as _mock_blob
+}
+
+_no_vuln_attestations_tpa := _attestations_with_reports({"sha256:image_digest": "sha256:no_vulnerabilities_tpa_report_digest"})
+
+_manifests_tpa := {
+	"registry.io/repository/image@sha256:report_digest": {"layers": [{
+		"mediaType": "application/vnd.redhat.tpa-report+json",
+		"digest": "sha256:report_blob_digest",
+	}]},
+	"registry.io/repository/image@sha256:no_vulnerabilities_tpa_report_digest": {"layers": [{
+		"mediaType": "application/vnd.redhat.tpa-report+json",
+		"digest": "sha256:no_vulnerabilities_report_blob_digest",
+	}]},
+}
+
+_mock_image_manifest_tpa(ref) := _manifests_tpa[ref]
+
+_manifests_both := {
+	"registry.io/repository/image@sha256:report_digest": {"layers": [
+		{
+			"mediaType": "application/vnd.redhat.clair-report+json",
+			"digest": "sha256:report_blob_digest",
+		},
+		{
+			"mediaType": "application/vnd.redhat.tpa-report+json",
+			"digest": "sha256:report_blob_digest",
+		},
+	]},
+	"registry.io/repository/image@sha256:no_vulnerabilities_report_digest": {"layers": [
+		{
+			"mediaType": "application/vnd.redhat.clair-report+json",
+			"digest": "sha256:no_vulnerabilities_report_blob_digest",
+		},
+		{
+			"mediaType": "application/vnd.redhat.tpa-report+json",
+			"digest": "sha256:no_vulnerabilities_report_blob_digest",
+		},
+	]},
+}
+
+_mock_image_manifest_both(ref) := _manifests_both[ref]


### PR DESCRIPTION
The TPA CVE scan report format is similar to the Clair report, so I just added the TPA media type (application/vnd.redhat.tpa-report+json) alongside the Clair media type.

Ref: https://redhat.atlassian.net/browse/EC-1770