### PR TITLE
feat: verify operator bundle operands use NetworkPolicies for new releases

### DIFF
--- a/antora/docs/modules/ROOT/pages/packages/release_olm.adoc
+++ b/antora/docs/modules/ROOT/pages/packages/release_olm.adoc
@@ -83,6 +83,19 @@ Each image indicated as a related image should match an entry in the list of pre
 * Effective from: `2025-04-15T00:00:00Z`
 * https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L232[Source, window="_blank"]
 
+[#olm__required_network_policy_rbac_for_operands]
+=== link:#olm__required_network_policy_rbac_for_operands[Required NetworkPolicy RBAC missing from OLM bundle]
+
+Operators are required to manage the network policies of their operands. This rule verifies that operator bundles request sufficient RBAC permissions to manage NetworkPolicy lifecycle (create, delete, and update/patch) for networking.k8s.io/networkpolicies in their ClusterServiceVersion. Bundles whose operator name and major.minor version are listed in the `operator_network_policy_rbac_exceptions` rule data key are exempt from this requirement.
+
+*Solution*: Add a rule granting create, delete, and update/patch on networking.k8s.io/networkpolicies to the ClusterServiceVersion clusterPermissions or permissions, or add the operator name and its major.minor version to the operator_network_policy_rbac_exceptions rule data key.
+
+* Rule type: [rule-type-indicator failure]#FAILURE#
+* FAILURE message: `Operator %q version %q is missing required NetworkPolicy RBAC (networking.k8s.io/networkpolicies with create, delete, and update/patch)`
+* Code: `olm.required_network_policy_rbac_for_operands`
+* Effective from: `2026-08-07T00:00:00Z`
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L387[Source, window="_blank"]
+
 [#olm__required_olm_features_annotations_provided]
 === link:#olm__required_olm_features_annotations_provided[Required OLM feature annotations list provided]
 

--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -141,6 +141,7 @@ Rules included:
 * xref:packages/release_olm.adoc#olm__allowed_resource_kinds[OLM: OLM bundle image manifests contain only allowed resource kinds]        
 * xref:packages/release_olm.adoc#olm__olm_bundle_multi_arch[OLM: OLM bundle images are not multi-arch]        
 * xref:packages/release_olm.adoc#olm__allowed_registries_related[OLM: Related images references are from allowed registries]        
+* xref:packages/release_olm.adoc#olm__required_network_policy_rbac_for_operands[OLM: Required NetworkPolicy RBAC missing from OLM bundle]        
 * xref:packages/release_olm.adoc#olm__required_olm_features_annotations_provided[OLM: Required OLM feature annotations list provided]        
 * xref:packages/release_olm.adoc#olm__subscriptions_annotation_format[OLM: Subscription annotation has expected value]        
 * xref:packages/release_olm.adoc#olm__inaccessible_related_images[OLM: Unable to access related images for a component]        

--- a/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
+++ b/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
@@ -67,6 +67,7 @@
 **** xref:packages/release_olm.adoc#olm__allowed_resource_kinds[OLM bundle image manifests contain only allowed resource kinds]
 **** xref:packages/release_olm.adoc#olm__olm_bundle_multi_arch[OLM bundle images are not multi-arch]
 **** xref:packages/release_olm.adoc#olm__allowed_registries_related[Related images references are from allowed registries]
+**** xref:packages/release_olm.adoc#olm__required_network_policy_rbac_for_operands[Required NetworkPolicy RBAC missing from OLM bundle]
 **** xref:packages/release_olm.adoc#olm__required_olm_features_annotations_provided[Required OLM feature annotations list provided]
 **** xref:packages/release_olm.adoc#olm__subscriptions_annotation_format[Subscription annotation has expected value]
 **** xref:packages/release_olm.adoc#olm__inaccessible_related_images[Unable to access related images for a component]

--- a/policy/lib/rule_data/rule_data.rego
+++ b/policy/lib/rule_data/rule_data.rego
@@ -117,6 +117,9 @@ defaults := {
 		"ConsoleLink",
 		"ConsolePlugin",
 	],
+	# Used in release/olm.rego
+	# Operators excepted from NetworkPolicy RBAC requirement by name and major.minor version
+	"operator_network_policy_rbac_exceptions": {},
 	#
 	# Used in release/hermetic_task/hermetic_task.rego
 	"required_hermetic_tasks": [

--- a/policy/release/olm/olm.rego
+++ b/policy/release/olm/olm.rego
@@ -384,6 +384,85 @@ deny contains result if {
 	result := metadata.result_helper_with_term(rego.metadata.chain(), [manifest.kind], manifest.kind)
 }
 
+# METADATA
+# title: Required NetworkPolicy RBAC missing from OLM bundle
+# description: >-
+#   Operators are required to manage the network policies of their operands.
+#   This rule verifies that operator bundles request sufficient RBAC permissions
+#   to manage NetworkPolicy lifecycle (create, delete, and update/patch) for
+#   networking.k8s.io/networkpolicies in their ClusterServiceVersion.
+#   Bundles whose operator name and major.minor version are listed in the
+#   `operator_network_policy_rbac_exceptions` rule data key are exempt from this
+#   requirement.
+# custom:
+#   short_name: required_network_policy_rbac_for_operands
+#   failure_msg: >-
+#     Operator %q version %q is missing required NetworkPolicy RBAC
+#     (networking.k8s.io/networkpolicies with create, delete, and update/patch)
+#   solution: >-
+#     Add a rule granting create, delete, and update/patch on networking.k8s.io/networkpolicies
+#     to the ClusterServiceVersion clusterPermissions or permissions, or add the operator name
+#     and its major.minor version to the operator_network_policy_rbac_exceptions rule data key.
+#   collections:
+#   - redhat
+#   rule_data_fields:
+#   - operator_network_policy_rbac_exceptions
+#   effective_on: 2026-08-07T00:00:00Z
+deny contains result if {
+	some manifest in _csv_manifests
+	not _network_policy_rbac_excepted(manifest)
+	not _has_network_policy_rbac(manifest)
+	result := metadata.result_helper(rego.metadata.chain(), [_operator_package_name, manifest.spec.version])
+}
+
+_operator_package_name := input.image.config.Labels["operators.operatorframework.io.bundle.package.v1"]
+
+_major_minor_version(ver) := mm if {
+	parts := split(ver, ".")
+	count(parts) >= 2
+	mm := concat(".", [parts[0], parts[1]])
+}
+
+_network_policy_rbac_excepted(manifest) if {
+	exceptions := rule_data.get("operator_network_policy_rbac_exceptions")
+	version := _major_minor_version(manifest.spec.version)
+	version in exceptions[_operator_package_name]
+}
+
+_has_network_policy_rbac(manifest) if {
+	some perm in manifest.spec.install.spec.clusterPermissions
+	some rule in perm.rules
+	_is_network_policy_rule(rule)
+}
+
+_has_network_policy_rbac(manifest) if {
+	some perm in manifest.spec.install.spec.permissions
+	some rule in perm.rules
+	_is_network_policy_rule(rule)
+}
+
+_is_network_policy_rule(rule) if {
+	"networking.k8s.io" in rule.apiGroups
+	"networkpolicies" in rule.resources
+	_has_lifecycle_verbs(rule.verbs)
+}
+
+_has_lifecycle_verbs(verbs) if {
+	"*" in verbs
+}
+
+_has_lifecycle_verbs(verbs) if {
+	"create" in verbs
+	"delete" in verbs
+	"update" in verbs
+}
+
+_has_lifecycle_verbs(verbs) if {
+	"create" in verbs
+	"delete" in verbs
+	"patch" in verbs
+}
+
 _name(o) := n if {
 	n := o.name
 } else := "unnamed"

--- a/policy/release/olm/olm_test.rego
+++ b/policy/release/olm/olm_test.rego
@@ -657,3 +657,414 @@ test_allowed_olm_resource_kind if {
 		with input.image.files as {"manifests/service.yaml": service_manifest}
 		with data.rule_data.allowed_olm_resource_kinds as ["Service"]
 }
+
+# NetworkPolicy RBAC Tests
+
+base_network_policy_manifest := {
+	"apiVersion": "operators.coreos.com/v1alpha1",
+	"kind": "ClusterServiceVersion",
+	"metadata": {
+		"name": "test-operator.v1.2.3",
+		"annotations": {
+			"operators.operatorframework.io/bundle.package.v1": "test-operator",
+			"features.operators.openshift.io/disconnected": "true",
+			"features.operators.openshift.io/fips-compliant": "true",
+			"features.operators.openshift.io/proxy-aware": "true",
+			"features.operators.openshift.io/tls-profiles": "true",
+			"features.operators.openshift.io/token-auth-aws": "true",
+			"features.operators.openshift.io/token-auth-azure": "true",
+			"features.operators.openshift.io/token-auth-gcp": "true",
+			"operators.openshift.io/valid-subscription": `["test"]`,
+		},
+	},
+	"spec": {
+		"version": "1.2.3",
+		"install": {"spec": {
+			"clusterPermissions": [],
+			"permissions": [],
+			"deployments": [],
+		}},
+	},
+}
+
+test_network_policy_rbac_with_all_required_verbs if {
+	manifest_with_rbac := json.patch(base_network_policy_manifest, [{
+		"op": "add",
+		"path": "/spec/install/spec/clusterPermissions",
+		"value": [{
+			"serviceAccountName": "test-sa",
+			"rules": [{
+				"apiGroups": ["networking.k8s.io"],
+				"resources": ["networkpolicies"],
+				"verbs": ["create", "update", "patch", "delete"],
+			}],
+		}],
+	}])
+
+	assertions.assert_empty(olm.deny) with input.image.files as {"manifests/csv.yaml": manifest_with_rbac}
+		with input.image.config.Labels as {olm.manifestv1: "manifests/", "operators.operatorframework.io.bundle.package.v1": "test-operator"}
+		with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.io"]
+		with data.rule_data.allowed_olm_resource_kinds as ["ClusterServiceVersion"]
+		with data.rule_data.operator_network_policy_rbac_exceptions as {}
+}
+
+test_network_policy_rbac_with_only_create if {
+	manifest_with_create := json.patch(base_network_policy_manifest, [{
+		"op": "add",
+		"path": "/spec/install/spec/clusterPermissions",
+		"value": [{
+			"serviceAccountName": "test-sa",
+			"rules": [{
+				"apiGroups": ["networking.k8s.io"],
+				"resources": ["networkpolicies"],
+				"verbs": ["create"],
+			}],
+		}],
+	}])
+
+	expected := {{
+		"code": "olm.required_network_policy_rbac_for_operands",
+		# regal ignore:line-length
+		"msg": `Operator "test-operator" version "1.2.3" is missing required NetworkPolicy RBAC (networking.k8s.io/networkpolicies with create, delete, and update/patch)`,
+	}}
+
+	assertions.assert_equal_results(olm.deny, expected) with input.image.files as {"manifests/csv.yaml": manifest_with_create}
+		with input.image.config.Labels as {olm.manifestv1: "manifests/", "operators.operatorframework.io.bundle.package.v1": "test-operator"}
+		with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.io"]
+		with data.rule_data.allowed_olm_resource_kinds as ["ClusterServiceVersion"]
+		with data.rule_data.operator_network_policy_rbac_exceptions as {}
+}
+
+test_network_policy_rbac_with_only_delete if {
+	manifest_with_delete := json.patch(base_network_policy_manifest, [{
+		"op": "add",
+		"path": "/spec/install/spec/clusterPermissions",
+		"value": [{
+			"serviceAccountName": "test-sa",
+			"rules": [{
+				"apiGroups": ["networking.k8s.io"],
+				"resources": ["networkpolicies"],
+				"verbs": ["delete"],
+			}],
+		}],
+	}])
+
+	expected := {{
+		"code": "olm.required_network_policy_rbac_for_operands",
+		# regal ignore:line-length
+		"msg": `Operator "test-operator" version "1.2.3" is missing required NetworkPolicy RBAC (networking.k8s.io/networkpolicies with create, delete, and update/patch)`,
+	}}
+
+	assertions.assert_equal_results(olm.deny, expected) with input.image.files as {"manifests/csv.yaml": manifest_with_delete}
+		with input.image.config.Labels as {olm.manifestv1: "manifests/", "operators.operatorframework.io.bundle.package.v1": "test-operator"}
+		with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.io"]
+		with data.rule_data.allowed_olm_resource_kinds as ["ClusterServiceVersion"]
+		with data.rule_data.operator_network_policy_rbac_exceptions as {}
+}
+
+test_network_policy_rbac_with_create_update_delete if {
+	manifest_cud := json.patch(base_network_policy_manifest, [{
+		"op": "add",
+		"path": "/spec/install/spec/clusterPermissions",
+		"value": [{
+			"serviceAccountName": "test-sa",
+			"rules": [{
+				"apiGroups": ["networking.k8s.io"],
+				"resources": ["networkpolicies"],
+				"verbs": ["create", "update", "delete"],
+			}],
+		}],
+	}])
+
+	assertions.assert_empty(olm.deny) with input.image.files as {"manifests/csv.yaml": manifest_cud}
+		with input.image.config.Labels as {olm.manifestv1: "manifests/", "operators.operatorframework.io.bundle.package.v1": "test-operator"}
+		with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.io"]
+		with data.rule_data.allowed_olm_resource_kinds as ["ClusterServiceVersion"]
+		with data.rule_data.operator_network_policy_rbac_exceptions as {}
+}
+
+test_network_policy_rbac_with_create_patch_delete if {
+	manifest_cpd := json.patch(base_network_policy_manifest, [{
+		"op": "add",
+		"path": "/spec/install/spec/clusterPermissions",
+		"value": [{
+			"serviceAccountName": "test-sa",
+			"rules": [{
+				"apiGroups": ["networking.k8s.io"],
+				"resources": ["networkpolicies"],
+				"verbs": ["create", "patch", "delete"],
+			}],
+		}],
+	}])
+
+	assertions.assert_empty(olm.deny) with input.image.files as {"manifests/csv.yaml": manifest_cpd}
+		with input.image.config.Labels as {olm.manifestv1: "manifests/", "operators.operatorframework.io.bundle.package.v1": "test-operator"}
+		with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.io"]
+		with data.rule_data.allowed_olm_resource_kinds as ["ClusterServiceVersion"]
+		with data.rule_data.operator_network_policy_rbac_exceptions as {}
+}
+
+test_network_policy_rbac_missing_entirely if {
+	manifest_without_rbac := base_network_policy_manifest
+
+	expected := {{
+		"code": "olm.required_network_policy_rbac_for_operands",
+		# regal ignore:line-length
+		"msg": `Operator "test-operator" version "1.2.3" is missing required NetworkPolicy RBAC (networking.k8s.io/networkpolicies with create, delete, and update/patch)`,
+	}}
+
+	assertions.assert_equal_results(olm.deny, expected) with input.image.files as {"manifests/csv.yaml": manifest_without_rbac}
+		with input.image.config.Labels as {olm.manifestv1: "manifests/", "operators.operatorframework.io.bundle.package.v1": "test-operator"}
+		with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.io"]
+		with data.rule_data.allowed_olm_resource_kinds as ["ClusterServiceVersion"]
+		with data.rule_data.operator_network_policy_rbac_exceptions as {}
+}
+
+test_network_policy_rbac_with_wildcard_verbs if {
+	manifest_with_wildcard := json.patch(base_network_policy_manifest, [{
+		"op": "add",
+		"path": "/spec/install/spec/clusterPermissions",
+		"value": [{
+			"serviceAccountName": "test-sa",
+			"rules": [{
+				"apiGroups": ["networking.k8s.io"],
+				"resources": ["networkpolicies"],
+				"verbs": ["*"],
+			}],
+		}],
+	}])
+
+	assertions.assert_empty(olm.deny) with input.image.files as {"manifests/csv.yaml": manifest_with_wildcard}
+		with input.image.config.Labels as {olm.manifestv1: "manifests/", "operators.operatorframework.io.bundle.package.v1": "test-operator"}
+		with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.io"]
+		with data.rule_data.allowed_olm_resource_kinds as ["ClusterServiceVersion"]
+		with data.rule_data.operator_network_policy_rbac_exceptions as {}
+}
+
+test_network_policy_rbac_with_only_read_verbs if {
+	manifest_read_only := json.patch(base_network_policy_manifest, [{
+		"op": "add",
+		"path": "/spec/install/spec/clusterPermissions",
+		"value": [{
+			"serviceAccountName": "test-sa",
+			"rules": [{
+				"apiGroups": ["networking.k8s.io"],
+				"resources": ["networkpolicies"],
+				"verbs": ["get", "list", "watch"],
+			}],
+		}],
+	}])
+
+	expected := {{
+		"code": "olm.required_network_policy_rbac_for_operands",
+		# regal ignore:line-length
+		"msg": `Operator "test-operator" version "1.2.3" is missing required NetworkPolicy RBAC (networking.k8s.io/networkpolicies with create, delete, and update/patch)`,
+	}}
+
+	assertions.assert_equal_results(olm.deny, expected) with input.image.files as {"manifests/csv.yaml": manifest_read_only}
+		with input.image.config.Labels as {olm.manifestv1: "manifests/", "operators.operatorframework.io.bundle.package.v1": "test-operator"}
+		with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.io"]
+		with data.rule_data.allowed_olm_resource_kinds as ["ClusterServiceVersion"]
+		with data.rule_data.operator_network_policy_rbac_exceptions as {}
+}
+
+test_network_policy_rbac_missing_networkpolicies_resource if {
+	manifest_wrong_resource := json.patch(base_network_policy_manifest, [{
+		"op": "add",
+		"path": "/spec/install/spec/clusterPermissions",
+		"value": [{
+			"serviceAccountName": "test-sa",
+			"rules": [{
+				"apiGroups": ["networking.k8s.io"],
+				"resources": ["ingresses"],
+				"verbs": ["create", "update", "patch", "delete"],
+			}],
+		}],
+	}])
+
+	expected := {{
+		"code": "olm.required_network_policy_rbac_for_operands",
+		# regal ignore:line-length
+		"msg": `Operator "test-operator" version "1.2.3" is missing required NetworkPolicy RBAC (networking.k8s.io/networkpolicies with create, delete, and update/patch)`,
+	}}
+
+	assertions.assert_equal_results(olm.deny, expected) with input.image.files as {"manifests/csv.yaml": manifest_wrong_resource}
+		with input.image.config.Labels as {olm.manifestv1: "manifests/", "operators.operatorframework.io.bundle.package.v1": "test-operator"}
+		with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.io"]
+		with data.rule_data.allowed_olm_resource_kinds as ["ClusterServiceVersion"]
+		with data.rule_data.operator_network_policy_rbac_exceptions as {}
+}
+
+test_network_policy_rbac_missing_networking_apigroup if {
+	manifest_wrong_group := json.patch(base_network_policy_manifest, [{
+		"op": "add",
+		"path": "/spec/install/spec/clusterPermissions",
+		"value": [{
+			"serviceAccountName": "test-sa",
+			"rules": [{
+				"apiGroups": ["apps"],
+				"resources": ["networkpolicies"],
+				"verbs": ["create", "update", "patch", "delete"],
+			}],
+		}],
+	}])
+
+	expected := {{
+		"code": "olm.required_network_policy_rbac_for_operands",
+		# regal ignore:line-length
+		"msg": `Operator "test-operator" version "1.2.3" is missing required NetworkPolicy RBAC (networking.k8s.io/networkpolicies with create, delete, and update/patch)`,
+	}}
+
+	assertions.assert_equal_results(olm.deny, expected) with input.image.files as {"manifests/csv.yaml": manifest_wrong_group}
+		with input.image.config.Labels as {olm.manifestv1: "manifests/", "operators.operatorframework.io.bundle.package.v1": "test-operator"}
+		with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.io"]
+		with data.rule_data.allowed_olm_resource_kinds as ["ClusterServiceVersion"]
+		with data.rule_data.operator_network_policy_rbac_exceptions as {}
+}
+
+test_network_policy_rbac_excepted_operator if {
+	manifest_without_rbac := base_network_policy_manifest
+
+	assertions.assert_empty(olm.deny) with input.image.files as {"manifests/csv.yaml": manifest_without_rbac}
+		with input.image.config.Labels as {olm.manifestv1: "manifests/", "operators.operatorframework.io.bundle.package.v1": "test-operator"}
+		with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.io"]
+		with data.rule_data.allowed_olm_resource_kinds as ["ClusterServiceVersion"]
+		with data.rule_data.operator_network_policy_rbac_exceptions as {"test-operator": ["1.2"]}
+}
+
+test_network_policy_rbac_with_extra_verbs if {
+	manifest_extra_verbs := json.patch(base_network_policy_manifest, [{
+		"op": "add",
+		"path": "/spec/install/spec/clusterPermissions",
+		"value": [{
+			"serviceAccountName": "test-sa",
+			"rules": [{
+				"apiGroups": ["networking.k8s.io"],
+				"resources": ["networkpolicies"],
+				"verbs": ["create", "update", "patch", "delete", "get", "list", "watch"],
+			}],
+		}],
+	}])
+
+	assertions.assert_empty(olm.deny) with input.image.files as {"manifests/csv.yaml": manifest_extra_verbs}
+		with input.image.config.Labels as {olm.manifestv1: "manifests/", "operators.operatorframework.io.bundle.package.v1": "test-operator"}
+		with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.io"]
+		with data.rule_data.allowed_olm_resource_kinds as ["ClusterServiceVersion"]
+		with data.rule_data.operator_network_policy_rbac_exceptions as {}
+}
+
+test_network_policy_rbac_multiple_rules if {
+	manifest_multiple_rules := json.patch(base_network_policy_manifest, [{
+		"op": "add",
+		"path": "/spec/install/spec/clusterPermissions",
+		"value": [{
+			"serviceAccountName": "test-sa",
+			"rules": [
+				{
+					"apiGroups": ["apps"],
+					"resources": ["deployments"],
+					"verbs": ["get", "list"],
+				},
+				{
+					"apiGroups": ["networking.k8s.io"],
+					"resources": ["networkpolicies"],
+					"verbs": ["create", "update", "patch", "delete"],
+				},
+				{
+					"apiGroups": [""],
+					"resources": ["pods"],
+					"verbs": ["get"],
+				},
+			],
+		}],
+	}])
+
+	assertions.assert_empty(olm.deny) with input.image.files as {"manifests/csv.yaml": manifest_multiple_rules}
+		with input.image.config.Labels as {olm.manifestv1: "manifests/", "operators.operatorframework.io.bundle.package.v1": "test-operator"}
+		with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.io"]
+		with data.rule_data.allowed_olm_resource_kinds as ["ClusterServiceVersion"]
+		with data.rule_data.operator_network_policy_rbac_exceptions as {}
+}
+
+test_network_policy_rbac_exception_wrong_version if {
+	manifest_without_rbac := base_network_policy_manifest
+
+	expected := {{
+		"code": "olm.required_network_policy_rbac_for_operands",
+		# regal ignore:line-length
+		"msg": `Operator "test-operator" version "1.2.3" is missing required NetworkPolicy RBAC (networking.k8s.io/networkpolicies with create, delete, and update/patch)`,
+	}}
+
+	assertions.assert_equal_results(olm.deny, expected) with input.image.files as {"manifests/csv.yaml": manifest_without_rbac}
+		with input.image.config.Labels as {olm.manifestv1: "manifests/", "operators.operatorframework.io.bundle.package.v1": "test-operator"}
+		with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.io"]
+		with data.rule_data.allowed_olm_resource_kinds as ["ClusterServiceVersion"]
+		with data.rule_data.operator_network_policy_rbac_exceptions as {"test-operator": ["2.0"]}
+}
+
+test_network_policy_rbac_mixed_resources if {
+	manifest_mixed := json.patch(base_network_policy_manifest, [{
+		"op": "add",
+		"path": "/spec/install/spec/clusterPermissions",
+		"value": [{
+			"serviceAccountName": "test-sa",
+			"rules": [{
+				"apiGroups": ["networking.k8s.io"],
+				"resources": ["ingresses", "networkpolicies"],
+				"verbs": ["create", "patch", "delete"],
+			}],
+		}],
+	}])
+
+	assertions.assert_empty(olm.deny) with input.image.files as {"manifests/csv.yaml": manifest_mixed}
+		with input.image.config.Labels as {olm.manifestv1: "manifests/", "operators.operatorframework.io.bundle.package.v1": "test-operator"}
+		with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.io"]
+		with data.rule_data.allowed_olm_resource_kinds as ["ClusterServiceVersion"]
+		with data.rule_data.operator_network_policy_rbac_exceptions as {}
+}
+
+test_network_policy_rbac_in_permissions if {
+	manifest_with_permissions := json.patch(base_network_policy_manifest, [{
+		"op": "add",
+		"path": "/spec/install/spec/permissions",
+		"value": [{
+			"serviceAccountName": "test-sa",
+			"rules": [{
+				"apiGroups": ["networking.k8s.io"],
+				"resources": ["networkpolicies"],
+				"verbs": ["create", "update", "patch", "delete"],
+			}],
+		}],
+	}])
+
+	assertions.assert_empty(olm.deny) with input.image.files as {"manifests/csv.yaml": manifest_with_permissions}
+		with input.image.config.Labels as {olm.manifestv1: "manifests/", "operators.operatorframework.io.bundle.package.v1": "test-operator"}
+		with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.io"]
+		with data.rule_data.allowed_olm_resource_kinds as ["ClusterServiceVersion"]
+		with data.rule_data.operator_network_policy_rbac_exceptions as {}
+}
+
+test_network_policy_rbac_uses_image_label_not_csv_annotation if {
+	# Create manifest with CSV annotation set to "wrong-package"
+	manifest_with_wrong_annotation := json.patch(base_network_policy_manifest, [{
+		"op": "replace",
+		"path": "/metadata/annotations/operators.operatorframework.io~1bundle.package.v1",
+		"value": "wrong-package",
+	}])
+
+	# Set exception for "correct-package" (which is in the image label)
+	# This should be found because package name should come from image label
+	exceptions := {"correct-package": ["1.2"]}
+
+	image_labels := {
+		"operators.operatorframework.io.bundle.manifests.v1": "manifests/",
+		"operators.operatorframework.io.bundle.package.v1": "correct-package",
+	}
+
+	# Should NOT deny because image label "correct-package" is in exceptions
+	assertions.assert_empty(olm.deny) with input.image.files as {"manifests/csv.yaml": manifest_with_wrong_annotation}
+		with input.image.config.Labels as image_labels
+		with data.rule_data.allowed_olm_image_registry_prefixes as ["registry.io"]
+		with data.rule_data.allowed_olm_resource_kinds as ["ClusterServiceVersion"]
+		with data.rule_data.operator_network_policy_rbac_exceptions as exceptions
+}


### PR DESCRIPTION
Network Policies have been supported for Operand images since v4.6. However, there’s no check anywhere to enforce it.

The ability of an operand to manage network policies is identified by the presence of necessary RBAC permissions in the operator bundle CSV. A warning for missing RBAC will be issued initially, with a plan to transition this to a release-blocking error later.

What it checks:
The rule inspects the operator bundle's ClusterServiceVersion (CSV) for the presence of explicit RBAC permissions targeting networking.k8s.io/networkpolicies with at least one of the verbs create, update, patch, or delete — in either clusterPermissions or permissions.


Exception handling:
Before enforcing the check, the rule looks up the operator's package name and major.minor version (e.g., "3scale-operator" / "0.10") in the operator_network_policy_rbac_exceptions rule_data map. If the version is found there, the check is skipped entirely for that bundle.

 

Refers to CLOUDDST-32507

Assisted-By: Claude