### PR TITLE
fix: support in-toto v0.1 statements in discovery layer

### DIFF
--- a/policy/lib/intoto/intoto.rego
+++ b/policy/lib/intoto/intoto.rego
@@ -20,6 +20,12 @@ import rego.v1
 
 _artifact_type := "application/vnd.in-toto+json"
 
+# Spec-defined in-toto statement versions this library can parse.
+# Intentionally separate from the policy-enforced known_attestation_types
+# in attestation_type.rego — discovery should be permissive so the
+# enforcement layer can report violations rather than silently dropping.
+_known_types := {"https://in-toto.io/Statement/v0.1", "https://in-toto.io/Statement/v1"}
+
 # statements returns the set of unsigned in-toto statements attached to the
 # image as OCI referrers. Trust is established via Chains provenance (EC-1774),
 # not via signatures on the statements themselves.
@@ -30,7 +36,7 @@ statements contains statement if {
 	statement := json.unmarshal(blob)
 
 	# regal ignore:leaked-internal-reference
-	statement._type == "https://in-toto.io/Statement/v1"
+	statement._type in _known_types
 }
 
 # Filter statements by predicate type.

--- a/policy/lib/intoto/intoto_test.rego
+++ b/policy/lib/intoto/intoto_test.rego
@@ -35,6 +35,19 @@ test_statements_from_referrer if {
 	statement.predicate.result == "PASSED"
 }
 
+test_statements_from_referrer_v01 if {
+	result := intoto.statements with input.image.ref as "registry.io/repo/image@sha256:abc123"
+		with ec.oci.image_referrers as [_referrer(
+			"sha256:aaa0000000000000000000000000000000000000000000000000000000000aaa",
+			"application/vnd.in-toto+json",
+		)]
+		with ec.oci.blob as _mock_blob_v01
+
+	count(result) == 1
+	some statement in result
+	statement.predicateType == "https://in-toto.io/attestation/test-result/v0.1"
+}
+
 test_statements_filters_unrelated_referrers if {
 	mock_referrers := [
 		_referrer(
@@ -109,6 +122,13 @@ _referrer(digest, artifact_type) := {
 
 _mock_blob_test_result(_) := json.marshal({
 	"_type": "https://in-toto.io/Statement/v1",
+	"predicateType": "https://in-toto.io/attestation/test-result/v0.1",
+	"subject": [{"name": "registry.io/repo/image", "digest": {"sha256": "abc123"}}],
+	"predicate": {"result": "PASSED", "resourceUri": "registry.io/repo/image@sha256:abc123"},
+})
+
+_mock_blob_v01(_) := json.marshal({
+	"_type": "https://in-toto.io/Statement/v0.1",
 	"predicateType": "https://in-toto.io/attestation/test-result/v0.1",
 	"subject": [{"name": "registry.io/repo/image", "digest": {"sha256": "abc123"}}],
 	"predicate": {"result": "PASSED", "resourceUri": "registry.io/repo/image@sha256:abc123"},


### PR DESCRIPTION
## Summary
- Add local `_known_types` set constant accepting both in-toto v0.1 and v1 statement formats
- Keeps discovery permissive so `attestation_type.rego` can report violations instead of silently dropping statements
- Adds test coverage for v0.1 statement discovery

Addresses review feedback from @simonbaird on #1722.

## Rationale

The discovery layer (`lib/intoto`) and the enforcement layer (`attestation_type.rego`) serve different concerns. Using `rule_data.get("known_attestation_types")` for discovery would mean a user narrowing that list to enforce a "no v0.1" policy would get silent omission instead of a policy violation — the worst failure mode for a policy engine.

## Test plan
- [x] All 867 Rego policy tests pass
- [x] New test verifies v0.1 statement discovery
- [x] OPA fmt clean, regal lint clean on changed files

Ref: EC-1773

🤖 Generated with [Claude Code](https://claude.com/claude-code)