### PR TITLE
Trusted task refactor

### DIFF
--- a/acceptance/testdata/trusted-task-rules-data.yml
+++ b/acceptance/testdata/trusted-task-rules-data.yml
@@ -16,9 +16,9 @@
 rule_data:
   trusted_task_rules:
     allow:
-      allow-konflux-tasks:
-        pattern: "oci://quay.io/konflux-ci/tekton-catalog/*"
+      konflux-tasks:
+        - pattern: "oci://quay.io/konflux-ci/tekton-catalog/*"
     deny:
-      deprecate-old-buildah-versions:
-        pattern: "oci://quay.io/konflux-ci/tekton-catalog/task-buildah"
-        versions: ["<=0.5"]
+      deprecated-buildah:
+        - pattern: "oci://quay.io/konflux-ci/tekton-catalog/task-buildah"
+          versions: ["<=0.5"]

--- a/acceptance/testdata/trusted-task-rules-data.yml
+++ b/acceptance/testdata/trusted-task-rules-data.yml
@@ -16,9 +16,9 @@
 rule_data:
   trusted_task_rules:
     allow:
-      - name: "Allow Konflux tasks"
+      allow-konflux-tasks:
         pattern: "oci://quay.io/konflux-ci/tekton-catalog/*"
     deny:
-      - name: "Deprecate old buildah versions"
+      deprecate-old-buildah-versions:
         pattern: "oci://quay.io/konflux-ci/tekton-catalog/task-buildah"
         versions: ["<=0.5"]

--- a/policy/lib/tekton/trusted.rego
+++ b/policy/lib/tekton/trusted.rego
@@ -142,34 +142,86 @@ _trusted_task_rules_data := {
 	),
 }
 
-# Safely extract allow from data.trusted_task_rules
+# Safely extract allow from data.trusted_task_rules.
+# Supports both array and object formats.
 default _data_allow_array := []
 
 _data_allow_array := data.trusted_task_rules.allow if {
 	is_object(data.trusted_task_rules)
+	is_array(data.trusted_task_rules.allow)
 }
 
-# Safely extract deny from data.trusted_task_rules
+_data_allow_array := [entry |
+	is_object(data.trusted_task_rules)
+	is_object(data.trusted_task_rules.allow)
+	some _, entry in data.trusted_task_rules.allow
+] if {
+	is_object(data.trusted_task_rules)
+	is_object(data.trusted_task_rules.allow)
+}
+
+# Safely extract deny from data.trusted_task_rules.
+# Supports both array and object formats.
 default _data_deny_array := []
 
 _data_deny_array := data.trusted_task_rules.deny if {
 	is_object(data.trusted_task_rules)
+	is_array(data.trusted_task_rules.deny)
 }
 
-# Safely extract allow from rule_data
+_data_deny_array := [entry |
+	is_object(data.trusted_task_rules)
+	is_object(data.trusted_task_rules.deny)
+	some _, entry in data.trusted_task_rules.deny
+] if {
+	is_object(data.trusted_task_rules)
+	is_object(data.trusted_task_rules.deny)
+}
+
+# Safely extract allow from rule_data.
+# Supports two formats:
+#   Array format:  {"allow": [{"name": "...", "pattern": "..."}, ...]}
+#   Object format: {"allow": {"my-key": {"pattern": "..."}, ...}}
+# The object format enables multiple data sources with the same key to be
+# merged by OPA without conflicts, since each entry has a unique map key.
 default _rule_data_allow_array := []
 
 _rule_data_allow_array := _rule_data_obj.allow if {
 	_rule_data_obj := lib_rule_data("trusted_task_rules")
 	is_object(_rule_data_obj)
+	is_array(_rule_data_obj.allow)
 }
 
-# Safely extract deny from rule_data
+_rule_data_allow_array := [entry |
+	_rule_data_obj := lib_rule_data("trusted_task_rules")
+	is_object(_rule_data_obj)
+	is_object(_rule_data_obj.allow)
+	some _, entry in _rule_data_obj.allow
+] if {
+	_rule_data_obj := lib_rule_data("trusted_task_rules")
+	is_object(_rule_data_obj)
+	is_object(_rule_data_obj.allow)
+}
+
+# Safely extract deny from rule_data.
+# Supports both array and object formats (same as allow above).
 default _rule_data_deny_array := []
 
 _rule_data_deny_array := _rule_data_obj.deny if {
 	_rule_data_obj := lib_rule_data("trusted_task_rules")
 	is_object(_rule_data_obj)
+	is_array(_rule_data_obj.deny)
+}
+
+_rule_data_deny_array := [entry |
+	_rule_data_obj := lib_rule_data("trusted_task_rules")
+	is_object(_rule_data_obj)
+	is_object(_rule_data_obj.deny)
+	some _, entry in _rule_data_obj.deny
+] if {
+	_rule_data_obj := lib_rule_data("trusted_task_rules")
+	is_object(_rule_data_obj)
+	is_object(_rule_data_obj.deny)
 }
 
 data_errors contains error if {
@@ -393,6 +445,51 @@ _pattern_matches(key, pattern) if {
 
 # Schema for trusted_task_rules as defined in trusted_tasks/trusted_task_rules.schema.json
 # This schema validates the rule-based trusted tasks configuration (ADR 53)
+# Schema definition for a single rule entry (used as object values in the object format)
+_trusted_task_rule_entry_schema := {
+	"type": "object",
+	"required": ["pattern"],
+	"properties": {
+		"pattern": {
+			"type": "string",
+			# regal ignore:line-length
+			"description": "URL pattern to match task references. Supports wildcards (*).",
+			"pattern": "^(oci://|git\\+)",
+		},
+		"effective_on": {
+			"type": "string",
+			"format": "date",
+			# regal ignore:line-length
+			"description": "Date when this rule becomes effective. If omitted, rule is effective immediately.",
+		},
+		"message": {
+			"type": "string",
+			"description": "User-visible message explaining why the task is denied",
+		},
+		"versions": {
+			"type": "array",
+			"description": "List of version constraints",
+			"items": {"type": "string"},
+		},
+	},
+	"additionalProperties": true,
+}
+
+# Array format item requires "name" since there is no map key to use
+_trusted_task_rule_array_item_schema := object.union(
+	_trusted_task_rule_entry_schema,
+	{
+		"required": ["name", "pattern"],
+		"properties": object.union(
+			_trusted_task_rule_entry_schema.properties,
+			{"name": {
+				"type": "string",
+				"description": "Human-readable name for the rule",
+			}},
+		),
+	},
+)
+
 _trusted_task_rules_schema := {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"$id": "https://konflux.io/schemas/trusted_task_rules.json",
@@ -401,80 +498,37 @@ _trusted_task_rules_schema := {
 	"type": "object",
 	"properties": {
 		"allow": {
-			"type": "array",
-			"description": "Rules that allow tasks matching the pattern",
-			"items": {
-				"type": "object",
-				"required": ["name", "pattern"],
-				"properties": {
-					"name": {
-						"type": "string",
-						"description": "Human-readable name for the rule",
-					},
-					"pattern": {
-						"type": "string",
-						# regal ignore:line-length
-						"description": "URL pattern to match task references. Must not include version tags (e.g., 'oci://quay.io/konflux-ci/tekton-catalog/*' not 'oci://quay.io/konflux-ci/tekton-catalog/task-buildah:0.4*'). Supports wildcards (*).",
-						"pattern": "^(oci://|git\\+)",
-					},
-					"effective_on": {
-						"type": "string",
-						"format": "date",
-						# regal ignore:line-length
-						"description": "Date when this rule becomes effective (e.g., '2025-02-01'). Rules with future effective_on dates are not considered. If omitted, rule is effective immediately.",
-					},
-					"versions": {
-						"type": "array",
-						"description": "List of version constraints to match only specific versions of the task",
-						"items": {
-							"type": "string",
-							"description": "Version constraint (e.g., '>=2.1', '<1.2.3')",
-						},
-					},
+			"oneOf": [
+				{
+					"type": "array",
+					"description": "Rules that allow tasks matching the pattern (array format)",
+					"items": _trusted_task_rule_array_item_schema,
+					"default": [],
 				},
-				"additionalProperties": true,
-			},
-			"default": [],
+				{
+					"type": "object",
+					# regal ignore:line-length
+					"description": "Rules that allow tasks matching the pattern (object format, keyed by name)",
+					"additionalProperties": _trusted_task_rule_entry_schema,
+				},
+			],
 		},
 		"deny": {
-			"type": "array",
-			"description": "Rules that deny tasks matching the pattern. Deny rules take precedence over allow rules.",
-			"items": {
-				"type": "object",
-				"required": ["name", "pattern"],
-				"properties": {
-					"name": {
-						"type": "string",
-						"description": "Human-readable name for the rule",
-					},
-					"pattern": {
-						"type": "string",
-						# regal ignore:line-length
-						"description": "URL pattern to match task references. Must not include version tags (e.g., 'oci://quay.io/konflux-ci/tekton-catalog/task-buildah*' not 'oci://quay.io/konflux-ci/tekton-catalog/task-buildah:0.4*'). Supports wildcards (*).",
-						"pattern": "^(oci://|git\\+)",
-					},
-					"effective_on": {
-						"type": "string",
-						"format": "date",
-						# regal ignore:line-length
-						"description": "Date when this rule becomes effective (e.g., '2025-11-15'). Rules with future effective_on dates are not considered. If omitted, rule is effective immediately.",
-					},
-					"message": {
-						"type": "string",
-						"description": "User-visible message explaining why the task is denied (e.g., deprecation notice)",
-					},
-					"versions": {
-						"type": "array",
-						"description": "List of version constraints to match only specific versions of the task",
-						"items": {
-							"type": "string",
-							"description": "Version constraint (e.g., '>=2.1', '<1.2.3')",
-						},
-					},
+			"oneOf": [
+				{
+					"type": "array",
+					# regal ignore:line-length
+					"description": "Rules that deny tasks matching the pattern (array format). Deny rules take precedence over allow rules.",
+					"items": _trusted_task_rule_array_item_schema,
+					"default": [],
 				},
-				"additionalProperties": true,
-			},
-			"default": [],
+				{
+					"type": "object",
+					# regal ignore:line-length
+					"description": "Rules that deny tasks matching the pattern (object format, keyed by name). Deny rules take precedence over allow rules.",
+					"additionalProperties": _trusted_task_rule_entry_schema,
+				},
+			],
 		},
 	},
 	"additionalProperties": false,

--- a/policy/lib/tekton/trusted.rego
+++ b/policy/lib/tekton/trusted.rego
@@ -142,54 +142,56 @@ _trusted_task_rules_data := {
 	),
 }
 
-# Safely extract allow from data.trusted_task_rules (object format keyed by name).
+# Safely extract allow rules from data.trusted_task_rules.
+# Each key maps to an array of rule objects; we flatten all arrays into one list.
 default _data_allow_array := []
 
-_data_allow_array := [entry |
+_data_allow_array := [rule |
 	is_object(data.trusted_task_rules)
 	is_object(data.trusted_task_rules.allow)
-	some _, entry in data.trusted_task_rules.allow # regal ignore:in-wildcard-key
+	some _, rules in data.trusted_task_rules.allow # regal ignore:in-wildcard-key
+	some rule in rules
 ] if {
 	is_object(data.trusted_task_rules)
 	is_object(data.trusted_task_rules.allow)
 }
 
-# Safely extract deny from data.trusted_task_rules (object format keyed by name).
+# Safely extract deny rules from data.trusted_task_rules.
 default _data_deny_array := []
 
-_data_deny_array := [entry |
+_data_deny_array := [rule |
 	is_object(data.trusted_task_rules)
 	is_object(data.trusted_task_rules.deny)
-	some _, entry in data.trusted_task_rules.deny # regal ignore:in-wildcard-key
+	some _, rules in data.trusted_task_rules.deny # regal ignore:in-wildcard-key
+	some rule in rules
 ] if {
 	is_object(data.trusted_task_rules)
 	is_object(data.trusted_task_rules.deny)
 }
 
-# Safely extract allow from rule_data (object format keyed by name).
-# The object format enables multiple data sources with the same key to be
-# merged by OPA without conflicts, since each entry has a unique map key.
+# Safely extract allow rules from rule_data.
+# Each key maps to an array of rule objects; we flatten all arrays into one list.
 default _rule_data_allow_array := []
 
-_rule_data_allow_array := [entry |
-	_rule_data_obj := lib_rule_data("trusted_task_rules")
+_rule_data_allow_array := [rule |
 	is_object(_rule_data_obj)
 	is_object(_rule_data_obj.allow)
-	some _, entry in _rule_data_obj.allow # regal ignore:in-wildcard-key
+	some _, rules in _rule_data_obj.allow # regal ignore:in-wildcard-key
+	some rule in rules
 ] if {
 	_rule_data_obj := lib_rule_data("trusted_task_rules")
 	is_object(_rule_data_obj)
 	is_object(_rule_data_obj.allow)
 }
 
-# Safely extract deny from rule_data (object format keyed by name).
+# Safely extract deny rules from rule_data.
 default _rule_data_deny_array := []
 
-_rule_data_deny_array := [entry |
-	_rule_data_obj := lib_rule_data("trusted_task_rules")
+_rule_data_deny_array := [rule |
 	is_object(_rule_data_obj)
 	is_object(_rule_data_obj.deny)
-	some _, entry in _rule_data_obj.deny # regal ignore:in-wildcard-key
+	some _, rules in _rule_data_obj.deny # regal ignore:in-wildcard-key
+	some rule in rules
 ] if {
 	_rule_data_obj := lib_rule_data("trusted_task_rules")
 	is_object(_rule_data_obj)
@@ -453,14 +455,21 @@ _trusted_task_rules_schema := {
 	"properties": {
 		"allow": {
 			"type": "object",
-			"description": "Rules that allow tasks matching the pattern, keyed by name",
-			"additionalProperties": _trusted_task_rule_entry_schema,
+			# regal ignore:line-length
+			"description": "Groups of allow rules keyed by a descriptive name. Each value is an array of rule objects.",
+			"additionalProperties": {
+				"type": "array",
+				"items": _trusted_task_rule_entry_schema,
+			},
 		},
 		"deny": {
 			"type": "object",
 			# regal ignore:line-length
-			"description": "Rules that deny tasks matching the pattern, keyed by name. Deny rules take precedence over allow rules.",
-			"additionalProperties": _trusted_task_rule_entry_schema,
+			"description": "Groups of deny rules keyed by a descriptive name. Deny rules take precedence over allow rules.",
+			"additionalProperties": {
+				"type": "array",
+				"items": _trusted_task_rule_entry_schema,
+			},
 		},
 	},
 	"additionalProperties": false,

--- a/policy/lib/tekton/trusted.rego
+++ b/policy/lib/tekton/trusted.rego
@@ -147,8 +147,6 @@ _trusted_task_rules_data := {
 default _data_allow_array := []
 
 _data_allow_array := [rule |
-	is_object(data.trusted_task_rules)
-	is_object(data.trusted_task_rules.allow)
 	some _, rules in data.trusted_task_rules.allow # regal ignore:in-wildcard-key
 	some rule in rules
 ] if {
@@ -160,8 +158,6 @@ _data_allow_array := [rule |
 default _data_deny_array := []
 
 _data_deny_array := [rule |
-	is_object(data.trusted_task_rules)
-	is_object(data.trusted_task_rules.deny)
 	some _, rules in data.trusted_task_rules.deny # regal ignore:in-wildcard-key
 	some rule in rules
 ] if {
@@ -174,8 +170,6 @@ _data_deny_array := [rule |
 default _rule_data_allow_array := []
 
 _rule_data_allow_array := [rule |
-	is_object(_rule_data_obj)
-	is_object(_rule_data_obj.allow)
 	some _, rules in _rule_data_obj.allow # regal ignore:in-wildcard-key
 	some rule in rules
 ] if {
@@ -188,8 +182,6 @@ _rule_data_allow_array := [rule |
 default _rule_data_deny_array := []
 
 _rule_data_deny_array := [rule |
-	is_object(_rule_data_obj)
-	is_object(_rule_data_obj.deny)
 	some _, rules in _rule_data_obj.deny # regal ignore:in-wildcard-key
 	some rule in rules
 ] if {

--- a/policy/lib/tekton/trusted.rego
+++ b/policy/lib/tekton/trusted.rego
@@ -148,7 +148,7 @@ default _data_allow_array := []
 _data_allow_array := [entry |
 	is_object(data.trusted_task_rules)
 	is_object(data.trusted_task_rules.allow)
-	some _, entry in data.trusted_task_rules.allow
+	some _, entry in data.trusted_task_rules.allow # regal ignore:in-wildcard-key
 ] if {
 	is_object(data.trusted_task_rules)
 	is_object(data.trusted_task_rules.allow)
@@ -160,7 +160,7 @@ default _data_deny_array := []
 _data_deny_array := [entry |
 	is_object(data.trusted_task_rules)
 	is_object(data.trusted_task_rules.deny)
-	some _, entry in data.trusted_task_rules.deny
+	some _, entry in data.trusted_task_rules.deny # regal ignore:in-wildcard-key
 ] if {
 	is_object(data.trusted_task_rules)
 	is_object(data.trusted_task_rules.deny)
@@ -175,7 +175,7 @@ _rule_data_allow_array := [entry |
 	_rule_data_obj := lib_rule_data("trusted_task_rules")
 	is_object(_rule_data_obj)
 	is_object(_rule_data_obj.allow)
-	some _, entry in _rule_data_obj.allow
+	some _, entry in _rule_data_obj.allow # regal ignore:in-wildcard-key
 ] if {
 	_rule_data_obj := lib_rule_data("trusted_task_rules")
 	is_object(_rule_data_obj)
@@ -189,7 +189,7 @@ _rule_data_deny_array := [entry |
 	_rule_data_obj := lib_rule_data("trusted_task_rules")
 	is_object(_rule_data_obj)
 	is_object(_rule_data_obj.deny)
-	some _, entry in _rule_data_obj.deny
+	some _, entry in _rule_data_obj.deny # regal ignore:in-wildcard-key
 ] if {
 	_rule_data_obj := lib_rule_data("trusted_task_rules")
 	is_object(_rule_data_obj)

--- a/policy/lib/tekton/trusted.rego
+++ b/policy/lib/tekton/trusted.rego
@@ -142,14 +142,8 @@ _trusted_task_rules_data := {
 	),
 }
 
-# Safely extract allow from data.trusted_task_rules.
-# Supports both array and object formats.
+# Safely extract allow from data.trusted_task_rules (object format keyed by name).
 default _data_allow_array := []
-
-_data_allow_array := data.trusted_task_rules.allow if {
-	is_object(data.trusted_task_rules)
-	is_array(data.trusted_task_rules.allow)
-}
 
 _data_allow_array := [entry |
 	is_object(data.trusted_task_rules)
@@ -160,14 +154,8 @@ _data_allow_array := [entry |
 	is_object(data.trusted_task_rules.allow)
 }
 
-# Safely extract deny from data.trusted_task_rules.
-# Supports both array and object formats.
+# Safely extract deny from data.trusted_task_rules (object format keyed by name).
 default _data_deny_array := []
-
-_data_deny_array := data.trusted_task_rules.deny if {
-	is_object(data.trusted_task_rules)
-	is_array(data.trusted_task_rules.deny)
-}
 
 _data_deny_array := [entry |
 	is_object(data.trusted_task_rules)
@@ -178,19 +166,10 @@ _data_deny_array := [entry |
 	is_object(data.trusted_task_rules.deny)
 }
 
-# Safely extract allow from rule_data.
-# Supports two formats:
-#   Array format:  {"allow": [{"name": "...", "pattern": "..."}, ...]}
-#   Object format: {"allow": {"my-key": {"pattern": "..."}, ...}}
+# Safely extract allow from rule_data (object format keyed by name).
 # The object format enables multiple data sources with the same key to be
 # merged by OPA without conflicts, since each entry has a unique map key.
 default _rule_data_allow_array := []
-
-_rule_data_allow_array := _rule_data_obj.allow if {
-	_rule_data_obj := lib_rule_data("trusted_task_rules")
-	is_object(_rule_data_obj)
-	is_array(_rule_data_obj.allow)
-}
 
 _rule_data_allow_array := [entry |
 	_rule_data_obj := lib_rule_data("trusted_task_rules")
@@ -203,15 +182,8 @@ _rule_data_allow_array := [entry |
 	is_object(_rule_data_obj.allow)
 }
 
-# Safely extract deny from rule_data.
-# Supports both array and object formats (same as allow above).
+# Safely extract deny from rule_data (object format keyed by name).
 default _rule_data_deny_array := []
-
-_rule_data_deny_array := _rule_data_obj.deny if {
-	_rule_data_obj := lib_rule_data("trusted_task_rules")
-	is_object(_rule_data_obj)
-	is_array(_rule_data_obj.deny)
-}
 
 _rule_data_deny_array := [entry |
 	_rule_data_obj := lib_rule_data("trusted_task_rules")
@@ -293,8 +265,7 @@ data_errors contains error if {
 	)
 }
 
-# Validate trusted_task_rules data format using the schema defined in
-# trusted_tasks/trusted_task_rules.schema.json
+# Validate trusted_task_rules data format.
 # Skip validation if trusted_task_rules is not provided (null or empty list []).
 # lib_rule_data returns [] when a key is not found, so we only validate when
 # the value is actually an object (the expected type).
@@ -443,9 +414,7 @@ _pattern_matches(key, pattern) if {
 	regex.match(regex_pattern, key)
 }
 
-# Schema for trusted_task_rules as defined in trusted_tasks/trusted_task_rules.schema.json
-# This schema validates the rule-based trusted tasks configuration (ADR 53)
-# Schema definition for a single rule entry (used as object values in the object format)
+# Schema definition for a single rule entry (object values keyed by name)
 _trusted_task_rule_entry_schema := {
 	"type": "object",
 	"required": ["pattern"],
@@ -475,21 +444,6 @@ _trusted_task_rule_entry_schema := {
 	"additionalProperties": true,
 }
 
-# Array format item requires "name" since there is no map key to use
-_trusted_task_rule_array_item_schema := object.union(
-	_trusted_task_rule_entry_schema,
-	{
-		"required": ["name", "pattern"],
-		"properties": object.union(
-			_trusted_task_rule_entry_schema.properties,
-			{"name": {
-				"type": "string",
-				"description": "Human-readable name for the rule",
-			}},
-		),
-	},
-)
-
 _trusted_task_rules_schema := {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"$id": "https://konflux.io/schemas/trusted_task_rules.json",
@@ -498,37 +452,15 @@ _trusted_task_rules_schema := {
 	"type": "object",
 	"properties": {
 		"allow": {
-			"oneOf": [
-				{
-					"type": "array",
-					"description": "Rules that allow tasks matching the pattern (array format)",
-					"items": _trusted_task_rule_array_item_schema,
-					"default": [],
-				},
-				{
-					"type": "object",
-					# regal ignore:line-length
-					"description": "Rules that allow tasks matching the pattern (object format, keyed by name)",
-					"additionalProperties": _trusted_task_rule_entry_schema,
-				},
-			],
+			"type": "object",
+			"description": "Rules that allow tasks matching the pattern, keyed by name",
+			"additionalProperties": _trusted_task_rule_entry_schema,
 		},
 		"deny": {
-			"oneOf": [
-				{
-					"type": "array",
-					# regal ignore:line-length
-					"description": "Rules that deny tasks matching the pattern (array format). Deny rules take precedence over allow rules.",
-					"items": _trusted_task_rule_array_item_schema,
-					"default": [],
-				},
-				{
-					"type": "object",
-					# regal ignore:line-length
-					"description": "Rules that deny tasks matching the pattern (object format, keyed by name). Deny rules take precedence over allow rules.",
-					"additionalProperties": _trusted_task_rule_entry_schema,
-				},
-			],
+			"type": "object",
+			# regal ignore:line-length
+			"description": "Rules that deny tasks matching the pattern, keyed by name. Deny rules take precedence over allow rules.",
+			"additionalProperties": _trusted_task_rule_entry_schema,
 		},
 	},
 	"additionalProperties": false,

--- a/policy/lib/tekton/trusted.rego
+++ b/policy/lib/tekton/trusted.rego
@@ -147,7 +147,7 @@ _trusted_task_rules_data := {
 default _data_allow_array := []
 
 _data_allow_array := [rule |
-	some _, rules in data.trusted_task_rules.allow # regal ignore:in-wildcard-key
+	some rules in data.trusted_task_rules.allow
 	some rule in rules
 ] if {
 	is_object(data.trusted_task_rules)
@@ -158,7 +158,7 @@ _data_allow_array := [rule |
 default _data_deny_array := []
 
 _data_deny_array := [rule |
-	some _, rules in data.trusted_task_rules.deny # regal ignore:in-wildcard-key
+	some rules in data.trusted_task_rules.deny
 	some rule in rules
 ] if {
 	is_object(data.trusted_task_rules)
@@ -170,7 +170,7 @@ _data_deny_array := [rule |
 default _rule_data_allow_array := []
 
 _rule_data_allow_array := [rule |
-	some _, rules in _rule_data_obj.allow # regal ignore:in-wildcard-key
+	some rules in _rule_data_obj.allow
 	some rule in rules
 ] if {
 	_rule_data_obj := lib_rule_data("trusted_task_rules")
@@ -182,7 +182,7 @@ _rule_data_allow_array := [rule |
 default _rule_data_deny_array := []
 
 _rule_data_deny_array := [rule |
-	some _, rules in _rule_data_obj.deny # regal ignore:in-wildcard-key
+	some rules in _rule_data_obj.deny
 	some rule in rules
 ] if {
 	_rule_data_obj := lib_rule_data("trusted_task_rules")

--- a/policy/lib/tekton/trusted_test.rego
+++ b/policy/lib/tekton/trusted_test.rego
@@ -202,21 +202,15 @@ test_is_trusted_task_with_rules if {
 	# Test with trusted_task_rules using allow/deny patterns
 	trusted_task_rules := {
 		"allow": {
-			"Allow konflux tasks": {
-				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-			},
-			"Allow registry.local tasks": {
-				"pattern": "oci://registry.local/*",
-			},
+			"Allow konflux tasks": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"},
+			"Allow registry.local tasks": {"pattern": "oci://registry.local/*"},
 			"Allow specific version range of a task": {
 				"pattern": "oci://quay.io/konflux-ci/another-catalog/allow-task-constrained",
 				"versions": [">1.2.3", "<2"],
 			},
 		},
 		"deny": {
-			"Deny old buildah": {
-				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
-			},
+			"Deny old buildah": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*"},
 			"Constrain version of task": {
 				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/deny-task-constrained",
 				"versions": ["<=1", ">1.2.3"],
@@ -361,16 +355,8 @@ test_is_trusted_task_with_rules if {
 	# Digest-only bundle reference (no tag). The key becomes "oci://repo" without tag or digest.
 	# Pattern must match the repo without tag/digest components.
 	digest_only_rules := {
-		"allow": {
-			"Allow digest-only from registry.local": {
-				"pattern": "oci://registry.local/*",
-			},
-		},
-		"deny": {
-			"Deny crook digest-only": {
-				"pattern": "oci://registry.local/crook",
-			},
-		},
+		"allow": {"Allow digest-only from registry.local": {"pattern": "oci://registry.local/*"}},
+		"deny": {"Deny crook digest-only": {"pattern": "oci://registry.local/crook"}},
 	}
 
 	# Digest-only task: key is "oci://registry.local/trusty" (no tag)
@@ -432,11 +418,7 @@ test_rule_data_merging if {
 test_data_trusted_task_rules_extraction if {
 	# Test extraction from data.trusted_task_rules (covers lines 144-156)
 	# Test when data.trusted_task_rules is provided with allow rules
-	data_rules_allow := {"allow": {
-		"Allow from data": {
-			"pattern": "oci://registry.local/*",
-		},
-	}}
+	data_rules_allow := {"allow": {"Allow from data": {"pattern": "oci://registry.local/*"}}}
 
 	# Task matching allow from data.trusted_task_rules should be trusted
 	allowed_task := {"spec": {"taskRef": {"resolver": "bundles", "params": [
@@ -449,11 +431,7 @@ test_data_trusted_task_rules_extraction if {
 		with data.rule_data.trusted_task_rules as null
 
 	# Test when data.trusted_task_rules is provided with deny rules
-	data_rules_deny := {"deny": {
-		"Deny from data": {
-			"pattern": "oci://registry.local/crook/*",
-		},
-	}}
+	data_rules_deny := {"deny": {"Deny from data": {"pattern": "oci://registry.local/crook/*"}}}
 
 	# Task matching deny from data.trusted_task_rules should not be trusted
 	denied_task := {"spec": {"taskRef": {"resolver": "bundles", "params": [
@@ -469,23 +447,14 @@ test_data_trusted_task_rules_extraction if {
 	# Should fall back to empty arrays, so task won't be trusted via rules
 	not tekton.is_trusted_task(allowed_task, _empty_bundle_manifests) with data.trusted_task_rules as null
 		with data.rule_data.trusted_task_rules as null
-
 }
 
 test_rule_data_trusted_task_rules_extraction if {
 	# Test extraction from lib_rule_data("trusted_task_rules") (covers lines 158-172)
 	# Test when lib_rule_data returns an object
 	rule_data_rules := {
-		"allow": {
-			"Allow from rule_data": {
-				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-			},
-		},
-		"deny": {
-			"Deny from rule_data": {
-				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
-			},
-		},
+		"allow": {"Allow from rule_data": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}},
+		"deny": {"Deny from rule_data": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*"}},
 	}
 
 	# Task matching allow from rule_data should be trusted
@@ -586,11 +555,7 @@ test_denying_pattern if {
 	# Test that denying_pattern returns the pattern that denied a task
 	trusted_task_rules := {
 		"allow": {},
-		"deny": {
-			"Deny old buildah": {
-				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
-			},
-		},
+		"deny": {"Deny old buildah": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*"}},
 	}
 
 	# Create a task that matches the deny rule
@@ -624,12 +589,8 @@ test_denying_pattern_multiple_rules if {
 	multiple_deny_rules := {
 		"allow": {},
 		"deny": {
-			"Deny all konflux": {
-				"pattern": "oci://quay.io/konflux-ci/*",
-			},
-			"Deny buildah specifically": {
-				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
-			},
+			"Deny all konflux": {"pattern": "oci://quay.io/konflux-ci/*"},
+			"Deny buildah specifically": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*"},
 		},
 	}
 
@@ -657,17 +618,11 @@ test_denying_pattern_multiple_rules if {
 test_denial_reason if {
 	# Test denial_reason returns the correct reason for denied tasks
 	trusted_task_rules := {
-		"allow": {
-			"Allow konflux tasks": {
-				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-			},
-		},
-		"deny": {
-			"Deny old buildah": {
-				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
-				"message": "This version is deprecated",
-			},
-		},
+		"allow": {"Allow konflux tasks": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}},
+		"deny": {"Deny old buildah": {
+			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
+			"message": "This version is deprecated",
+		}},
 	}
 
 	# Case 1: Matches a deny rule (even though it also matches allow)
@@ -748,18 +703,12 @@ test_trusted_task_rules_data_errors if {
 
 	# Valid trusted_task_rules should pass
 	valid_rules := {
-		"allow": {
-			"Allow all konflux tasks": {
-				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-			},
-		},
-		"deny": {
-			"Deny old buildah": {
-				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
-				"effective_on": "2025-11-15",
-				"message": "Deprecated",
-			},
-		},
+		"allow": {"Allow all konflux tasks": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}},
+		"deny": {"Deny old buildah": {
+			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
+			"effective_on": "2025-11-15",
+			"message": "Deprecated",
+		}},
 	}
 	assertions.assert_empty(tekton.data_errors) with data.rule_data.trusted_task_rules as valid_rules
 
@@ -773,12 +722,10 @@ test_trusted_task_rules_data_errors if {
 	assertions.assert_equal(tekton.data_errors, expected) with data.rule_data.trusted_task_rules as invalid_rules
 
 	# Invalid effective_on date format
-	invalid_date_rules := {"allow": {
-		"Invalid date": {
-			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-			"effective_on": "not-a-date",
-		},
-	}}
+	invalid_date_rules := {"allow": {"Invalid date": {
+		"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
+		"effective_on": "not-a-date",
+	}}}
 	expected_date := {{
 		# regal ignore:line-length
 		"message": "trusted_task_rules data has unexpected format: allow.Invalid date.effective_on: Does not match format 'date'",
@@ -792,11 +739,7 @@ test_trusted_task_rules_data_errors if {
 	# Invalid allow/deny - not objects
 	invalid_structure := {
 		"allow": "not-an-object",
-		"deny": {
-			"Valid deny": {
-				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-			},
-		},
+		"deny": {"Valid deny": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}},
 	}
 	expected_structure := {{
 		# regal ignore:line-length
@@ -814,11 +757,7 @@ test_denying_pattern_invalid_task if {
 	# Any rules - doesn't matter since task has no valid ref
 	rules := {
 		"allow": {},
-		"deny": {
-			"Deny something": {
-				"pattern": "oci://quay.io/*",
-			},
-		},
+		"deny": {"Deny something": {"pattern": "oci://quay.io/*"}},
 	}
 
 	# Should return empty list (else branch) since task_ref fails
@@ -832,11 +771,7 @@ test_denying_pattern_invalid_task if {
 test_denying_rules_info_empty if {
 	# Rules with no deny rules
 	rules_no_deny := {
-		"allow": {
-			"Allow all": {
-				"pattern": "oci://quay.io/*",
-			},
-		},
+		"allow": {"Allow all": {"pattern": "oci://quay.io/*"}},
 		"deny": {},
 	}
 

--- a/policy/lib/tekton/trusted_test.rego
+++ b/policy/lib/tekton/trusted_test.rego
@@ -362,6 +362,41 @@ test_is_trusted_task_with_rules if {
 	# regal ignore:line-length
 	mismatch_manifests_2 := _mock_bundle_manifests("quay.io/konflux-ci/another-catalog/allow-task-constrained:1.2.3@sha256:d19e5700000000000000000000000000000000000000000000000000d19e5700", "1.5")
 	tekton.is_trusted_task(allow_constrained_task_denied_version_mismatching_2, mismatch_manifests_2) with data.rule_data.trusted_task_rules as trusted_task_rules # regal ignore:line-length
+
+	# Digest-only bundle reference (no tag). The key becomes "oci://repo" without tag or digest.
+	# Pattern must match the repo without tag/digest components.
+	digest_only_rules := {
+		"allow": [
+			{
+				"name": "Allow digest-only from registry.local",
+				"pattern": "oci://registry.local/*",
+			},
+		],
+		"deny": [
+			{
+				"name": "Deny crook digest-only",
+				"pattern": "oci://registry.local/crook",
+			},
+		],
+	}
+
+	# Digest-only task: key is "oci://registry.local/trusty" (no tag)
+	digest_only_allowed := {"spec": {"taskRef": {"resolver": "bundles", "params": [
+		# regal ignore:line-length
+		{"name": "bundle", "value": "registry.local/trusty@sha256:d19e5700000000000000000000000000000000000000000000000000d19e5700"},
+		{"name": "name", "value": "trusty"},
+		{"name": "kind", "value": "task"},
+	]}}}
+	tekton.is_trusted_task(digest_only_allowed, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as digest_only_rules
+
+	# Digest-only task matching deny: key is "oci://registry.local/crook" (no tag)
+	digest_only_denied := {"spec": {"taskRef": {"resolver": "bundles", "params": [
+		# regal ignore:line-length
+		{"name": "bundle", "value": "registry.local/crook@sha256:d19e5700000000000000000000000000000000000000000000000000d19e5700"},
+		{"name": "name", "value": "crook"},
+		{"name": "kind", "value": "task"},
+	]}}}
+	not tekton.is_trusted_task(digest_only_denied, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as digest_only_rules
 }
 
 test_trusted_task_records if {
@@ -439,6 +474,24 @@ test_data_trusted_task_rules_extraction if {
 	# Should fall back to empty arrays, so task won't be trusted via rules
 	not tekton.is_trusted_task(allowed_task, _empty_bundle_manifests) with data.trusted_task_rules as null
 		with data.rule_data.trusted_task_rules as null
+
+	# Test object format (keyed by name) via data.trusted_task_rules
+	data_rules_obj := {
+		"allow": {
+			"Allow from data obj": {
+				"pattern": "oci://registry.local/*",
+			},
+		},
+		"deny": {
+			"Deny from data obj": {
+				"pattern": "oci://registry.local/crook:*",
+			},
+		},
+	}
+	tekton.is_trusted_task(allowed_task, _empty_bundle_manifests) with data.trusted_task_rules as data_rules_obj
+		with data.rule_data.trusted_task_rules as null
+	not tekton.is_trusted_task(denied_task, _empty_bundle_manifests) with data.trusted_task_rules as data_rules_obj
+		with data.rule_data.trusted_task_rules as null
 }
 
 test_rule_data_trusted_task_rules_extraction if {
@@ -478,6 +531,24 @@ test_rule_data_trusted_task_rules_extraction if {
 	# Test when lib_rule_data returns [] (not an object) - covers default cases
 	# When rule_data returns [], it's not an object, so defaults are used
 	not tekton.is_trusted_task(allowed_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as []
+
+	# Test object format (keyed by name) - allow
+	rule_data_rules_obj := {
+		"allow": {
+			"Allow from rule_data": {
+				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
+			},
+		},
+		"deny": {
+			"Deny from rule_data": {
+				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
+			},
+		},
+	}
+	tekton.is_trusted_task(allowed_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as rule_data_rules_obj
+
+	# regal ignore:line-length
+	not tekton.is_trusted_task(denied_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as rule_data_rules_obj
 }
 
 test_data_errors if {
@@ -738,13 +809,13 @@ test_trusted_task_rules_data_errors if {
 			"message": "trusted_task_rules data has unexpected format: allow.0: pattern is required",
 			"severity": "failure",
 		},
+		{
+			# regal ignore:line-length
+			"message": "trusted_task_rules data has unexpected format: allow: Must validate one and only one schema (oneOf)",
+			"severity": "failure",
+		},
 	}
 	assertions.assert_equal(tekton.data_errors, expected) with data.rule_data.trusted_task_rules as invalid_rules
-
-	# Invalid pattern validation is not tested here because JSON schema
-	# pattern validation may not be enforced by the OPA json.match_schema
-	# function. Pattern validation should be implemented separately in the
-	# rule evaluation logic when trusted_task_rules is used.
 
 	# Invalid effective_on date format
 	invalid_date_rules := {"allow": [{
@@ -752,17 +823,24 @@ test_trusted_task_rules_data_errors if {
 		"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
 		"effective_on": "not-a-date",
 	}]}
-	expected_date := {{
-		# regal ignore:line-length
-		"message": "trusted_task_rules data has unexpected format: allow.0.effective_on: Does not match format 'date'",
-		"severity": "failure",
-	}}
+	expected_date := {
+		{
+			# regal ignore:line-length
+			"message": "trusted_task_rules data has unexpected format: allow.0.effective_on: Does not match format 'date'",
+			"severity": "failure",
+		},
+		{
+			# regal ignore:line-length
+			"message": "trusted_task_rules data has unexpected format: allow: Must validate one and only one schema (oneOf)",
+			"severity": "failure",
+		},
+	}
 	assertions.assert_equal(tekton.data_errors, expected_date) with data.rule_data.trusted_task_rules as invalid_date_rules
 
 	# Invalid structure - not an object
 	assertions.assert_empty(tekton.data_errors) with data.rule_data.trusted_task_rules as [] # Empty list is skipped
 
-	# Invalid allow/deny - not arrays
+	# Invalid allow/deny - not arrays or objects
 	invalid_structure := {
 		"allow": "not-an-array",
 		"deny": [{
@@ -770,10 +848,18 @@ test_trusted_task_rules_data_errors if {
 			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
 		}],
 	}
-	expected_structure := {{
-		"message": "trusted_task_rules data has unexpected format: allow: Invalid type. Expected: array, given: string",
-		"severity": "failure",
-	}}
+	expected_structure := {
+		{
+			# regal ignore:line-length
+			"message": "trusted_task_rules data has unexpected format: allow: Invalid type. Expected: array, given: string",
+			"severity": "failure",
+		},
+		{
+			# regal ignore:line-length
+			"message": "trusted_task_rules data has unexpected format: allow: Must validate one and only one schema (oneOf)",
+			"severity": "failure",
+		},
+	}
 	assertions.assert_equal(tekton.data_errors, expected_structure) with data.rule_data.trusted_task_rules as invalid_structure
 }
 

--- a/policy/lib/tekton/trusted_test.rego
+++ b/policy/lib/tekton/trusted_test.rego
@@ -170,8 +170,8 @@ test_untrusted_task_refs_routes_to_rules if {
 
 	# Allow trusted_bundle_task pattern, deny nothing
 	task_rules := {
-		"allow": [{"pattern": "oci://registry.local/trusty:*"}],
-		"deny": [],
+		"allow": {"Allow trusty": {"pattern": "oci://registry.local/trusty:*"}},
+		"deny": {},
 	}
 
 	# untrusted_bundle_task should be untrusted (doesn't match allow pattern)
@@ -201,32 +201,27 @@ test_is_trusted_task if {
 test_is_trusted_task_with_rules if {
 	# Test with trusted_task_rules using allow/deny patterns
 	trusted_task_rules := {
-		"allow": [
-			{
-				"name": "Allow konflux tasks",
+		"allow": {
+			"Allow konflux tasks": {
 				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
 			},
-			{
-				"name": "Allow registry.local tasks",
+			"Allow registry.local tasks": {
 				"pattern": "oci://registry.local/*",
 			},
-			{
-				"name": "Allow specific version range of a task",
+			"Allow specific version range of a task": {
 				"pattern": "oci://quay.io/konflux-ci/another-catalog/allow-task-constrained",
 				"versions": [">1.2.3", "<2"],
 			},
-		],
-		"deny": [
-			{
-				"name": "Deny old buildah",
+		},
+		"deny": {
+			"Deny old buildah": {
 				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
 			},
-			{
-				"name": "Constrain version of task",
+			"Constrain version of task": {
 				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/deny-task-constrained",
 				"versions": ["<=1", ">1.2.3"],
 			},
-		],
+		},
 	}
 
 	# Task that matches allow rule should be trusted
@@ -366,18 +361,16 @@ test_is_trusted_task_with_rules if {
 	# Digest-only bundle reference (no tag). The key becomes "oci://repo" without tag or digest.
 	# Pattern must match the repo without tag/digest components.
 	digest_only_rules := {
-		"allow": [
-			{
-				"name": "Allow digest-only from registry.local",
+		"allow": {
+			"Allow digest-only from registry.local": {
 				"pattern": "oci://registry.local/*",
 			},
-		],
-		"deny": [
-			{
-				"name": "Deny crook digest-only",
+		},
+		"deny": {
+			"Deny crook digest-only": {
 				"pattern": "oci://registry.local/crook",
 			},
-		],
+		},
 	}
 
 	# Digest-only task: key is "oci://registry.local/trusty" (no tag)
@@ -439,10 +432,11 @@ test_rule_data_merging if {
 test_data_trusted_task_rules_extraction if {
 	# Test extraction from data.trusted_task_rules (covers lines 144-156)
 	# Test when data.trusted_task_rules is provided with allow rules
-	data_rules_allow := {"allow": [{
-		"name": "Allow from data",
-		"pattern": "oci://registry.local/*",
-	}]}
+	data_rules_allow := {"allow": {
+		"Allow from data": {
+			"pattern": "oci://registry.local/*",
+		},
+	}}
 
 	# Task matching allow from data.trusted_task_rules should be trusted
 	allowed_task := {"spec": {"taskRef": {"resolver": "bundles", "params": [
@@ -455,10 +449,11 @@ test_data_trusted_task_rules_extraction if {
 		with data.rule_data.trusted_task_rules as null
 
 	# Test when data.trusted_task_rules is provided with deny rules
-	data_rules_deny := {"deny": [{
-		"name": "Deny from data",
-		"pattern": "oci://registry.local/crook/*",
-	}]}
+	data_rules_deny := {"deny": {
+		"Deny from data": {
+			"pattern": "oci://registry.local/crook/*",
+		},
+	}}
 
 	# Task matching deny from data.trusted_task_rules should not be trusted
 	denied_task := {"spec": {"taskRef": {"resolver": "bundles", "params": [
@@ -475,37 +470,22 @@ test_data_trusted_task_rules_extraction if {
 	not tekton.is_trusted_task(allowed_task, _empty_bundle_manifests) with data.trusted_task_rules as null
 		with data.rule_data.trusted_task_rules as null
 
-	# Test object format (keyed by name) via data.trusted_task_rules
-	data_rules_obj := {
-		"allow": {
-			"Allow from data obj": {
-				"pattern": "oci://registry.local/*",
-			},
-		},
-		"deny": {
-			"Deny from data obj": {
-				"pattern": "oci://registry.local/crook:*",
-			},
-		},
-	}
-	tekton.is_trusted_task(allowed_task, _empty_bundle_manifests) with data.trusted_task_rules as data_rules_obj
-		with data.rule_data.trusted_task_rules as null
-	not tekton.is_trusted_task(denied_task, _empty_bundle_manifests) with data.trusted_task_rules as data_rules_obj
-		with data.rule_data.trusted_task_rules as null
 }
 
 test_rule_data_trusted_task_rules_extraction if {
 	# Test extraction from lib_rule_data("trusted_task_rules") (covers lines 158-172)
 	# Test when lib_rule_data returns an object
 	rule_data_rules := {
-		"allow": [{
-			"name": "Allow from rule_data",
-			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-		}],
-		"deny": [{
-			"name": "Deny from rule_data",
-			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
-		}],
+		"allow": {
+			"Allow from rule_data": {
+				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
+			},
+		},
+		"deny": {
+			"Deny from rule_data": {
+				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
+			},
+		},
 	}
 
 	# Task matching allow from rule_data should be trusted
@@ -531,24 +511,6 @@ test_rule_data_trusted_task_rules_extraction if {
 	# Test when lib_rule_data returns [] (not an object) - covers default cases
 	# When rule_data returns [], it's not an object, so defaults are used
 	not tekton.is_trusted_task(allowed_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as []
-
-	# Test object format (keyed by name) - allow
-	rule_data_rules_obj := {
-		"allow": {
-			"Allow from rule_data": {
-				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-			},
-		},
-		"deny": {
-			"Deny from rule_data": {
-				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
-			},
-		},
-	}
-	tekton.is_trusted_task(allowed_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as rule_data_rules_obj
-
-	# regal ignore:line-length
-	not tekton.is_trusted_task(denied_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as rule_data_rules_obj
 }
 
 test_data_errors if {
@@ -623,11 +585,12 @@ test_task_expiry_warning_days_data if {
 test_denying_pattern if {
 	# Test that denying_pattern returns the pattern that denied a task
 	trusted_task_rules := {
-		"allow": [],
-		"deny": [{
-			"name": "Deny old buildah",
-			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
-		}],
+		"allow": {},
+		"deny": {
+			"Deny old buildah": {
+				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
+			},
+		},
 	}
 
 	# Create a task that matches the deny rule
@@ -659,17 +622,15 @@ test_denying_pattern if {
 test_denying_pattern_multiple_rules if {
 	# Test with multiple deny rules - should return one of the matching patterns
 	multiple_deny_rules := {
-		"allow": [],
-		"deny": [
-			{
-				"name": "Deny all konflux",
+		"allow": {},
+		"deny": {
+			"Deny all konflux": {
 				"pattern": "oci://quay.io/konflux-ci/*",
 			},
-			{
-				"name": "Deny buildah specifically",
+			"Deny buildah specifically": {
 				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
 			},
-		],
+		},
 	}
 
 	# Should match both patterns (both rules match this task)
@@ -696,15 +657,17 @@ test_denying_pattern_multiple_rules if {
 test_denial_reason if {
 	# Test denial_reason returns the correct reason for denied tasks
 	trusted_task_rules := {
-		"allow": [{
-			"name": "Allow konflux tasks",
-			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-		}],
-		"deny": [{
-			"name": "Deny old buildah",
-			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
-			"message": "This version is deprecated",
-		}],
+		"allow": {
+			"Allow konflux tasks": {
+				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
+			},
+		},
+		"deny": {
+			"Deny old buildah": {
+				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
+				"message": "This version is deprecated",
+			},
+		},
 	}
 
 	# Case 1: Matches a deny rule (even though it also matches allow)
@@ -759,8 +722,8 @@ test_denial_reason if {
 test_denial_reason_no_allow_rules if {
 	# If there are no allow rules, we fall back to legacy, so "not_allowed" shouldn't apply
 	rules_no_allow := {
-		"allow": [],
-		"deny": [],
+		"allow": {},
+		"deny": {},
 	}
 
 	# Task not in legacy should return nothing (we fall back to legacy, which is empty, but denial_reason
@@ -785,81 +748,61 @@ test_trusted_task_rules_data_errors if {
 
 	# Valid trusted_task_rules should pass
 	valid_rules := {
-		"allow": [{
-			"name": "Allow all konflux tasks",
-			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-		}],
-		"deny": [{
-			"name": "Deny old buildah",
-			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
-			"effective_on": "2025-11-15",
-			"message": "Deprecated",
-		}],
+		"allow": {
+			"Allow all konflux tasks": {
+				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
+			},
+		},
+		"deny": {
+			"Deny old buildah": {
+				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
+				"effective_on": "2025-11-15",
+				"message": "Deprecated",
+			},
+		},
 	}
 	assertions.assert_empty(tekton.data_errors) with data.rule_data.trusted_task_rules as valid_rules
 
-	# Missing required fields
-	invalid_rules := {"allow": [{}]} # missing name and pattern
-	expected := {
-		{
-			"message": "trusted_task_rules data has unexpected format: allow.0: name is required",
-			"severity": "failure",
-		},
-		{
-			"message": "trusted_task_rules data has unexpected format: allow.0: pattern is required",
-			"severity": "failure",
-		},
-		{
-			# regal ignore:line-length
-			"message": "trusted_task_rules data has unexpected format: allow: Must validate one and only one schema (oneOf)",
-			"severity": "failure",
-		},
-	}
+	# Missing required fields - object entry without pattern
+	invalid_rules := {"allow": {"Bad entry": {}}}
+	expected := {{
+		# regal ignore:line-length
+		"message": "trusted_task_rules data has unexpected format: allow.Bad entry: pattern is required",
+		"severity": "failure",
+	}}
 	assertions.assert_equal(tekton.data_errors, expected) with data.rule_data.trusted_task_rules as invalid_rules
 
 	# Invalid effective_on date format
-	invalid_date_rules := {"allow": [{
-		"name": "Invalid date",
-		"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-		"effective_on": "not-a-date",
-	}]}
-	expected_date := {
-		{
-			# regal ignore:line-length
-			"message": "trusted_task_rules data has unexpected format: allow.0.effective_on: Does not match format 'date'",
-			"severity": "failure",
+	invalid_date_rules := {"allow": {
+		"Invalid date": {
+			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
+			"effective_on": "not-a-date",
 		},
-		{
-			# regal ignore:line-length
-			"message": "trusted_task_rules data has unexpected format: allow: Must validate one and only one schema (oneOf)",
-			"severity": "failure",
-		},
-	}
+	}}
+	expected_date := {{
+		# regal ignore:line-length
+		"message": "trusted_task_rules data has unexpected format: allow.Invalid date.effective_on: Does not match format 'date'",
+		"severity": "failure",
+	}}
 	assertions.assert_equal(tekton.data_errors, expected_date) with data.rule_data.trusted_task_rules as invalid_date_rules
 
 	# Invalid structure - not an object
 	assertions.assert_empty(tekton.data_errors) with data.rule_data.trusted_task_rules as [] # Empty list is skipped
 
-	# Invalid allow/deny - not arrays or objects
+	# Invalid allow/deny - not objects
 	invalid_structure := {
-		"allow": "not-an-array",
-		"deny": [{
-			"name": "Valid deny",
-			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-		}],
-	}
-	expected_structure := {
-		{
-			# regal ignore:line-length
-			"message": "trusted_task_rules data has unexpected format: allow: Invalid type. Expected: array, given: string",
-			"severity": "failure",
-		},
-		{
-			# regal ignore:line-length
-			"message": "trusted_task_rules data has unexpected format: allow: Must validate one and only one schema (oneOf)",
-			"severity": "failure",
+		"allow": "not-an-object",
+		"deny": {
+			"Valid deny": {
+				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
+			},
 		},
 	}
+	expected_structure := {{
+		# regal ignore:line-length
+		"message": "trusted_task_rules data has unexpected format: allow: Invalid type. Expected: object, given: string",
+		"severity": "failure",
+	}}
 	assertions.assert_equal(tekton.data_errors, expected_structure) with data.rule_data.trusted_task_rules as invalid_structure
 }
 
@@ -870,11 +813,12 @@ test_denying_pattern_invalid_task if {
 
 	# Any rules - doesn't matter since task has no valid ref
 	rules := {
-		"allow": [],
-		"deny": [{
-			"name": "Deny something",
-			"pattern": "oci://quay.io/*",
-		}],
+		"allow": {},
+		"deny": {
+			"Deny something": {
+				"pattern": "oci://quay.io/*",
+			},
+		},
 	}
 
 	# Should return empty list (else branch) since task_ref fails
@@ -888,11 +832,12 @@ test_denying_pattern_invalid_task if {
 test_denying_rules_info_empty if {
 	# Rules with no deny rules
 	rules_no_deny := {
-		"allow": [{
-			"name": "Allow all",
-			"pattern": "oci://quay.io/*",
-		}],
-		"deny": [],
+		"allow": {
+			"Allow all": {
+				"pattern": "oci://quay.io/*",
+			},
+		},
+		"deny": {},
 	}
 
 	# Task that matches allow rule - denial_reason should be empty

--- a/policy/lib/tekton/trusted_test.rego
+++ b/policy/lib/tekton/trusted_test.rego
@@ -170,7 +170,7 @@ test_untrusted_task_refs_routes_to_rules if {
 
 	# Allow trusted_bundle_task pattern, deny nothing
 	task_rules := {
-		"allow": {"Allow trusty": {"pattern": "oci://registry.local/trusty:*"}},
+		"allow": {"trusty-tasks": [{"pattern": "oci://registry.local/trusty:*"}]},
 		"deny": {},
 	}
 
@@ -201,21 +201,21 @@ test_is_trusted_task if {
 test_is_trusted_task_with_rules if {
 	# Test with trusted_task_rules using allow/deny patterns
 	trusted_task_rules := {
-		"allow": {
-			"Allow konflux tasks": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"},
-			"Allow registry.local tasks": {"pattern": "oci://registry.local/*"},
-			"Allow specific version range of a task": {
+		"allow": {"konflux-tasks": [
+			{"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"},
+			{"pattern": "oci://registry.local/*"},
+			{
 				"pattern": "oci://quay.io/konflux-ci/another-catalog/allow-task-constrained",
 				"versions": [">1.2.3", "<2"],
 			},
-		},
-		"deny": {
-			"Deny old buildah": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*"},
-			"Constrain version of task": {
+		]},
+		"deny": {"deprecated-tasks": [
+			{"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*"},
+			{
 				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/deny-task-constrained",
 				"versions": ["<=1", ">1.2.3"],
 			},
-		},
+		]},
 	}
 
 	# Task that matches allow rule should be trusted
@@ -355,8 +355,8 @@ test_is_trusted_task_with_rules if {
 	# Digest-only bundle reference (no tag). The key becomes "oci://repo" without tag or digest.
 	# Pattern must match the repo without tag/digest components.
 	digest_only_rules := {
-		"allow": {"Allow digest-only from registry.local": {"pattern": "oci://registry.local/*"}},
-		"deny": {"Deny crook digest-only": {"pattern": "oci://registry.local/crook"}},
+		"allow": {"registry-local": [{"pattern": "oci://registry.local/*"}]},
+		"deny": {"blocked": [{"pattern": "oci://registry.local/crook"}]},
 	}
 
 	# Digest-only task: key is "oci://registry.local/trusty" (no tag)
@@ -418,7 +418,7 @@ test_rule_data_merging if {
 test_data_trusted_task_rules_extraction if {
 	# Test extraction from data.trusted_task_rules (covers lines 144-156)
 	# Test when data.trusted_task_rules is provided with allow rules
-	data_rules_allow := {"allow": {"Allow from data": {"pattern": "oci://registry.local/*"}}}
+	data_rules_allow := {"allow": {"local-tasks": [{"pattern": "oci://registry.local/*"}]}}
 
 	# Task matching allow from data.trusted_task_rules should be trusted
 	allowed_task := {"spec": {"taskRef": {"resolver": "bundles", "params": [
@@ -431,7 +431,7 @@ test_data_trusted_task_rules_extraction if {
 		with data.rule_data.trusted_task_rules as null
 
 	# Test when data.trusted_task_rules is provided with deny rules
-	data_rules_deny := {"deny": {"Deny from data": {"pattern": "oci://registry.local/crook/*"}}}
+	data_rules_deny := {"deny": {"blocked": [{"pattern": "oci://registry.local/crook/*"}]}}
 
 	# Task matching deny from data.trusted_task_rules should not be trusted
 	denied_task := {"spec": {"taskRef": {"resolver": "bundles", "params": [
@@ -453,8 +453,8 @@ test_rule_data_trusted_task_rules_extraction if {
 	# Test extraction from lib_rule_data("trusted_task_rules") (covers lines 158-172)
 	# Test when lib_rule_data returns an object
 	rule_data_rules := {
-		"allow": {"Allow from rule_data": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}},
-		"deny": {"Deny from rule_data": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*"}},
+		"allow": {"tekton-catalog": [{"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}]},
+		"deny": {"deprecated": [{"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*"}]},
 	}
 
 	# Task matching allow from rule_data should be trusted
@@ -555,7 +555,7 @@ test_denying_pattern if {
 	# Test that denying_pattern returns the pattern that denied a task
 	trusted_task_rules := {
 		"allow": {},
-		"deny": {"Deny old buildah": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*"}},
+		"deny": {"deprecated": [{"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*"}]},
 	}
 
 	# Create a task that matches the deny rule
@@ -589,8 +589,8 @@ test_denying_pattern_multiple_rules if {
 	multiple_deny_rules := {
 		"allow": {},
 		"deny": {
-			"Deny all konflux": {"pattern": "oci://quay.io/konflux-ci/*"},
-			"Deny buildah specifically": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*"},
+			"broad-deny": [{"pattern": "oci://quay.io/konflux-ci/*"}],
+			"specific-deny": [{"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*"}],
 		},
 	}
 
@@ -618,11 +618,11 @@ test_denying_pattern_multiple_rules if {
 test_denial_reason if {
 	# Test denial_reason returns the correct reason for denied tasks
 	trusted_task_rules := {
-		"allow": {"Allow konflux tasks": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}},
-		"deny": {"Deny old buildah": {
+		"allow": {"tekton-catalog": [{"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}]},
+		"deny": {"deprecated": [{
 			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
 			"message": "This version is deprecated",
-		}},
+		}]},
 	}
 
 	# Case 1: Matches a deny rule (even though it also matches allow)
@@ -703,32 +703,32 @@ test_trusted_task_rules_data_errors if {
 
 	# Valid trusted_task_rules should pass
 	valid_rules := {
-		"allow": {"Allow all konflux tasks": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}},
-		"deny": {"Deny old buildah": {
+		"allow": {"tekton-catalog": [{"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}]},
+		"deny": {"deprecated": [{
 			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
 			"effective_on": "2025-11-15",
 			"message": "Deprecated",
-		}},
+		}]},
 	}
 	assertions.assert_empty(tekton.data_errors) with data.rule_data.trusted_task_rules as valid_rules
 
-	# Missing required fields - object entry without pattern
-	invalid_rules := {"allow": {"Bad entry": {}}}
+	# Missing required fields - array entry without pattern
+	invalid_rules := {"allow": {"bad-group": [{}]}}
 	expected := {{
 		# regal ignore:line-length
-		"message": "trusted_task_rules data has unexpected format: allow.Bad entry: pattern is required",
+		"message": "trusted_task_rules data has unexpected format: allow.bad-group.0: pattern is required",
 		"severity": "failure",
 	}}
 	assertions.assert_equal(tekton.data_errors, expected) with data.rule_data.trusted_task_rules as invalid_rules
 
 	# Invalid effective_on date format
-	invalid_date_rules := {"allow": {"Invalid date": {
+	invalid_date_rules := {"allow": {"bad-date": [{
 		"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
 		"effective_on": "not-a-date",
-	}}}
+	}]}}
 	expected_date := {{
 		# regal ignore:line-length
-		"message": "trusted_task_rules data has unexpected format: allow.Invalid date.effective_on: Does not match format 'date'",
+		"message": "trusted_task_rules data has unexpected format: allow.bad-date.0.effective_on: Does not match format 'date'",
 		"severity": "failure",
 	}}
 	assertions.assert_equal(tekton.data_errors, expected_date) with data.rule_data.trusted_task_rules as invalid_date_rules
@@ -739,7 +739,7 @@ test_trusted_task_rules_data_errors if {
 	# Invalid allow/deny - not objects
 	invalid_structure := {
 		"allow": "not-an-object",
-		"deny": {"Valid deny": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}},
+		"deny": {"valid-deny": [{"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}]},
 	}
 	expected_structure := {{
 		# regal ignore:line-length
@@ -757,7 +757,7 @@ test_denying_pattern_invalid_task if {
 	# Any rules - doesn't matter since task has no valid ref
 	rules := {
 		"allow": {},
-		"deny": {"Deny something": {"pattern": "oci://quay.io/*"}},
+		"deny": {"blocked": [{"pattern": "oci://quay.io/*"}]},
 	}
 
 	# Should return empty list (else branch) since task_ref fails
@@ -771,7 +771,7 @@ test_denying_pattern_invalid_task if {
 test_denying_rules_info_empty if {
 	# Rules with no deny rules
 	rules_no_deny := {
-		"allow": {"Allow all": {"pattern": "oci://quay.io/*"}},
+		"allow": {"all": [{"pattern": "oci://quay.io/*"}]},
 		"deny": {},
 	}
 

--- a/policy/release/trusted_task/trusted_task_test.rego
+++ b/policy/release/trusted_task/trusted_task_test.rego
@@ -224,17 +224,11 @@ test_trusted_artifact_outdated if {
 test_trusted_artifact_denied_by_rules if {
 	# Deny all trusty tasks via trusted_task_rules
 	task_rules := {
-		"allow": {
-			"Allow all trusty tasks": {
-				"pattern": "oci://registry.local/trusty*",
-			},
-		},
-		"deny": {
-			"Deny trusty 1.0": {
-				"pattern": "oci://registry.local/trusty:1.0",
-				"message": "Version 1.0 is deprecated",
-			},
-		},
+		"allow": {"Allow all trusty tasks": {"pattern": "oci://registry.local/trusty*"}},
+		"deny": {"Deny trusty 1.0": {
+			"pattern": "oci://registry.local/trusty:1.0",
+			"message": "Version 1.0 is deprecated",
+		}},
 	}
 
 	# Use the full TA attestation - all tasks use the same bundle so all chains are denied
@@ -309,12 +303,10 @@ test_future_deny_rule_warning if {
 	# Task is allowed but a deny rule with future effective_on is present
 	task_rules := {
 		"allow": {"Allow all trusty tasks": {"pattern": "oci://registry.local/trusty*"}},
-		"deny": {
-			"Deny trusty 1.0 in the future": {
-				"pattern": "oci://registry.local/trusty:1.0*",
-				"effective_on": "2099-01-01",
-			},
-		},
+		"deny": {"Deny trusty 1.0 in the future": {
+			"pattern": "oci://registry.local/trusty:1.0*",
+			"effective_on": "2099-01-01",
+		}},
 	}
 
 	expected := {{
@@ -343,11 +335,7 @@ test_future_deny_rule_no_warning_when_already_effective if {
 	# Deny rule has no effective_on, so it's already effective (no warning)
 	task_rules := {
 		"allow": {"Allow all trusty tasks": {"pattern": "oci://registry.local/trusty*"}},
-		"deny": {
-			"Deny trusty 1.0": {
-				"pattern": "oci://registry.local/trusty:1.0*",
-			},
-		},
+		"deny": {"Deny trusty 1.0": {"pattern": "oci://registry.local/trusty:1.0*"}},
 	}
 
 	# No future_deny_rule warning expected (the deny itself will fire, but not the warning)
@@ -966,11 +954,7 @@ test_not_on_trusted_tasks_no_rules_untrusted if {
 # Task matches allow pattern → should NOT produce warn
 test_allow_by_location if {
 	trusted_task_rules_data := {
-		"allow": {
-			"Trust all tekton-catalog": {
-				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-			},
-		},
+		"allow": {"Trust all tekton-catalog": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}},
 		"deny": {},
 	}
 
@@ -994,11 +978,7 @@ test_allow_by_location if {
 # Task does NOT match allow pattern → should produce warn
 test_outside_pattern_not_trusted if {
 	trusted_task_rules_data := {
-		"allow": {
-			"Trust all tekton-catalog": {
-				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-			},
-		},
+		"allow": {"Trust all tekton-catalog": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}},
 		"deny": {},
 	}
 
@@ -1031,18 +1011,12 @@ test_outside_pattern_not_trusted if {
 # Task matches allow pattern but also matches deny → should produce deny with message
 test_deny_takes_precedence_over_allow if {
 	task_rules := {
-		"allow": {
-			"Allow tekton catalog": {
-				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-			},
-		},
-		"deny": {
-			"Block buildah 0.4": {
-				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
-				"message": "task-buildah:0.4 is deprecated",
-				"effective_on": "2025-01-01",
-			},
-		},
+		"allow": {"Allow tekton catalog": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}},
+		"deny": {"Block buildah 0.4": {
+			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
+			"message": "task-buildah:0.4 is deprecated",
+			"effective_on": "2025-01-01",
+		}},
 	}
 
 	att := _rules_make_attestation([_rules_make_task(
@@ -1075,12 +1049,10 @@ test_deny_takes_precedence_over_allow if {
 # D1 — Allow rule not yet effective → not trusted
 test_allow_rule_not_yet_effective if {
 	trusted_task_rules_data := {
-		"allow": {
-			"Trust tekton starting Feb": {
-				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-				"effective_on": "2025-02-01",
-			},
-		},
+		"allow": {"Trust tekton starting Feb": {
+			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
+			"effective_on": "2025-02-01",
+		}},
 		"deny": {},
 	}
 
@@ -1110,12 +1082,10 @@ test_allow_rule_not_yet_effective if {
 # D1 — Allow rule becomes effective → trusted
 test_allow_rule_effective_trusted if {
 	trusted_task_rules_data := {
-		"allow": {
-			"Trust tekton starting Feb": {
-				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-				"effective_on": "2025-02-01",
-			},
-		},
+		"allow": {"Trust tekton starting Feb": {
+			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
+			"effective_on": "2025-02-01",
+		}},
 		"deny": {},
 	}
 
@@ -1139,17 +1109,11 @@ test_allow_rule_effective_trusted if {
 # Time-based deny rule - not yet effective
 test_deny_rule_not_yet_effective if {
 	trusted_task_rules_data := {
-		"allow": {
-			"Allow tekton catalog": {
-				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-			},
-		},
-		"deny": {
-			"Expire buildah": {
-				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
-				"effective_on": "2025-03-01",
-			},
-		},
+		"allow": {"Allow tekton catalog": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}},
+		"deny": {"Expire buildah": {
+			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
+			"effective_on": "2025-03-01",
+		}},
 	}
 
 	att := _rules_make_attestation([_rules_make_task(
@@ -1172,17 +1136,11 @@ test_deny_rule_not_yet_effective if {
 # Time-based deny rule - becomes effective
 test_deny_rule_becomes_effective if {
 	trusted_task_rules_data := {
-		"allow": {
-			"Allow tekton catalog": {
-				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-			},
-		},
-		"deny": {
-			"Expire buildah": {
-				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
-				"effective_on": "2025-03-01",
-			},
-		},
+		"allow": {"Allow tekton catalog": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}},
+		"deny": {"Expire buildah": {
+			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
+			"effective_on": "2025-03-01",
+		}},
 	}
 
 	att := _rules_make_attestation([_rules_make_task(
@@ -1216,12 +1174,8 @@ test_deny_rule_becomes_effective if {
 test_multiple_allow_rules if {
 	trusted_task_rules_data := {
 		"allow": {
-			"Base allow by location": {
-				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-			},
-			"Additional allow rule with different scope": {
-				"pattern": "oci://quay.io/konflux-ci/*",
-			},
+			"Base allow by location": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"},
+			"Additional allow rule with different scope": {"pattern": "oci://quay.io/konflux-ci/*"},
 		},
 		"deny": {},
 	}
@@ -1249,18 +1203,12 @@ test_multiple_allow_rules if {
 # G1 — Deny with user-visible message
 test_deny_with_message if {
 	task_rules := {
-		"allow": {
-			"Allow tekton": {
-				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-			},
-		},
-		"deny": {
-			"Deprecate manifest": {
-				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-build-image-manifest*",
-				"message": "This task was renamed to build-image-index.",
-				"effective_on": "2025-10-26",
-			},
-		},
+		"allow": {"Allow tekton": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}},
+		"deny": {"Deprecate manifest": {
+			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-build-image-manifest*",
+			"message": "This task was renamed to build-image-index.",
+			"effective_on": "2025-10-26",
+		}},
 	}
 
 	att := _rules_make_attestation([_rules_make_task(
@@ -1300,11 +1248,7 @@ test_rules_allow_trusted_tasks_expiry_ignored if {
 	}]}
 
 	trusted_task_rules_data := {
-		"allow": {
-			"Allow tekton catalog": {
-				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-			},
-		},
+		"allow": {"Allow tekton catalog": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}},
 		"deny": {},
 	}
 
@@ -1332,12 +1276,10 @@ test_rules_allow_trusted_tasks_expiry_ignored if {
 # K1 — Unknown fields ignored
 test_unknown_fields_ignored if {
 	trusted_task_rules_data := {
-		"allow": {
-			"Allow tekton": {
-				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-				"foo": "bar", # unknown field - should be ignored
-			},
-		},
+		"allow": {"Allow tekton": {
+			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
+			"foo": "bar", # unknown field - should be ignored
+		}},
 		"deny": {},
 	}
 
@@ -1365,11 +1307,7 @@ test_unknown_fields_ignored if {
 # Test multiple tasks - some trusted, some not
 test_mixed_trusted_and_untrusted_tasks if {
 	trusted_task_rules_data := {
-		"allow": {
-			"Allow tekton catalog": {
-				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-			},
-		},
+		"allow": {"Allow tekton catalog": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}},
 		"deny": {},
 	}
 

--- a/policy/release/trusted_task/trusted_task_test.rego
+++ b/policy/release/trusted_task/trusted_task_test.rego
@@ -224,11 +224,11 @@ test_trusted_artifact_outdated if {
 test_trusted_artifact_denied_by_rules if {
 	# Deny all trusty tasks via trusted_task_rules
 	task_rules := {
-		"allow": {"Allow all trusty tasks": {"pattern": "oci://registry.local/trusty*"}},
-		"deny": {"Deny trusty 1.0": {
+		"allow": {"trusty-tasks": [{"pattern": "oci://registry.local/trusty*"}]},
+		"deny": {"deprecated": [{
 			"pattern": "oci://registry.local/trusty:1.0",
 			"message": "Version 1.0 is deprecated",
-		}},
+		}]},
 	}
 
 	# Use the full TA attestation - all tasks use the same bundle so all chains are denied
@@ -302,11 +302,11 @@ test_future_deny_rule_warning if {
 
 	# Task is allowed but a deny rule with future effective_on is present
 	task_rules := {
-		"allow": {"Allow all trusty tasks": {"pattern": "oci://registry.local/trusty*"}},
-		"deny": {"Deny trusty 1.0 in the future": {
+		"allow": {"trusty-tasks": [{"pattern": "oci://registry.local/trusty*"}]},
+		"deny": {"future-deny": [{
 			"pattern": "oci://registry.local/trusty:1.0*",
 			"effective_on": "2099-01-01",
-		}},
+		}]},
 	}
 
 	expected := {{
@@ -334,8 +334,8 @@ test_future_deny_rule_no_warning_when_already_effective if {
 
 	# Deny rule has no effective_on, so it's already effective (no warning)
 	task_rules := {
-		"allow": {"Allow all trusty tasks": {"pattern": "oci://registry.local/trusty*"}},
-		"deny": {"Deny trusty 1.0": {"pattern": "oci://registry.local/trusty:1.0*"}},
+		"allow": {"trusty-tasks": [{"pattern": "oci://registry.local/trusty*"}]},
+		"deny": {"current-deny": [{"pattern": "oci://registry.local/trusty:1.0*"}]},
 	}
 
 	# No future_deny_rule warning expected (the deny itself will fire, but not the warning)
@@ -954,7 +954,7 @@ test_not_on_trusted_tasks_no_rules_untrusted if {
 # Task matches allow pattern → should NOT produce warn
 test_allow_by_location if {
 	trusted_task_rules_data := {
-		"allow": {"Trust all tekton-catalog": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}},
+		"allow": {"tekton-catalog": [{"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}]},
 		"deny": {},
 	}
 
@@ -978,7 +978,7 @@ test_allow_by_location if {
 # Task does NOT match allow pattern → should produce warn
 test_outside_pattern_not_trusted if {
 	trusted_task_rules_data := {
-		"allow": {"Trust all tekton-catalog": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}},
+		"allow": {"tekton-catalog": [{"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}]},
 		"deny": {},
 	}
 
@@ -1011,12 +1011,12 @@ test_outside_pattern_not_trusted if {
 # Task matches allow pattern but also matches deny → should produce deny with message
 test_deny_takes_precedence_over_allow if {
 	task_rules := {
-		"allow": {"Allow tekton catalog": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}},
-		"deny": {"Block buildah 0.4": {
+		"allow": {"tekton-catalog": [{"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}]},
+		"deny": {"deprecated-buildah": [{
 			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
 			"message": "task-buildah:0.4 is deprecated",
 			"effective_on": "2025-01-01",
-		}},
+		}]},
 	}
 
 	att := _rules_make_attestation([_rules_make_task(
@@ -1049,10 +1049,10 @@ test_deny_takes_precedence_over_allow if {
 # D1 — Allow rule not yet effective → not trusted
 test_allow_rule_not_yet_effective if {
 	trusted_task_rules_data := {
-		"allow": {"Trust tekton starting Feb": {
+		"allow": {"tekton-catalog": [{
 			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
 			"effective_on": "2025-02-01",
-		}},
+		}]},
 		"deny": {},
 	}
 
@@ -1082,10 +1082,10 @@ test_allow_rule_not_yet_effective if {
 # D1 — Allow rule becomes effective → trusted
 test_allow_rule_effective_trusted if {
 	trusted_task_rules_data := {
-		"allow": {"Trust tekton starting Feb": {
+		"allow": {"tekton-catalog": [{
 			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
 			"effective_on": "2025-02-01",
-		}},
+		}]},
 		"deny": {},
 	}
 
@@ -1109,11 +1109,11 @@ test_allow_rule_effective_trusted if {
 # Time-based deny rule - not yet effective
 test_deny_rule_not_yet_effective if {
 	trusted_task_rules_data := {
-		"allow": {"Allow tekton catalog": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}},
-		"deny": {"Expire buildah": {
+		"allow": {"tekton-catalog": [{"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}]},
+		"deny": {"expire-buildah": [{
 			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
 			"effective_on": "2025-03-01",
-		}},
+		}]},
 	}
 
 	att := _rules_make_attestation([_rules_make_task(
@@ -1136,11 +1136,11 @@ test_deny_rule_not_yet_effective if {
 # Time-based deny rule - becomes effective
 test_deny_rule_becomes_effective if {
 	trusted_task_rules_data := {
-		"allow": {"Allow tekton catalog": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}},
-		"deny": {"Expire buildah": {
+		"allow": {"tekton-catalog": [{"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}]},
+		"deny": {"expire-buildah": [{
 			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
 			"effective_on": "2025-03-01",
-		}},
+		}]},
 	}
 
 	att := _rules_make_attestation([_rules_make_task(
@@ -1174,8 +1174,8 @@ test_deny_rule_becomes_effective if {
 test_multiple_allow_rules if {
 	trusted_task_rules_data := {
 		"allow": {
-			"Base allow by location": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"},
-			"Additional allow rule with different scope": {"pattern": "oci://quay.io/konflux-ci/*"},
+			"tekton-catalog": [{"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}],
+			"all-konflux": [{"pattern": "oci://quay.io/konflux-ci/*"}],
 		},
 		"deny": {},
 	}
@@ -1203,12 +1203,12 @@ test_multiple_allow_rules if {
 # G1 — Deny with user-visible message
 test_deny_with_message if {
 	task_rules := {
-		"allow": {"Allow tekton": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}},
-		"deny": {"Deprecate manifest": {
+		"allow": {"tekton-catalog": [{"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}]},
+		"deny": {"deprecated-manifest": [{
 			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-build-image-manifest*",
 			"message": "This task was renamed to build-image-index.",
 			"effective_on": "2025-10-26",
-		}},
+		}]},
 	}
 
 	att := _rules_make_attestation([_rules_make_task(
@@ -1248,7 +1248,7 @@ test_rules_allow_trusted_tasks_expiry_ignored if {
 	}]}
 
 	trusted_task_rules_data := {
-		"allow": {"Allow tekton catalog": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}},
+		"allow": {"tekton-catalog": [{"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}]},
 		"deny": {},
 	}
 
@@ -1276,10 +1276,10 @@ test_rules_allow_trusted_tasks_expiry_ignored if {
 # K1 — Unknown fields ignored
 test_unknown_fields_ignored if {
 	trusted_task_rules_data := {
-		"allow": {"Allow tekton": {
+		"allow": {"tekton-catalog": [{
 			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
 			"foo": "bar", # unknown field - should be ignored
-		}},
+		}]},
 		"deny": {},
 	}
 
@@ -1307,7 +1307,7 @@ test_unknown_fields_ignored if {
 # Test multiple tasks - some trusted, some not
 test_mixed_trusted_and_untrusted_tasks if {
 	trusted_task_rules_data := {
-		"allow": {"Allow tekton catalog": {"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}},
+		"allow": {"tekton-catalog": [{"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*"}]},
 		"deny": {},
 	}
 

--- a/policy/release/trusted_task/trusted_task_test.rego
+++ b/policy/release/trusted_task/trusted_task_test.rego
@@ -224,15 +224,17 @@ test_trusted_artifact_outdated if {
 test_trusted_artifact_denied_by_rules if {
 	# Deny all trusty tasks via trusted_task_rules
 	task_rules := {
-		"allow": [{
-			"name": "Allow all trusty tasks",
-			"pattern": "oci://registry.local/trusty*",
-		}],
-		"deny": [{
-			"name": "Deny trusty 1.0",
-			"pattern": "oci://registry.local/trusty:1.0",
-			"message": "Version 1.0 is deprecated",
-		}],
+		"allow": {
+			"Allow all trusty tasks": {
+				"pattern": "oci://registry.local/trusty*",
+			},
+		},
+		"deny": {
+			"Deny trusty 1.0": {
+				"pattern": "oci://registry.local/trusty:1.0",
+				"message": "Version 1.0 is deprecated",
+			},
+		},
 	}
 
 	# Use the full TA attestation - all tasks use the same bundle so all chains are denied
@@ -306,12 +308,13 @@ test_future_deny_rule_warning if {
 
 	# Task is allowed but a deny rule with future effective_on is present
 	task_rules := {
-		"allow": [{"name": "Allow all trusty tasks", "pattern": "oci://registry.local/trusty*"}],
-		"deny": [{
-			"name": "Deny trusty 1.0 in the future",
-			"pattern": "oci://registry.local/trusty:1.0*",
-			"effective_on": "2099-01-01",
-		}],
+		"allow": {"Allow all trusty tasks": {"pattern": "oci://registry.local/trusty*"}},
+		"deny": {
+			"Deny trusty 1.0 in the future": {
+				"pattern": "oci://registry.local/trusty:1.0*",
+				"effective_on": "2099-01-01",
+			},
+		},
 	}
 
 	expected := {{
@@ -339,11 +342,12 @@ test_future_deny_rule_no_warning_when_already_effective if {
 
 	# Deny rule has no effective_on, so it's already effective (no warning)
 	task_rules := {
-		"allow": [{"name": "Allow all trusty tasks", "pattern": "oci://registry.local/trusty*"}],
-		"deny": [{
-			"name": "Deny trusty 1.0",
-			"pattern": "oci://registry.local/trusty:1.0*",
-		}],
+		"allow": {"Allow all trusty tasks": {"pattern": "oci://registry.local/trusty*"}},
+		"deny": {
+			"Deny trusty 1.0": {
+				"pattern": "oci://registry.local/trusty:1.0*",
+			},
+		},
 	}
 
 	# No future_deny_rule warning expected (the deny itself will fire, but not the warning)
@@ -876,8 +880,8 @@ test_on_trusted_tasks_no_rules_trusted if {
 	rules_trusted_tasks_data := {"oci://quay.io/konflux-ci/tekton-catalog/task-buildah:0.4": [{"ref": "sha256:abc1230000000000000000000000000000000000000000000000000000abc123"}]}
 
 	trusted_task_rules_data := {
-		"allow": [],
-		"deny": [],
+		"allow": {},
+		"deny": {},
 	}
 
 	att := _rules_make_attestation([_rules_make_task(
@@ -902,8 +906,8 @@ test_on_trusted_tasks_expired_untrusted if {
 	}]}
 
 	trusted_task_rules_data := {
-		"allow": [],
-		"deny": [],
+		"allow": {},
+		"deny": {},
 	}
 
 	att := _rules_make_attestation([_rules_make_task(
@@ -933,8 +937,8 @@ test_not_on_trusted_tasks_no_rules_untrusted if {
 	rules_trusted_tasks_data := {}
 
 	trusted_task_rules_data := {
-		"allow": [],
-		"deny": [],
+		"allow": {},
+		"deny": {},
 	}
 
 	att := _rules_make_attestation([_rules_make_task(
@@ -962,11 +966,12 @@ test_not_on_trusted_tasks_no_rules_untrusted if {
 # Task matches allow pattern → should NOT produce warn
 test_allow_by_location if {
 	trusted_task_rules_data := {
-		"allow": [{
-			"name": "Trust all tekton-catalog",
-			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-		}],
-		"deny": [],
+		"allow": {
+			"Trust all tekton-catalog": {
+				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
+			},
+		},
+		"deny": {},
 	}
 
 	att := _rules_make_attestation([_rules_make_task(
@@ -989,11 +994,12 @@ test_allow_by_location if {
 # Task does NOT match allow pattern → should produce warn
 test_outside_pattern_not_trusted if {
 	trusted_task_rules_data := {
-		"allow": [{
-			"name": "Trust all tekton-catalog",
-			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-		}],
-		"deny": [],
+		"allow": {
+			"Trust all tekton-catalog": {
+				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
+			},
+		},
+		"deny": {},
 	}
 
 	att := _rules_make_attestation([_rules_make_task(
@@ -1025,16 +1031,18 @@ test_outside_pattern_not_trusted if {
 # Task matches allow pattern but also matches deny → should produce deny with message
 test_deny_takes_precedence_over_allow if {
 	task_rules := {
-		"allow": [{
-			"name": "Allow tekton catalog",
-			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-		}],
-		"deny": [{
-			"name": "Block buildah 0.4",
-			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
-			"message": "task-buildah:0.4 is deprecated",
-			"effective_on": "2025-01-01",
-		}],
+		"allow": {
+			"Allow tekton catalog": {
+				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
+			},
+		},
+		"deny": {
+			"Block buildah 0.4": {
+				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
+				"message": "task-buildah:0.4 is deprecated",
+				"effective_on": "2025-01-01",
+			},
+		},
 	}
 
 	att := _rules_make_attestation([_rules_make_task(
@@ -1067,12 +1075,13 @@ test_deny_takes_precedence_over_allow if {
 # D1 — Allow rule not yet effective → not trusted
 test_allow_rule_not_yet_effective if {
 	trusted_task_rules_data := {
-		"allow": [{
-			"name": "Trust tekton starting Feb",
-			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-			"effective_on": "2025-02-01",
-		}],
-		"deny": [],
+		"allow": {
+			"Trust tekton starting Feb": {
+				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
+				"effective_on": "2025-02-01",
+			},
+		},
+		"deny": {},
 	}
 
 	att := _rules_make_attestation([_rules_make_task(
@@ -1101,12 +1110,13 @@ test_allow_rule_not_yet_effective if {
 # D1 — Allow rule becomes effective → trusted
 test_allow_rule_effective_trusted if {
 	trusted_task_rules_data := {
-		"allow": [{
-			"name": "Trust tekton starting Feb",
-			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-			"effective_on": "2025-02-01",
-		}],
-		"deny": [],
+		"allow": {
+			"Trust tekton starting Feb": {
+				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
+				"effective_on": "2025-02-01",
+			},
+		},
+		"deny": {},
 	}
 
 	att := _rules_make_attestation([_rules_make_task(
@@ -1129,15 +1139,17 @@ test_allow_rule_effective_trusted if {
 # Time-based deny rule - not yet effective
 test_deny_rule_not_yet_effective if {
 	trusted_task_rules_data := {
-		"allow": [{
-			"name": "Allow tekton catalog",
-			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-		}],
-		"deny": [{
-			"name": "Expire buildah",
-			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
-			"effective_on": "2025-03-01",
-		}],
+		"allow": {
+			"Allow tekton catalog": {
+				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
+			},
+		},
+		"deny": {
+			"Expire buildah": {
+				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
+				"effective_on": "2025-03-01",
+			},
+		},
 	}
 
 	att := _rules_make_attestation([_rules_make_task(
@@ -1160,15 +1172,17 @@ test_deny_rule_not_yet_effective if {
 # Time-based deny rule - becomes effective
 test_deny_rule_becomes_effective if {
 	trusted_task_rules_data := {
-		"allow": [{
-			"name": "Allow tekton catalog",
-			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-		}],
-		"deny": [{
-			"name": "Expire buildah",
-			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
-			"effective_on": "2025-03-01",
-		}],
+		"allow": {
+			"Allow tekton catalog": {
+				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
+			},
+		},
+		"deny": {
+			"Expire buildah": {
+				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-buildah*",
+				"effective_on": "2025-03-01",
+			},
+		},
 	}
 
 	att := _rules_make_attestation([_rules_make_task(
@@ -1201,17 +1215,15 @@ test_deny_rule_becomes_effective if {
 # Multiple allow rules with same pattern - task matching any effective rule is trusted
 test_multiple_allow_rules if {
 	trusted_task_rules_data := {
-		"allow": [
-			{
-				"name": "Base allow by location",
+		"allow": {
+			"Base allow by location": {
 				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
 			},
-			{
-				"name": "Additional allow rule with different scope",
+			"Additional allow rule with different scope": {
 				"pattern": "oci://quay.io/konflux-ci/*",
 			},
-		],
-		"deny": [],
+		},
+		"deny": {},
 	}
 
 	att := _rules_make_attestation([_rules_make_task(
@@ -1237,16 +1249,18 @@ test_multiple_allow_rules if {
 # G1 — Deny with user-visible message
 test_deny_with_message if {
 	task_rules := {
-		"allow": [{
-			"name": "Allow tekton",
-			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-		}],
-		"deny": [{
-			"name": "Deprecate manifest",
-			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-build-image-manifest*",
-			"message": "This task was renamed to build-image-index.",
-			"effective_on": "2025-10-26",
-		}],
+		"allow": {
+			"Allow tekton": {
+				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
+			},
+		},
+		"deny": {
+			"Deprecate manifest": {
+				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/task-build-image-manifest*",
+				"message": "This task was renamed to build-image-index.",
+				"effective_on": "2025-10-26",
+			},
+		},
 	}
 
 	att := _rules_make_attestation([_rules_make_task(
@@ -1286,11 +1300,12 @@ test_rules_allow_trusted_tasks_expiry_ignored if {
 	}]}
 
 	trusted_task_rules_data := {
-		"allow": [{
-			"name": "Allow tekton catalog",
-			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-		}],
-		"deny": [],
+		"allow": {
+			"Allow tekton catalog": {
+				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
+			},
+		},
+		"deny": {},
 	}
 
 	att := _rules_make_attestation([_rules_make_task(
@@ -1317,12 +1332,13 @@ test_rules_allow_trusted_tasks_expiry_ignored if {
 # K1 — Unknown fields ignored
 test_unknown_fields_ignored if {
 	trusted_task_rules_data := {
-		"allow": [{
-			"name": "Allow tekton",
-			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-			"foo": "bar", # unknown field - should be ignored
-		}],
-		"deny": [],
+		"allow": {
+			"Allow tekton": {
+				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
+				"foo": "bar", # unknown field - should be ignored
+			},
+		},
+		"deny": {},
 	}
 
 	att := _rules_make_attestation([_rules_make_task(
@@ -1349,11 +1365,12 @@ test_unknown_fields_ignored if {
 # Test multiple tasks - some trusted, some not
 test_mixed_trusted_and_untrusted_tasks if {
 	trusted_task_rules_data := {
-		"allow": [{
-			"name": "Allow tekton catalog",
-			"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
-		}],
-		"deny": [],
+		"allow": {
+			"Allow tekton catalog": {
+				"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
+			},
+		},
+		"deny": {},
 	}
 
 	att := _rules_make_attestation([


### PR DESCRIPTION
When multiple data sources each define trusted_task_rules entries, OPA fails to merge them because arrays at the same path produce a merge error at data load time, before Rego evaluation begins. This change switches allow and deny from arrays to objects keyed by a unique name, allowing OPA to deep-merge entries from multiple data sources without conflict.

https://redhat.atlassian.net/browse/EC-1782
