### PR TITLE
feat: add in-toto statement discovery library

### DIFF
--- a/policy/lib/intoto/intoto.rego
+++ b/policy/lib/intoto/intoto.rego
@@ -18,26 +18,18 @@ package lib.intoto
 
 import rego.v1
 
-# Artifact types used to discover in-toto attestations attached as OCI referrers.
 # TODO(EC-1773): Confirm the artifact type once the test task implementation is finalized.
-# Sigstore bundle format used by cosign attest.
-_sigstore_bundle_type := "application/vnd.dev.sigstore.bundle.v0.3+json"
+_artifact_type := "application/vnd.in-toto+json"
 
-# Raw in-toto statement format.
-_intoto_statement_type := "application/vnd.in-toto+json"
-
-_artifact_types := {
-	_sigstore_bundle_type,
-	_intoto_statement_type,
-}
-
-# statements returns the set of in-toto statements attached to the image as OCI referrers.
-# Supports both raw in-toto JSON and Sigstore bundle (DSSE envelope) formats.
+# statements returns the set of unsigned in-toto statements attached to the
+# image as OCI referrers. Trust is established via Chains provenance (EC-1774),
+# not via signatures on the statements themselves.
 statements contains statement if {
 	some referrer in ec.oci.image_referrers(input.image.ref)
-	referrer.artifactType in _artifact_types
+	referrer.artifactType == _artifact_type
 	blob := ec.oci.blob(referrer.ref)
-	statement := _parse_statement(blob)
+	statement := json.unmarshal(blob)
+	statement._type == "https://in-toto.io/Statement/v1"
 }
 
 # Filter statements by predicate type.
@@ -46,22 +38,6 @@ statements_by_predicate(predicate_type) := {statement |
 	statement.predicateType == predicate_type
 }
 
-# Predicate type constants for convenience.
 predicate_test_result := "https://in-toto.io/attestation/test-result/v0.1"
 
 predicate_vuln_scan := "https://in-toto.io/attestation/vulns/v0.2"
-
-# Parse a blob as a raw in-toto statement (direct JSON).
-_parse_statement(blob) := statement if {
-	parsed := json.unmarshal(blob)
-	parsed._type == "https://in-toto.io/Statement/v1"
-	statement := parsed
-}
-
-# Parse a blob as a Sigstore bundle containing a DSSE envelope with an in-toto payload.
-_parse_statement(blob) := statement if {
-	bundle := json.unmarshal(blob)
-	envelope := bundle.dsseEnvelope
-	envelope.payloadType == "application/vnd.in-toto+json"
-	statement := json.unmarshal(base64.decode(envelope.payload))
-}

--- a/policy/lib/intoto/intoto.rego
+++ b/policy/lib/intoto/intoto.rego
@@ -28,6 +28,8 @@ statements contains statement if {
 	referrer.artifactType == _artifact_type
 	blob := ec.oci.blob(referrer.ref)
 	statement := json.unmarshal(blob)
+
+	# regal ignore:leaked-internal-reference
 	statement._type == "https://in-toto.io/Statement/v1"
 }
 

--- a/policy/lib/intoto/intoto.rego
+++ b/policy/lib/intoto/intoto.rego
@@ -1,0 +1,67 @@
+# Copyright The Conforma Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+package lib.intoto
+
+import rego.v1
+
+# Artifact types used to discover in-toto attestations attached as OCI referrers.
+# TODO(EC-1773): Confirm the artifact type once the test task implementation is finalized.
+# Sigstore bundle format used by cosign attest.
+_sigstore_bundle_type := "application/vnd.dev.sigstore.bundle.v0.3+json"
+
+# Raw in-toto statement format.
+_intoto_statement_type := "application/vnd.in-toto+json"
+
+_artifact_types := {
+	_sigstore_bundle_type,
+	_intoto_statement_type,
+}
+
+# statements returns the set of in-toto statements attached to the image as OCI referrers.
+# Supports both raw in-toto JSON and Sigstore bundle (DSSE envelope) formats.
+statements contains statement if {
+	some referrer in ec.oci.image_referrers(input.image.ref)
+	referrer.artifactType in _artifact_types
+	blob := ec.oci.blob(referrer.ref)
+	statement := _parse_statement(blob)
+}
+
+# Filter statements by predicate type.
+statements_by_predicate(predicate_type) := {statement |
+	some statement in statements
+	statement.predicateType == predicate_type
+}
+
+# Predicate type constants for convenience.
+predicate_test_result := "https://in-toto.io/attestation/test-result/v0.1"
+
+predicate_vuln_scan := "https://in-toto.io/attestation/vulns/v0.2"
+
+# Parse a blob as a raw in-toto statement (direct JSON).
+_parse_statement(blob) := statement if {
+	parsed := json.unmarshal(blob)
+	parsed._type == "https://in-toto.io/Statement/v1"
+	statement := parsed
+}
+
+# Parse a blob as a Sigstore bundle containing a DSSE envelope with an in-toto payload.
+_parse_statement(blob) := statement if {
+	bundle := json.unmarshal(blob)
+	envelope := bundle.dsseEnvelope
+	envelope.payloadType == "application/vnd.in-toto+json"
+	statement := json.unmarshal(base64.decode(envelope.payload))
+}

--- a/policy/lib/intoto/intoto.rego
+++ b/policy/lib/intoto/intoto.rego
@@ -18,7 +18,6 @@ package lib.intoto
 
 import rego.v1
 
-# TODO(EC-1773): Confirm the artifact type once the test task implementation is finalized.
 _artifact_type := "application/vnd.in-toto+json"
 
 # statements returns the set of unsigned in-toto statements attached to the

--- a/policy/lib/intoto/intoto_test.rego
+++ b/policy/lib/intoto/intoto_test.rego
@@ -1,0 +1,178 @@
+# Copyright The Conforma Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+package lib.intoto_test
+
+import rego.v1
+
+import data.lib.assertions
+import data.lib.intoto
+
+test_statements_from_raw_intoto_referrer if {
+	mock_referrers := [{
+		"mediaType": "application/vnd.oci.image.manifest.v1+json",
+		"size": 100,
+		# regal ignore:line-length
+		"digest": "sha256:aaa0000000000000000000000000000000000000000000000000000000000aaa",
+		"artifactType": "application/vnd.in-toto+json",
+		# regal ignore:line-length
+		"ref": "registry.io/repo/image@sha256:aaa0000000000000000000000000000000000000000000000000000000000aaa",
+	}]
+
+	result := intoto.statements with input.image.ref as "registry.io/repo/image@sha256:abc123"
+		with ec.oci.image_referrers as mock_referrers
+		with ec.oci.blob as _mock_blob_raw_test_result
+
+	count(result) == 1
+	some statement in result
+	statement.predicateType == "https://in-toto.io/attestation/test-result/v0.1"
+	statement.predicate.result == "PASSED"
+}
+
+test_statements_from_sigstore_bundle_referrer if {
+	mock_referrers := [{
+		"mediaType": "application/vnd.oci.image.manifest.v1+json",
+		"size": 200,
+		# regal ignore:line-length
+		"digest": "sha256:bbb0000000000000000000000000000000000000000000000000000000000bbb",
+		"artifactType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+		# regal ignore:line-length
+		"ref": "registry.io/repo/image@sha256:bbb0000000000000000000000000000000000000000000000000000000000bbb",
+	}]
+
+	result := intoto.statements with input.image.ref as "registry.io/repo/image@sha256:abc123"
+		with ec.oci.image_referrers as mock_referrers
+		with ec.oci.blob as _mock_blob_sigstore_bundle
+
+	count(result) == 1
+	some statement in result
+	statement.predicateType == "https://in-toto.io/attestation/test-result/v0.1"
+	statement.predicate.result == "PASSED"
+}
+
+test_statements_filters_unrelated_referrers if {
+	mock_referrers := [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"size": 100,
+			# regal ignore:line-length
+			"digest": "sha256:aaa0000000000000000000000000000000000000000000000000000000000aaa",
+			"artifactType": "application/vnd.in-toto+json",
+			# regal ignore:line-length
+			"ref": "registry.io/repo/image@sha256:aaa0000000000000000000000000000000000000000000000000000000000aaa",
+		},
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"size": 300,
+			# regal ignore:line-length
+			"digest": "sha256:ccc0000000000000000000000000000000000000000000000000000000000ccc",
+			"artifactType": "application/vnd.dev.cosign.simplesigning.v1+json",
+			# regal ignore:line-length
+			"ref": "registry.io/repo/image@sha256:ccc0000000000000000000000000000000000000000000000000000000000ccc",
+		},
+	]
+
+	result := intoto.statements with input.image.ref as "registry.io/repo/image@sha256:abc123"
+		with ec.oci.image_referrers as mock_referrers
+		with ec.oci.blob as _mock_blob_raw_test_result
+
+	count(result) == 1
+}
+
+test_statements_empty_when_no_referrers if {
+	result := intoto.statements with input.image.ref as "registry.io/repo/image@sha256:abc123"
+		with ec.oci.image_referrers as []
+
+	count(result) == 0
+}
+
+test_statements_by_predicate_filters_correctly if {
+	mock_referrers := [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"size": 100,
+			# regal ignore:line-length
+			"digest": "sha256:aaa0000000000000000000000000000000000000000000000000000000000aaa",
+			"artifactType": "application/vnd.in-toto+json",
+			# regal ignore:line-length
+			"ref": "registry.io/repo/image@sha256:aaa0000000000000000000000000000000000000000000000000000000000aaa",
+		},
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"size": 200,
+			# regal ignore:line-length
+			"digest": "sha256:ddd0000000000000000000000000000000000000000000000000000000000ddd",
+			"artifactType": "application/vnd.in-toto+json",
+			# regal ignore:line-length
+			"ref": "registry.io/repo/image@sha256:ddd0000000000000000000000000000000000000000000000000000000000ddd",
+		},
+	]
+
+	result := intoto.statements_by_predicate(intoto.predicate_test_result) with input.image.ref as "registry.io/repo/image@sha256:abc123"
+		with ec.oci.image_referrers as mock_referrers
+		with ec.oci.blob as _mock_blob_mixed_predicates
+
+	count(result) == 1
+	some statement in result
+	statement.predicateType == "https://in-toto.io/attestation/test-result/v0.1"
+}
+
+test_predicate_constants if {
+	assertions.assert_equal(intoto.predicate_test_result, "https://in-toto.io/attestation/test-result/v0.1")
+	assertions.assert_equal(intoto.predicate_vuln_scan, "https://in-toto.io/attestation/vulns/v0.2")
+}
+
+# Mock blob returning a raw in-toto test-result statement
+_mock_blob_raw_test_result(_) := json.marshal({
+	"_type": "https://in-toto.io/Statement/v1",
+	"predicateType": "https://in-toto.io/attestation/test-result/v0.1",
+	"subject": [{"name": "registry.io/repo/image", "digest": {"sha256": "abc123"}}],
+	"predicate": {"result": "PASSED", "resourceUri": "registry.io/repo/image@sha256:abc123"},
+})
+
+# Mock blob returning a Sigstore bundle with a DSSE envelope wrapping an in-toto statement
+_mock_blob_sigstore_bundle(_) := json.marshal({
+	"mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+	"dsseEnvelope": {
+		"payloadType": "application/vnd.in-toto+json",
+		"payload": base64.encode(json.marshal({
+			"_type": "https://in-toto.io/Statement/v1",
+			"predicateType": "https://in-toto.io/attestation/test-result/v0.1",
+			"subject": [{"name": "registry.io/repo/image", "digest": {"sha256": "abc123"}}],
+			"predicate": {"result": "PASSED", "resourceUri": "registry.io/repo/image@sha256:abc123"},
+		})),
+		"signatures": [{"sig": "fakesig"}],
+	},
+})
+
+# Mock blob that returns different predicates based on ref
+_mock_blob_mixed_predicates(ref) := json.marshal({
+	"_type": "https://in-toto.io/Statement/v1",
+	"predicateType": "https://in-toto.io/attestation/test-result/v0.1",
+	"subject": [{"name": "registry.io/repo/image", "digest": {"sha256": "abc123"}}],
+	"predicate": {"result": "PASSED"},
+}) if {
+	contains(ref, "aaa")
+}
+
+_mock_blob_mixed_predicates(ref) := json.marshal({
+	"_type": "https://in-toto.io/Statement/v1",
+	"predicateType": "https://in-toto.io/attestation/vulns/v0.2",
+	"subject": [{"name": "registry.io/repo/image", "digest": {"sha256": "abc123"}}],
+	"predicate": {"scanner": {"uri": "https://scanner.example.com"}},
+}) if {
+	contains(ref, "ddd")
+}

--- a/policy/lib/intoto/intoto_test.rego
+++ b/policy/lib/intoto/intoto_test.rego
@@ -21,41 +21,13 @@ import rego.v1
 import data.lib.assertions
 import data.lib.intoto
 
-test_statements_from_raw_intoto_referrer if {
-	mock_referrers := [{
-		"mediaType": "application/vnd.oci.image.manifest.v1+json",
-		"size": 100,
-		# regal ignore:line-length
-		"digest": "sha256:aaa0000000000000000000000000000000000000000000000000000000000aaa",
-		"artifactType": "application/vnd.in-toto+json",
-		# regal ignore:line-length
-		"ref": "registry.io/repo/image@sha256:aaa0000000000000000000000000000000000000000000000000000000000aaa",
-	}]
-
+test_statements_from_referrer if {
 	result := intoto.statements with input.image.ref as "registry.io/repo/image@sha256:abc123"
-		with ec.oci.image_referrers as mock_referrers
-		with ec.oci.blob as _mock_blob_raw_test_result
-
-	count(result) == 1
-	some statement in result
-	statement.predicateType == "https://in-toto.io/attestation/test-result/v0.1"
-	statement.predicate.result == "PASSED"
-}
-
-test_statements_from_sigstore_bundle_referrer if {
-	mock_referrers := [{
-		"mediaType": "application/vnd.oci.image.manifest.v1+json",
-		"size": 200,
-		# regal ignore:line-length
-		"digest": "sha256:bbb0000000000000000000000000000000000000000000000000000000000bbb",
-		"artifactType": "application/vnd.dev.sigstore.bundle.v0.3+json",
-		# regal ignore:line-length
-		"ref": "registry.io/repo/image@sha256:bbb0000000000000000000000000000000000000000000000000000000000bbb",
-	}]
-
-	result := intoto.statements with input.image.ref as "registry.io/repo/image@sha256:abc123"
-		with ec.oci.image_referrers as mock_referrers
-		with ec.oci.blob as _mock_blob_sigstore_bundle
+		with ec.oci.image_referrers as [_referrer(
+			"sha256:aaa0000000000000000000000000000000000000000000000000000000000aaa",
+			"application/vnd.in-toto+json",
+		)]
+		with ec.oci.blob as _mock_blob_test_result
 
 	count(result) == 1
 	some statement in result
@@ -65,29 +37,19 @@ test_statements_from_sigstore_bundle_referrer if {
 
 test_statements_filters_unrelated_referrers if {
 	mock_referrers := [
-		{
-			"mediaType": "application/vnd.oci.image.manifest.v1+json",
-			"size": 100,
-			# regal ignore:line-length
-			"digest": "sha256:aaa0000000000000000000000000000000000000000000000000000000000aaa",
-			"artifactType": "application/vnd.in-toto+json",
-			# regal ignore:line-length
-			"ref": "registry.io/repo/image@sha256:aaa0000000000000000000000000000000000000000000000000000000000aaa",
-		},
-		{
-			"mediaType": "application/vnd.oci.image.manifest.v1+json",
-			"size": 300,
-			# regal ignore:line-length
-			"digest": "sha256:ccc0000000000000000000000000000000000000000000000000000000000ccc",
-			"artifactType": "application/vnd.dev.cosign.simplesigning.v1+json",
-			# regal ignore:line-length
-			"ref": "registry.io/repo/image@sha256:ccc0000000000000000000000000000000000000000000000000000000000ccc",
-		},
+		_referrer(
+			"sha256:aaa0000000000000000000000000000000000000000000000000000000000aaa",
+			"application/vnd.in-toto+json",
+		),
+		_referrer(
+			"sha256:ccc0000000000000000000000000000000000000000000000000000000000ccc",
+			"application/vnd.dev.cosign.simplesigning.v1+json",
+		),
 	]
 
 	result := intoto.statements with input.image.ref as "registry.io/repo/image@sha256:abc123"
 		with ec.oci.image_referrers as mock_referrers
-		with ec.oci.blob as _mock_blob_raw_test_result
+		with ec.oci.blob as _mock_blob_test_result
 
 	count(result) == 1
 }
@@ -99,26 +61,27 @@ test_statements_empty_when_no_referrers if {
 	count(result) == 0
 }
 
+test_statements_skips_non_intoto_json if {
+	result := intoto.statements with input.image.ref as "registry.io/repo/image@sha256:abc123"
+		with ec.oci.image_referrers as [_referrer(
+			"sha256:aaa0000000000000000000000000000000000000000000000000000000000aaa",
+			"application/vnd.in-toto+json",
+		)]
+		with ec.oci.blob as _mock_blob_not_intoto
+
+	count(result) == 0
+}
+
 test_statements_by_predicate_filters_correctly if {
 	mock_referrers := [
-		{
-			"mediaType": "application/vnd.oci.image.manifest.v1+json",
-			"size": 100,
-			# regal ignore:line-length
-			"digest": "sha256:aaa0000000000000000000000000000000000000000000000000000000000aaa",
-			"artifactType": "application/vnd.in-toto+json",
-			# regal ignore:line-length
-			"ref": "registry.io/repo/image@sha256:aaa0000000000000000000000000000000000000000000000000000000000aaa",
-		},
-		{
-			"mediaType": "application/vnd.oci.image.manifest.v1+json",
-			"size": 200,
-			# regal ignore:line-length
-			"digest": "sha256:ddd0000000000000000000000000000000000000000000000000000000000ddd",
-			"artifactType": "application/vnd.in-toto+json",
-			# regal ignore:line-length
-			"ref": "registry.io/repo/image@sha256:ddd0000000000000000000000000000000000000000000000000000000000ddd",
-		},
+		_referrer(
+			"sha256:aaa0000000000000000000000000000000000000000000000000000000000aaa",
+			"application/vnd.in-toto+json",
+		),
+		_referrer(
+			"sha256:ddd0000000000000000000000000000000000000000000000000000000000ddd",
+			"application/vnd.in-toto+json",
+		),
 	]
 
 	result := intoto.statements_by_predicate(intoto.predicate_test_result) with input.image.ref as "registry.io/repo/image@sha256:abc123"
@@ -135,30 +98,24 @@ test_predicate_constants if {
 	assertions.assert_equal(intoto.predicate_vuln_scan, "https://in-toto.io/attestation/vulns/v0.2")
 }
 
-# Mock blob returning a raw in-toto test-result statement
-_mock_blob_raw_test_result(_) := json.marshal({
+# Helper to build a referrer descriptor
+_referrer(digest, artifact_type) := {
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"size": 100,
+	"digest": digest,
+	"artifactType": artifact_type,
+	"ref": sprintf("registry.io/repo/image@%s", [digest]),
+}
+
+_mock_blob_test_result(_) := json.marshal({
 	"_type": "https://in-toto.io/Statement/v1",
 	"predicateType": "https://in-toto.io/attestation/test-result/v0.1",
 	"subject": [{"name": "registry.io/repo/image", "digest": {"sha256": "abc123"}}],
 	"predicate": {"result": "PASSED", "resourceUri": "registry.io/repo/image@sha256:abc123"},
 })
 
-# Mock blob returning a Sigstore bundle with a DSSE envelope wrapping an in-toto statement
-_mock_blob_sigstore_bundle(_) := json.marshal({
-	"mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
-	"dsseEnvelope": {
-		"payloadType": "application/vnd.in-toto+json",
-		"payload": base64.encode(json.marshal({
-			"_type": "https://in-toto.io/Statement/v1",
-			"predicateType": "https://in-toto.io/attestation/test-result/v0.1",
-			"subject": [{"name": "registry.io/repo/image", "digest": {"sha256": "abc123"}}],
-			"predicate": {"result": "PASSED", "resourceUri": "registry.io/repo/image@sha256:abc123"},
-		})),
-		"signatures": [{"sig": "fakesig"}],
-	},
-})
+_mock_blob_not_intoto(_) := json.marshal({"some": "random json", "not": "intoto"})
 
-# Mock blob that returns different predicates based on ref
 _mock_blob_mixed_predicates(ref) := json.marshal({
 	"_type": "https://in-toto.io/Statement/v1",
 	"predicateType": "https://in-toto.io/attestation/test-result/v0.1",


### PR DESCRIPTION
## Summary

- New `policy/lib/intoto/` library for discovering unsigned in-toto statements attached to images as OCI referrers
- Follows the established SBOM referrer discovery pattern (`policy/lib/sbom/sbom.rego`)
- Filters referrers by `application/vnd.in-toto+json` artifact type
- Provides `statements_by_predicate()` helper for filtering by predicate type (test-result, vuln-scan)
- Statements are unsigned — trust verification is handled separately in EC-1774

Part of EC-1773. Foundation for EC-1774 (chain of trust) and EC-1775 (test content verification).

## Test plan

- [x] 831/831 tests pass
- [x] 100% line coverage on new files
- [x] New test: statement discovery from raw in-toto referrer
- [x] New test: unrelated referrer types filtered out
- [x] New test: empty referrers returns empty set
- [x] New test: non-in-toto JSON blobs skipped
- [x] New test: predicate type filtering
- [x] New test: predicate constants
- [x] `make quiet-test opa-check fmt-check` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)