### PR TITLE
fix(olm): use ec.oci.descriptor to check unmapped image accessibility

### DIFF
--- a/antora/docs/modules/ROOT/pages/packages/release_olm.adoc
+++ b/antora/docs/modules/ROOT/pages/packages/release_olm.adoc
@@ -43,7 +43,7 @@ Each image referenced by the OLM bundle should match an entry in the list of pre
 * FAILURE message: `The %q CSV image reference is not from an allowed registry.`
 * Code: `olm.allowed_registries`
 * Effective from: `2024-09-01T00:00:00Z`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L306[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L308[Source, window="_blank"]
 
 [#olm__allowed_resource_kinds]
 === link:#olm__allowed_resource_kinds[OLM bundle image manifests contain only allowed resource kinds]
@@ -55,7 +55,7 @@ Every manifest in an OLM bundle must be of an allowed resource kind, as defined 
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `The %q manifest kind is not in the list of OLM allowed resource kinds.`
 * Code: `olm.allowed_resource_kinds`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L361[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L363[Source, window="_blank"]
 
 [#olm__olm_bundle_multi_arch]
 === link:#olm__olm_bundle_multi_arch[OLM bundle images are not multi-arch]
@@ -68,7 +68,7 @@ OLM bundle images should be built for a single architecture. They should not be 
 * FAILURE message: `The %q bundle image is a multi-arch reference.`
 * Code: `olm.olm_bundle_multi_arch`
 * Effective from: `2025-05-01T00:00:00Z`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L339[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L341[Source, window="_blank"]
 
 [#olm__allowed_registries_related]
 === link:#olm__allowed_registries_related[Related images references are from allowed registries]

--- a/policy/release/olm/olm.rego
+++ b/policy/release/olm/olm.rego
@@ -297,7 +297,9 @@ deny contains result if {
 	]
 
 	some unmatched_image in unmatched_image_refs
-	not ec.oci.image_manifest(image.str(unmatched_image.ref))
+
+	# Use descriptor (HEAD request) instead of image_manifest to avoid platform resolution failures on multi-arch indexes.
+	not ec.oci.descriptor(image.str(unmatched_image.ref))
 
 	# regal ignore:line-length
 	result := metadata.result_helper_with_term(rego.metadata.chain(), [image.str(unmatched_image.ref)], image.str(unmatched_image.ref))

--- a/policy/release/source_image/source_image.rego
+++ b/policy/release/source_image/source_image.rego
@@ -53,7 +53,9 @@ _source_image_errors contains error if {
 
 _source_image_errors contains error if {
 	some img in _source_images
-	not ec.oci.image_manifest(img)
+
+	# Use descriptor (HEAD request) instead of image_manifest to avoid platform resolution failures on multi-arch indexes.
+	not ec.oci.descriptor(img)
 	error := sprintf("Unable to access source image %q", [img])
 }
 

--- a/policy/release/source_image/source_image_test.rego
+++ b/policy/release/source_image/source_image_test.rego
@@ -57,6 +57,7 @@ test_success if {
 
 	assertions.assert_empty(source_image.deny) with input.attestations as attestations
 		with ec.oci.image_manifest as mock_ec_oci_image_manifest
+		with ec.oci.descriptor as mock_ec_oci_descriptor
 		with ec.sigstore.verify_image as _mock_verify_image
 }
 
@@ -130,6 +131,7 @@ test_inaccessible_source_image_references if {
 	}
 
 	assertions.assert_equal_results(expected, source_image.deny) with input.attestations as attestations
+		with ec.oci.descriptor as false
 		with ec.oci.image_manifest as false
 		with ec.sigstore.verify_image as _mock_verify_image
 }
@@ -177,6 +179,7 @@ test_empty_source_image if {
 
 	assertions.assert_equal_results(expected, source_image.deny) with input.attestations as attestations
 		with ec.oci.image_manifest as {"schemaVersion": 2}
+		with ec.oci.descriptor as mock_ec_oci_descriptor
 		with ec.sigstore.verify_image as _mock_verify_image
 }
 
@@ -226,7 +229,13 @@ test_missing_signature if {
 
 	assertions.assert_equal_results(expected, source_image.deny) with input.attestations as attestations
 		with ec.oci.image_manifest as mock_ec_oci_image_manifest
+		with ec.oci.descriptor as mock_ec_oci_descriptor
 		with ec.sigstore.verify_image as {"errors": ["kaboom!"]}
+}
+
+mock_ec_oci_descriptor(img) := descriptor if {
+	not contains(img, "\n")
+	descriptor := {"mediaType": "application/vnd.oci.image.manifest.v1+json"}
 }
 
 mock_ec_oci_image_manifest(img) := manifest if {


### PR DESCRIPTION
`ec.oci.image_manifest` resolves multi-arch indexes to linux/amd64, failing for indexes that only contain other platforms. Use `ec.oci.descriptor` instead, which performs a HEAD request to verify the image exists without platform resolution.

https://redhat.atlassian.net/browse/EC-1781