### PR TITLE
feat: fix Codecov configuration with OIDC and flags

### DIFF
--- a/.github/workflows/pre-merge-ci.yaml
+++ b/.github/workflows/pre-merge-ci.yaml
@@ -30,6 +30,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   all-tests-and-checks:
@@ -73,5 +74,7 @@ jobs:
       - name: Upload test coverage report
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         if: always()
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          use_oidc: true
+          flags: unit-tests
+          fail_ci_if_error: false

--- a/.github/workflows/pre-merge-ci.yaml
+++ b/.github/workflows/pre-merge-ci.yaml
@@ -30,11 +30,13 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   all-tests-and-checks:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0


### PR DESCRIPTION
## Summary
- Switch from token-based auth (`CODECOV_TOKEN`) to OIDC — no secret needed for public repos
- Add `unit-tests` flag to categorize coverage uploads
- Add `fail_ci_if_error: false` to prevent CI failures from Codecov issues
- Add `id-token: write` permission required for OIDC

## Test plan
- [ ] CI workflow passes with OIDC-based upload
- [ ] Coverage data continues to appear at https://app.codecov.io/gh/conforma/policy
- [ ] `unit-tests` flag visible in Codecov Flags tab
- [ ] No regression in 100% coverage enforcement

Ref: COVERPORT-208