### PR TITLE
Update proxy rules to support Hermeto SBOM format

### DIFF
--- a/acceptance/features/sbom_proxy.feature
+++ b/acceptance/features/sbom_proxy.feature
@@ -27,6 +27,7 @@ Feature: SBOM proxy rules
         When input is validated
         Then there should be violations with "sbom_spdx.proxy_metadata_required" code in the result
         And there should be no violations with "sbom_spdx.proxy_metadata_required" code and "pkg:npm/%40babel/code-frame@7.29.0" term in the result
+        And there should be no violations with "sbom_spdx.proxy_metadata_required" code and "pkg:npm/fsevents@2.3.3" term in the result
 
     Scenario: SPDX proxy metadata required does not fire for non-proxy PURL types
         Given a sample policy input "spdx-sbom"
@@ -82,6 +83,7 @@ Feature: SBOM proxy rules
         When input is validated
         Then there should be violations with "sbom_spdx.allowed_proxy_urls" code in the result
         And there should be no violations with "sbom_spdx.allowed_proxy_urls" code and "pkg:npm/%40babel/code-frame@7.29.0" term in the result
+        And there should be no violations with "sbom_spdx.allowed_proxy_urls" code and "pkg:npm/fsevents@2.3.3" term in the result
 
     Scenario: SPDX proxy rules do not fire before effective date
         Given a sample policy input "spdx-sbom"
@@ -138,6 +140,7 @@ Feature: SBOM proxy rules
         When input is validated
         Then there should be violations with "sbom_cyclonedx.proxy_metadata_required" code in the result
         And there should be no violations with "sbom_cyclonedx.proxy_metadata_required" code and "pkg:npm/%40babel/code-frame@7.29.0" term in the result
+        And there should be no violations with "sbom_cyclonedx.proxy_metadata_required" code and "pkg:npm/fsevents@2.3.3" term in the result
 
     Scenario: CycloneDX proxy metadata required does not fire for non-proxy PURL types
         Given a sample policy input "cdx-sbom"
@@ -193,6 +196,7 @@ Feature: SBOM proxy rules
         When input is validated
         Then there should be violations with "sbom_cyclonedx.allowed_proxy_urls" code in the result
         And there should be no violations with "sbom_cyclonedx.allowed_proxy_urls" code and "pkg:npm/%40babel/code-frame@7.29.0" term in the result
+        And there should be no violations with "sbom_cyclonedx.allowed_proxy_urls" code and "pkg:npm/fsevents@2.3.3" term in the result
 
     Scenario: CycloneDX proxy rules do not fire before effective date
         Given a sample policy input "cdx-sbom"

--- a/acceptance/features/sbom_proxy.feature
+++ b/acceptance/features/sbom_proxy.feature
@@ -56,7 +56,7 @@ Feature: SBOM proxy rules
         When input is validated
         Then there should be no violations in the result
 
-    Scenario: SPDX allowed proxy URLs denies non-matching downloadLocation
+    Scenario: SPDX allowed proxy URLs denies non-matching sourceInfo
         Given a sample policy input "spdx-sbom"
         And a policy config:
             """

--- a/acceptance/samples/policy-input-cdx-sbom.json
+++ b/acceptance/samples/policy-input-cdx-sbom.json
@@ -31,6 +31,7 @@
               "externalReferences": [
                 {
                   "type": "distribution",
+                  "comment": "proxy URL",
                   "url": "https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy"
                 }
               ]
@@ -49,6 +50,7 @@
               "externalReferences": [
                 {
                   "type": "distribution",
+                  "comment": "proxy URL",
                   "url": "https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy"
                 }
               ]
@@ -67,6 +69,7 @@
               "externalReferences": [
                 {
                   "type": "distribution",
+                  "comment": "proxy URL",
                   "url": "https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy"
                 }
               ]
@@ -85,6 +88,7 @@
               "externalReferences": [
                 {
                   "type": "distribution",
+                  "comment": "proxy URL",
                   "url": "https://evil.example.com/npm/compat-data-7.29.0.tgz"
                 }
               ]

--- a/acceptance/samples/policy-input-cdx-sbom.json
+++ b/acceptance/samples/policy-input-cdx-sbom.json
@@ -103,6 +103,22 @@
             },
             {
               "type": "library",
+              "name": "fsevents",
+              "version": "2.3.3",
+              "purl": "pkg:npm/fsevents@2.3.3",
+              "properties": [
+                {
+                  "name": "hermeto:found_by",
+                  "value": "hermeto"
+                },
+                {
+                  "name": "cdx:npm:package:bundled",
+                  "value": "true"
+                }
+              ]
+            },
+            {
+              "type": "library",
               "name": "libbrotli",
               "version": "1.1.0",
               "purl": "pkg:rpm/redhat/libbrotli@1.1.0-7.el10_1?arch=x86_64&checksum=sha256:894800ee7893f8e4aa1d3870afb22b54d92624134bc7cf5d2cdc1a1db92366db&repository_id=ubi-10-for-x86_64-baseos-rpms",

--- a/acceptance/samples/policy-input-spdx-sbom.json
+++ b/acceptance/samples/policy-input-spdx-sbom.json
@@ -238,6 +238,40 @@
               "versionInfo": "5.2.1"
             },
             {
+              "SPDXID": "SPDXRef-Package-npm-fsevents-2.3.3-bundled",
+              "annotations": [
+                {
+                  "annotationDate": "2026-04-23T14:19:57Z",
+                  "annotationType": "OTHER",
+                  "annotator": "Tool: hermeto:jsonencoded",
+                  "comment": "hermeto:backend:npm"
+                },
+                {
+                  "annotationDate": "2026-04-23T14:19:57Z",
+                  "annotationType": "OTHER",
+                  "annotator": "Tool: hermeto:jsonencoded",
+                  "comment": "{\"name\": \"hermeto:found_by\", \"value\": \"hermeto\"}"
+                },
+                {
+                  "annotationDate": "2026-04-23T14:19:57Z",
+                  "annotationType": "OTHER",
+                  "annotator": "Tool: hermeto:jsonencoded",
+                  "comment": "{\"name\": \"cdx:npm:package:bundled\", \"value\": \"true\"}"
+                }
+              ],
+              "downloadLocation": "NOASSERTION",
+              "externalRefs": [
+                {
+                  "referenceCategory": "PACKAGE_MANAGER",
+                  "referenceLocator": "pkg:npm/fsevents@2.3.3",
+                  "referenceType": "purl"
+                }
+              ],
+              "filesAnalyzed": true,
+              "name": "fsevents",
+              "versionInfo": "2.3.3"
+            },
+            {
               "SPDXID": "SPDXRef-Package-libbrotli-1.1.0-1e61557cdb9610ac9b4cb1db23b878ceb9048c799c8536650f49f42268db3ff2",
               "annotations": [
                 {

--- a/acceptance/samples/policy-input-spdx-sbom.json
+++ b/acceptance/samples/policy-input-spdx-sbom.json
@@ -361,7 +361,7 @@
                   "comment": "{\"name\": \"hermeto:found_by\", \"value\": \"hermeto\"}"
                 }
               ],
-              "downloadLocation": "https://evil.example.com/npm/compat-data-7.29.0.tgz",
+              "downloadLocation": "NOASSERTION",
               "externalRefs": [
                 {
                   "referenceCategory": "PACKAGE_MANAGER",
@@ -371,7 +371,7 @@
               ],
               "filesAnalyzed": true,
               "name": "@babel/compat-data",
-              "sourceInfo": "https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy",
+              "sourceInfo": "https://evil.example.com/npm/compat-data-7.29.0.tgz",
               "versionInfo": "7.29.0"
             }
           ],

--- a/antora/docs/modules/ROOT/pages/packages/release_sbom_cyclonedx.adoc
+++ b/antora/docs/modules/ROOT/pages/packages/release_sbom_cyclonedx.adoc
@@ -48,7 +48,7 @@ For each of the components fetched by Hermeto which define externalReferences of
 [#sbom_cyclonedx__allowed_proxy_urls]
 === link:#sbom_cyclonedx__allowed_proxy_urls[Allowed proxy URLs]
 
-For components found by Hermeto with a PURL type listed in proxy_enabled_purl_types that are registry dependencies (no download_url or vcs_url qualifier, not bundled), verify proxy URLs in externalReferences of type distribution match at least one pattern from allowed_proxy_url_patterns. The "proxy_enabled_purl_types" rule data key is a list of PURL type strings (e.g. ["maven", "npm"]). The "allowed_proxy_url_patterns" rule data key is an object mapping each PURL type string to a list of regular expression patterns (e.g. {"maven": ["^https://proxy\\.example\\.com/maven/.*"]}). If a PURL type is listed in proxy_enabled_purl_types but has no entry in allowed_proxy_url_patterns, all components of that type are denied.
+For components found by Hermeto with a PURL type listed in proxy_enabled_purl_types that are registry dependencies (no download_url or vcs_url qualifier, not bundled), verify proxy URLs in externalReferences of type distribution with comment "proxy URL" match at least one pattern from allowed_proxy_url_patterns. The "proxy_enabled_purl_types" rule data key is a list of PURL type strings (e.g. ["maven", "npm"]). The "allowed_proxy_url_patterns" rule data key is an object mapping each PURL type string to a list of regular expression patterns (e.g. {"maven": ["^https://proxy\\.example\\.com/maven/.*"]}). If a PURL type is listed in proxy_enabled_purl_types but has no entry in allowed_proxy_url_patterns, all components of that type are denied.
 
 *Solution*: Ensure the proxy URL matches one of the patterns defined in the allowed_proxy_url_patterns rule data for the given PURL type.
 
@@ -87,15 +87,15 @@ Confirm the CycloneDX SBOM contains only packages without disallowed external re
 [#sbom_cyclonedx__proxy_metadata_required]
 === link:#sbom_cyclonedx__proxy_metadata_required[Proxy metadata required]
 
-For components found by Hermeto with a PURL type listed in proxy_enabled_purl_types that are registry dependencies (no download_url or vcs_url qualifier, not bundled), verify that proxy metadata is present. In CycloneDX, this means at least one externalReference with type "distribution" must exist.
+For components found by Hermeto with a PURL type listed in proxy_enabled_purl_types that are registry dependencies (no download_url or vcs_url qualifier, not bundled), verify that proxy metadata is present. In CycloneDX, this means at least one externalReference with type "distribution" and comment "proxy URL" must exist.
 
 *Solution*: Ensure the build process produces proxy metadata for packages fetched by Hermeto from a package registry.
 
 * Rule type: [rule-type-indicator failure]#FAILURE#
-* FAILURE message: `Package %s is missing proxy metadata (no externalReference of type "distribution")`
+* FAILURE message: `Package %s is missing proxy metadata (no externalReference of type "distribution" with comment "proxy URL")`
 * Code: `sbom_cyclonedx.proxy_metadata_required`
 * Effective from: `2026-05-13T00:00:00Z`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego#L319[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego#L320[Source, window="_blank"]
 
 [#sbom_cyclonedx__cdx_supported_version]
 === link:#sbom_cyclonedx__cdx_supported_version[Supported Version]

--- a/antora/docs/modules/ROOT/pages/packages/release_sbom_cyclonedx.adoc
+++ b/antora/docs/modules/ROOT/pages/packages/release_sbom_cyclonedx.adoc
@@ -48,7 +48,7 @@ For each of the components fetched by Hermeto which define externalReferences of
 [#sbom_cyclonedx__allowed_proxy_urls]
 === link:#sbom_cyclonedx__allowed_proxy_urls[Allowed proxy URLs]
 
-For components found by Hermeto with a PURL type listed in proxy_enabled_purl_types that are registry dependencies (no download_url or vcs_url qualifier, not bundled), verify proxy URLs in externalReferences of type distribution match at least one pattern from allowed_proxy_url_patterns. The "proxy_enabled_purl_types" rule data key is a list of PURL type strings (e.g. ["maven", "npm"]). The "allowed_proxy_url_patterns" rule data key is an object mapping each PURL type string to a list of regular expression patterns (e.g. {"maven": ["^https://proxy\\.example\\.com/maven/.*"]}). Components with a URL of "NOASSERTION" are skipped. If a PURL type is listed in proxy_enabled_purl_types but has no entry in allowed_proxy_url_patterns, all components of that type are denied.
+For components found by Hermeto with a PURL type listed in proxy_enabled_purl_types that are registry dependencies (no download_url or vcs_url qualifier, not bundled), verify proxy URLs in externalReferences of type distribution match at least one pattern from allowed_proxy_url_patterns. The "proxy_enabled_purl_types" rule data key is a list of PURL type strings (e.g. ["maven", "npm"]). The "allowed_proxy_url_patterns" rule data key is an object mapping each PURL type string to a list of regular expression patterns (e.g. {"maven": ["^https://proxy\\.example\\.com/maven/.*"]}). If a PURL type is listed in proxy_enabled_purl_types but has no entry in allowed_proxy_url_patterns, all components of that type are denied.
 
 *Solution*: Ensure the proxy URL matches one of the patterns defined in the allowed_proxy_url_patterns rule data for the given PURL type.
 
@@ -95,7 +95,7 @@ For components found by Hermeto with a PURL type listed in proxy_enabled_purl_ty
 * FAILURE message: `Package %s is missing proxy metadata (no externalReference of type "distribution")`
 * Code: `sbom_cyclonedx.proxy_metadata_required`
 * Effective from: `2026-05-13T00:00:00Z`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego#L320[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego#L319[Source, window="_blank"]
 
 [#sbom_cyclonedx__cdx_supported_version]
 === link:#sbom_cyclonedx__cdx_supported_version[Supported Version]

--- a/antora/docs/modules/ROOT/pages/packages/release_sbom_cyclonedx.adoc
+++ b/antora/docs/modules/ROOT/pages/packages/release_sbom_cyclonedx.adoc
@@ -48,7 +48,7 @@ For each of the components fetched by Hermeto which define externalReferences of
 [#sbom_cyclonedx__allowed_proxy_urls]
 === link:#sbom_cyclonedx__allowed_proxy_urls[Allowed proxy URLs]
 
-For components found by Hermeto with a PURL type listed in proxy_enabled_purl_types that are registry dependencies (no download_url or vcs_url qualifier), verify proxy URLs in externalReferences of type distribution match at least one pattern from allowed_proxy_url_patterns. The "proxy_enabled_purl_types" rule data key is a list of PURL type strings (e.g. ["maven", "npm"]). The "allowed_proxy_url_patterns" rule data key is an object mapping each PURL type string to a list of regular expression patterns (e.g. {"maven": ["^https://proxy\\.example\\.com/maven/.*"]}). Components with a URL of "NOASSERTION" are skipped. If a PURL type is listed in proxy_enabled_purl_types but has no entry in allowed_proxy_url_patterns, all components of that type are denied.
+For components found by Hermeto with a PURL type listed in proxy_enabled_purl_types that are registry dependencies (no download_url or vcs_url qualifier, not bundled), verify proxy URLs in externalReferences of type distribution match at least one pattern from allowed_proxy_url_patterns. The "proxy_enabled_purl_types" rule data key is a list of PURL type strings (e.g. ["maven", "npm"]). The "allowed_proxy_url_patterns" rule data key is an object mapping each PURL type string to a list of regular expression patterns (e.g. {"maven": ["^https://proxy\\.example\\.com/maven/.*"]}). Components with a URL of "NOASSERTION" are skipped. If a PURL type is listed in proxy_enabled_purl_types but has no entry in allowed_proxy_url_patterns, all components of that type are denied.
 
 *Solution*: Ensure the proxy URL matches one of the patterns defined in the allowed_proxy_url_patterns rule data for the given PURL type.
 
@@ -87,7 +87,7 @@ Confirm the CycloneDX SBOM contains only packages without disallowed external re
 [#sbom_cyclonedx__proxy_metadata_required]
 === link:#sbom_cyclonedx__proxy_metadata_required[Proxy metadata required]
 
-For components found by Hermeto with a PURL type listed in proxy_enabled_purl_types that are registry dependencies (no download_url or vcs_url qualifier), verify that proxy metadata is present. In CycloneDX, this means at least one externalReference with type "distribution" must exist.
+For components found by Hermeto with a PURL type listed in proxy_enabled_purl_types that are registry dependencies (no download_url or vcs_url qualifier, not bundled), verify that proxy metadata is present. In CycloneDX, this means at least one externalReference with type "distribution" must exist.
 
 *Solution*: Ensure the build process produces proxy metadata for packages fetched by Hermeto from a package registry.
 

--- a/antora/docs/modules/ROOT/pages/packages/release_sbom_spdx.adoc
+++ b/antora/docs/modules/ROOT/pages/packages/release_sbom_spdx.adoc
@@ -48,7 +48,7 @@ For each of the packages fetched by Hermeto which define externalReferences, ver
 [#sbom_spdx__allowed_proxy_urls]
 === link:#sbom_spdx__allowed_proxy_urls[Allowed proxy URLs]
 
-For packages found by Hermeto with a PURL type listed in proxy_enabled_purl_types that are registry dependencies (no download_url or vcs_url qualifier), verify the downloadLocation matches at least one pattern from allowed_proxy_url_patterns. The "proxy_enabled_purl_types" rule data key is a list of PURL type strings (e.g. ["maven", "npm"]). The "allowed_proxy_url_patterns" rule data key is an object mapping each PURL type string to a list of regular expression patterns (e.g. {"maven": ["^https://proxy\\.example\\.com/maven/.*"]}). Packages with downloadLocation set to "NOASSERTION" are skipped. If a PURL type is listed in proxy_enabled_purl_types but has no entry in allowed_proxy_url_patterns, all packages of that type are denied.
+For packages found by Hermeto with a PURL type listed in proxy_enabled_purl_types that are registry dependencies (no download_url or vcs_url qualifier, not bundled), verify the downloadLocation matches at least one pattern from allowed_proxy_url_patterns. The "proxy_enabled_purl_types" rule data key is a list of PURL type strings (e.g. ["maven", "npm"]). The "allowed_proxy_url_patterns" rule data key is an object mapping each PURL type string to a list of regular expression patterns (e.g. {"maven": ["^https://proxy\\.example\\.com/maven/.*"]}). Packages with downloadLocation set to "NOASSERTION" are skipped. If a PURL type is listed in proxy_enabled_purl_types but has no entry in allowed_proxy_url_patterns, all packages of that type are denied.
 
 *Solution*: Ensure the proxy URL matches one of the patterns defined in the allowed_proxy_url_patterns rule data for the given PURL type.
 
@@ -123,7 +123,7 @@ Check the SPDX SBOM targets the image being validated.
 [#sbom_spdx__proxy_metadata_required]
 === link:#sbom_spdx__proxy_metadata_required[Proxy metadata required]
 
-For packages found by Hermeto with a PURL type listed in proxy_enabled_purl_types that are registry dependencies (no download_url or vcs_url qualifier), verify that proxy metadata is present. In SPDX, the sourceInfo field must be non-empty.
+For packages found by Hermeto with a PURL type listed in proxy_enabled_purl_types that are registry dependencies (no download_url or vcs_url qualifier, not bundled), verify that proxy metadata is present. In SPDX, the sourceInfo field must be non-empty.
 
 *Solution*: Ensure the build process produces proxy metadata for packages fetched by Hermeto from a package registry.
 

--- a/antora/docs/modules/ROOT/pages/packages/release_sbom_spdx.adoc
+++ b/antora/docs/modules/ROOT/pages/packages/release_sbom_spdx.adoc
@@ -48,7 +48,7 @@ For each of the packages fetched by Hermeto which define externalReferences, ver
 [#sbom_spdx__allowed_proxy_urls]
 === link:#sbom_spdx__allowed_proxy_urls[Allowed proxy URLs]
 
-For packages found by Hermeto with a PURL type listed in proxy_enabled_purl_types that are registry dependencies (no download_url or vcs_url qualifier, not bundled), verify the downloadLocation matches at least one pattern from allowed_proxy_url_patterns. The "proxy_enabled_purl_types" rule data key is a list of PURL type strings (e.g. ["maven", "npm"]). The "allowed_proxy_url_patterns" rule data key is an object mapping each PURL type string to a list of regular expression patterns (e.g. {"maven": ["^https://proxy\\.example\\.com/maven/.*"]}). Packages with downloadLocation set to "NOASSERTION" are skipped. If a PURL type is listed in proxy_enabled_purl_types but has no entry in allowed_proxy_url_patterns, all packages of that type are denied.
+For packages found by Hermeto with a PURL type listed in proxy_enabled_purl_types that are registry dependencies (no download_url or vcs_url qualifier, not bundled), verify each proxy URL in sourceInfo matches at least one pattern from allowed_proxy_url_patterns. Hermeto records proxy URLs in the sourceInfo field, semicolon-separated when multiple proxies are used. The "proxy_enabled_purl_types" rule data key is a list of PURL type strings (e.g. ["maven", "npm"]). The "allowed_proxy_url_patterns" rule data key is an object mapping each PURL type string to a list of regular expression patterns (e.g. {"maven": ["^https://proxy\\.example\\.com/maven/.*"]}). If a PURL type is listed in proxy_enabled_purl_types but has no entry in allowed_proxy_url_patterns, all packages of that type are denied.
 
 *Solution*: Ensure the proxy URL matches one of the patterns defined in the allowed_proxy_url_patterns rule data for the given PURL type.
 
@@ -131,7 +131,7 @@ For packages found by Hermeto with a PURL type listed in proxy_enabled_purl_type
 * FAILURE message: `Package %s is missing proxy metadata (sourceInfo is empty or missing)`
 * Code: `sbom_spdx.proxy_metadata_required`
 * Effective from: `2026-05-13T00:00:00Z`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_spdx/sbom_spdx.rego#L306[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_spdx/sbom_spdx.rego#L309[Source, window="_blank"]
 
 [#sbom_spdx__valid]
 === link:#sbom_spdx__valid[Valid]

--- a/policy/lib/sbom/sbom.rego
+++ b/policy/lib/sbom/sbom.rego
@@ -412,13 +412,36 @@ package_found_by_hermeto(pkg) if {
 	annotation.annotationType == "OTHER"
 } else := false
 
-# is_registry_dependency returns true if the parsed PURL has no download_url
-# or vcs_url qualifier, indicating it is a registry dependency.
-is_registry_dependency(parsed_purl) if {
+# is_registry_dependency checks that an SBOM artifact (CycloneDX component
+# or SPDX package) is a registry dependency: fetched from a package
+# registry, not from a direct URL or VCS, and not bundled inside another
+# dependency's tarball.
+is_registry_dependency(parsed_purl, dependency) if {
+	_is_registry_purl(parsed_purl)
+	not _is_bundled(dependency)
+}
+
+_is_registry_purl(parsed_purl) if {
 	qualifiers := {q.key | some q in object.get(parsed_purl, "qualifiers", [])}
 	not "download_url" in qualifiers
 	not "vcs_url" in qualifiers
 }
+
+# CycloneDX: bundled property in component.properties
+_is_bundled(dependency) if {
+	some property in object.get(dependency, "properties", [])
+	property == _npm_bundled_property
+}
+
+# SPDX: bundled property JSON-encoded in package annotations
+_is_bundled(dependency) if {
+	some annotation in object.get(dependency, "annotations", [])
+	annotation.annotationType == "OTHER"
+	parsed := json.unmarshal(annotation.comment)
+	parsed == _npm_bundled_property
+}
+
+_npm_bundled_property := {"name": "cdx:npm:package:bundled", "value": "true"}
 
 # hermeto_found_by_property generates the CycloneDX property object used
 # to identify components fetched by the given tool name.

--- a/policy/lib/sbom/sbom_test.rego
+++ b/policy/lib/sbom/sbom_test.rego
@@ -338,24 +338,36 @@ test_package_found_by_hermeto_no_annotations if {
 }
 
 # Tests for is_registry_dependency
-test_is_registry_dependency_no_qualifiers if {
-	parsed_purl := {"type": "maven", "name": "lib", "qualifiers": []}
-	sbom.is_registry_dependency(parsed_purl)
+test_is_registry_dependency_cdx_plain if {
+	parsed_purl := {"type": "npm", "name": "lib", "qualifiers": []}
+	component := {"properties": [{"name": "hermeto:found_by", "value": "hermeto"}]}
+	sbom.is_registry_dependency(parsed_purl, component)
+}
+
+test_is_registry_dependency_spdx_plain if {
+	parsed_purl := {"type": "npm", "name": "lib", "qualifiers": []}
+	pkg := {"annotations": [{
+		"annotator": "Tool: hermeto:jsonencoded",
+		"comment": "{\"name\":\"hermeto:found_by\",\"value\":\"hermeto\"}",
+		"annotationDate": "2024-12-09T12:00:00Z",
+		"annotationType": "OTHER",
+	}]}
+	sbom.is_registry_dependency(parsed_purl, pkg)
 }
 
 test_is_registry_dependency_unrelated_qualifiers if {
 	parsed_purl := {"type": "maven", "name": "lib", "qualifiers": [{"key": "type", "value": "pom"}]}
-	sbom.is_registry_dependency(parsed_purl)
+	sbom.is_registry_dependency(parsed_purl, {})
 }
 
 test_is_registry_dependency_with_download_url if {
 	parsed_purl := {"type": "generic", "name": "lib", "qualifiers": [{"key": "download_url", "value": "https://example.com/lib.tar.gz"}]}
-	not sbom.is_registry_dependency(parsed_purl)
+	not sbom.is_registry_dependency(parsed_purl, {})
 }
 
 test_is_registry_dependency_with_vcs_url if {
 	parsed_purl := {"type": "generic", "name": "lib", "qualifiers": [{"key": "vcs_url", "value": "https://github.com/example/lib.git"}]}
-	not sbom.is_registry_dependency(parsed_purl)
+	not sbom.is_registry_dependency(parsed_purl, {})
 }
 
 test_is_registry_dependency_with_both if {
@@ -363,10 +375,43 @@ test_is_registry_dependency_with_both if {
 		{"key": "download_url", "value": "https://example.com/lib.tar.gz"},
 		{"key": "vcs_url", "value": "https://github.com/example/lib.git"},
 	]}
-	not sbom.is_registry_dependency(parsed_purl)
+	not sbom.is_registry_dependency(parsed_purl, {})
 }
 
 test_is_registry_dependency_missing_qualifiers_field if {
 	parsed_purl := {"type": "maven", "name": "lib"}
-	sbom.is_registry_dependency(parsed_purl)
+	sbom.is_registry_dependency(parsed_purl, {})
+}
+
+test_is_registry_dependency_cdx_bundled if {
+	parsed_purl := {"type": "npm", "name": "lib", "qualifiers": []}
+	component := {"properties": [
+		{"name": "hermeto:found_by", "value": "hermeto"},
+		{"name": "cdx:npm:package:bundled", "value": "true"},
+	]}
+	not sbom.is_registry_dependency(parsed_purl, component)
+}
+
+test_is_registry_dependency_spdx_bundled if {
+	parsed_purl := {"type": "npm", "name": "lib", "qualifiers": []}
+	pkg := {"annotations": [
+		{
+			"annotator": "Tool: hermeto:jsonencoded",
+			"comment": "{\"name\":\"hermeto:found_by\",\"value\":\"hermeto\"}",
+			"annotationDate": "2024-12-09T12:00:00Z",
+			"annotationType": "OTHER",
+		},
+		{
+			"annotator": "Tool: hermeto:jsonencoded",
+			"comment": "{\"name\":\"cdx:npm:package:bundled\",\"value\":\"true\"}",
+			"annotationDate": "2024-12-09T12:00:00Z",
+			"annotationType": "OTHER",
+		},
+	]}
+	not sbom.is_registry_dependency(parsed_purl, pkg)
+}
+
+test_is_registry_dependency_no_properties_or_annotations if {
+	parsed_purl := {"type": "npm", "name": "lib", "qualifiers": []}
+	sbom.is_registry_dependency(parsed_purl, {})
 }

--- a/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego
+++ b/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego
@@ -266,15 +266,15 @@ deny contains result if {
 # title: Allowed proxy URLs
 # description: >-
 #   For components found by Hermeto with a PURL type listed in proxy_enabled_purl_types
-#   that are registry dependencies (no download_url or vcs_url qualifier), verify proxy
-#   URLs in externalReferences of type distribution match at least one pattern from
-#   allowed_proxy_url_patterns. The "proxy_enabled_purl_types" rule data key is a list
-#   of PURL type strings (e.g. ["maven", "npm"]). The "allowed_proxy_url_patterns" rule
-#   data key is an object mapping each PURL type string to a list of regular expression
-#   patterns (e.g. {"maven": ["^https://proxy\\.example\\.com/maven/.*"]}). Components
-#   with a URL of "NOASSERTION" are skipped. If a PURL type is listed in
-#   proxy_enabled_purl_types but has no entry in allowed_proxy_url_patterns, all
-#   components of that type are denied.
+#   that are registry dependencies (no download_url or vcs_url qualifier, not bundled),
+#   verify proxy URLs in externalReferences of type distribution match at least one
+#   pattern from allowed_proxy_url_patterns. The "proxy_enabled_purl_types" rule data
+#   key is a list of PURL type strings (e.g. ["maven", "npm"]). The
+#   "allowed_proxy_url_patterns" rule data key is an object mapping each PURL type
+#   string to a list of regular expression patterns (e.g.
+#   {"maven": ["^https://proxy\\.example\\.com/maven/.*"]}). Components with a URL of
+#   "NOASSERTION" are skipped. If a PURL type is listed in proxy_enabled_purl_types but
+#   has no entry in allowed_proxy_url_patterns, all components of that type are denied.
 # custom:
 #   short_name: allowed_proxy_urls
 #   failure_msg: >-
@@ -303,7 +303,7 @@ deny contains result if {
 	parsed_purl := ec.purl.parse(purl)
 	parsed_purl.type in proxy_enabled
 
-	sbom.is_registry_dependency(parsed_purl)
+	sbom.is_registry_dependency(parsed_purl, component)
 
 	distribution_url := object.get(reference, "url", "")
 	distribution_url != "NOASSERTION"
@@ -321,9 +321,9 @@ deny contains result if {
 # title: Proxy metadata required
 # description: >-
 #   For components found by Hermeto with a PURL type listed in proxy_enabled_purl_types
-#   that are registry dependencies (no download_url or vcs_url qualifier), verify that
-#   proxy metadata is present. In CycloneDX, this means at least one externalReference
-#   with type "distribution" must exist.
+#   that are registry dependencies (no download_url or vcs_url qualifier, not bundled),
+#   verify that proxy metadata is present. In CycloneDX, this means at least one
+#   externalReference with type "distribution" must exist.
 # custom:
 #   short_name: proxy_metadata_required
 #   failure_msg: >-
@@ -348,7 +348,7 @@ deny contains result if {
 	parsed_purl := ec.purl.parse(purl)
 	parsed_purl.type in proxy_enabled
 
-	sbom.is_registry_dependency(parsed_purl)
+	sbom.is_registry_dependency(parsed_purl, component)
 
 	not _has_distribution_reference(component)
 

--- a/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego
+++ b/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego
@@ -272,9 +272,9 @@ deny contains result if {
 #   key is a list of PURL type strings (e.g. ["maven", "npm"]). The
 #   "allowed_proxy_url_patterns" rule data key is an object mapping each PURL type
 #   string to a list of regular expression patterns (e.g.
-#   {"maven": ["^https://proxy\\.example\\.com/maven/.*"]}). Components with a URL of
-#   "NOASSERTION" are skipped. If a PURL type is listed in proxy_enabled_purl_types but
-#   has no entry in allowed_proxy_url_patterns, all components of that type are denied.
+#   {"maven": ["^https://proxy\\.example\\.com/maven/.*"]}). If a PURL type is listed
+#   in proxy_enabled_purl_types but has no entry in allowed_proxy_url_patterns, all
+#   components of that type are denied.
 # custom:
 #   short_name: allowed_proxy_urls
 #   failure_msg: >-
@@ -306,7 +306,6 @@ deny contains result if {
 	sbom.is_registry_dependency(parsed_purl, component)
 
 	distribution_url := object.get(reference, "url", "")
-	distribution_url != "NOASSERTION"
 	patterns := object.get(allowed_patterns, parsed_purl.type, [])
 	not sbom.url_matches_any_pattern(distribution_url, patterns)
 
@@ -362,7 +361,6 @@ deny contains result if {
 _has_distribution_reference(component) if {
 	some reference in component.externalReferences
 	reference.type == "distribution"
-	object.get(reference, "url", "") != "NOASSERTION"
 }
 
 # _with_effective_on annotates the result with the item's effective_on attribute. If the item does

--- a/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego
+++ b/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego
@@ -267,8 +267,8 @@ deny contains result if {
 # description: >-
 #   For components found by Hermeto with a PURL type listed in proxy_enabled_purl_types
 #   that are registry dependencies (no download_url or vcs_url qualifier, not bundled),
-#   verify proxy URLs in externalReferences of type distribution match at least one
-#   pattern from allowed_proxy_url_patterns. The "proxy_enabled_purl_types" rule data
+#   verify proxy URLs in externalReferences of type distribution with comment
+#   "proxy URL" match at least one pattern from allowed_proxy_url_patterns. The "proxy_enabled_purl_types" rule data
 #   key is a list of PURL type strings (e.g. ["maven", "npm"]). The
 #   "allowed_proxy_url_patterns" rule data key is an object mapping each PURL type
 #   string to a list of regular expression patterns (e.g.
@@ -298,6 +298,7 @@ deny contains result if {
 
 	some reference in component.externalReferences
 	reference.type == "distribution"
+	object.get(reference, "comment", "") == "proxy URL"
 
 	purl := component.purl
 	parsed_purl := ec.purl.parse(purl)
@@ -322,11 +323,11 @@ deny contains result if {
 #   For components found by Hermeto with a PURL type listed in proxy_enabled_purl_types
 #   that are registry dependencies (no download_url or vcs_url qualifier, not bundled),
 #   verify that proxy metadata is present. In CycloneDX, this means at least one
-#   externalReference with type "distribution" must exist.
+#   externalReference with type "distribution" and comment "proxy URL" must exist.
 # custom:
 #   short_name: proxy_metadata_required
 #   failure_msg: >-
-#     Package %s is missing proxy metadata (no externalReference of type "distribution")
+#     Package %s is missing proxy metadata (no externalReference of type "distribution" with comment "proxy URL")
 #   solution: >-
 #     Ensure the build process produces proxy metadata for packages fetched by
 #     Hermeto from a package registry.
@@ -361,6 +362,7 @@ deny contains result if {
 _has_distribution_reference(component) if {
 	some reference in component.externalReferences
 	reference.type == "distribution"
+	object.get(reference, "comment", "") == "proxy URL"
 }
 
 # _with_effective_on annotates the result with the item's effective_on attribute. If the item does

--- a/policy/release/sbom_cyclonedx/sbom_cyclonedx_test.rego
+++ b/policy/release/sbom_cyclonedx/sbom_cyclonedx_test.rego
@@ -704,8 +704,8 @@ test_proxy_url_cyclonedx_multiple_distribution_refs if {
 			"purl": "pkg:maven/org.example/lib@1.0",
 			"properties": [{"name": "hermeto:found_by", "value": "hermeto"}],
 			"externalReferences": [
-				{"type": "distribution", "url": "https://proxy.example.com/maven/org/example/lib-1.0.jar"},
-				{"type": "distribution", "url": "https://evil.com/lib-1.0.jar"},
+				{"type": "distribution", "comment": "proxy URL", "url": "https://proxy.example.com/maven/org/example/lib-1.0.jar"},
+				{"type": "distribution", "comment": "proxy URL", "url": "https://evil.com/lib-1.0.jar"},
 			],
 		},
 	}])]
@@ -863,7 +863,7 @@ _cdx_proxy_component(purl, distribution_url) := {
 	"name": "component",
 	"purl": purl,
 	"properties": [{"name": "hermeto:found_by", "value": "hermeto"}],
-	"externalReferences": [{"type": "distribution", "url": distribution_url}],
+	"externalReferences": [{"type": "distribution", "comment": "proxy URL", "url": distribution_url}],
 }
 
 _cdx_hermeto_component(purl, external_refs) := {
@@ -889,7 +889,7 @@ test_proxy_metadata_required_cdx_denied if {
 		"code": "sbom_cyclonedx.proxy_metadata_required",
 		"term": "pkg:maven/org.example/lib@1.0",
 		# regal ignore:line-length
-		"msg": `Package pkg:maven/org.example/lib@1.0 is missing proxy metadata (no externalReference of type "distribution")`,
+		"msg": `Package pkg:maven/org.example/lib@1.0 is missing proxy metadata (no externalReference of type "distribution" with comment "proxy URL")`,
 	}}
 
 	att := json.patch(_sbom_1_5_attestation, [{
@@ -911,7 +911,7 @@ test_proxy_metadata_required_cdx_with_distribution_passes if {
 		"path": "/statement/predicate/components/-",
 		"value": _cdx_hermeto_component(
 			"pkg:maven/org.example/lib@1.0",
-			[{"type": "distribution", "url": "https://proxy.example.com/maven/lib-1.0.jar"}],
+			[{"type": "distribution", "comment": "proxy URL", "url": "https://proxy.example.com/maven/lib-1.0.jar"}],
 		),
 	}])]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
@@ -946,7 +946,7 @@ test_proxy_metadata_required_cdx_non_distribution_refs_denied if {
 		"code": "sbom_cyclonedx.proxy_metadata_required",
 		"term": "pkg:maven/org.example/lib@1.0",
 		# regal ignore:line-length
-		"msg": `Package pkg:maven/org.example/lib@1.0 is missing proxy metadata (no externalReference of type "distribution")`,
+		"msg": `Package pkg:maven/org.example/lib@1.0 is missing proxy metadata (no externalReference of type "distribution" with comment "proxy URL")`,
 	}}
 
 	att := json.patch(_sbom_1_5_attestation, [{

--- a/policy/release/sbom_cyclonedx/sbom_cyclonedx_test.rego
+++ b/policy/release/sbom_cyclonedx/sbom_cyclonedx_test.rego
@@ -833,6 +833,48 @@ test_proxy_url_cyclonedx_download_url_skipped if {
 	count({r | some r in results; r.code == "sbom_cyclonedx.allowed_proxy_urls"}) == 0
 }
 
+test_proxy_url_cyclonedx_bundled_skipped if {
+	att := json.patch(_sbom_1_5_attestation, [{
+		"op": "add",
+		"path": "/statement/predicate/components/-",
+		"value": _cdx_bundled_component("pkg:npm/example-lib@2.0"),
+	}])
+
+	results := sbom_cyclonedx.deny with input.attestations as [att]
+		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
+		with ec.oci.image_referrers as []
+		with ec.oci.image_tag_refs as []
+		with data.rule_data as _proxy_rule_data
+
+	count({r | some r in results; r.code == "sbom_cyclonedx.allowed_proxy_urls"}) == 0
+}
+
+test_proxy_metadata_required_cdx_bundled_passes if {
+	att := json.patch(_sbom_1_5_attestation, [{
+		"op": "add",
+		"path": "/statement/predicate/components/-",
+		"value": _cdx_bundled_component("pkg:npm/example-lib@2.0"),
+	}])
+
+	results := sbom_cyclonedx.deny with input.attestations as [att]
+		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
+		with ec.oci.image_referrers as []
+		with ec.oci.image_tag_refs as []
+		with data.rule_data as _proxy_rule_data
+
+	count({r | some r in results; r.code == "sbom_cyclonedx.proxy_metadata_required"}) == 0
+}
+
+_cdx_bundled_component(purl) := {
+	"type": "library",
+	"name": "component",
+	"purl": purl,
+	"properties": [
+		{"name": "hermeto:found_by", "value": "hermeto"},
+		{"name": "cdx:npm:package:bundled", "value": "true"},
+	],
+}
+
 _cdx_proxy_component(purl, distribution_url) := {
 	"type": "library",
 	"name": "component",

--- a/policy/release/sbom_cyclonedx/sbom_cyclonedx_test.rego
+++ b/policy/release/sbom_cyclonedx/sbom_cyclonedx_test.rego
@@ -694,23 +694,6 @@ test_proxy_url_cyclonedx_denied if {
 	count(proxy_results) == 1
 }
 
-test_proxy_url_cyclonedx_noassertion_skipped if {
-	results := sbom_cyclonedx.deny with input.attestations as [json.patch(_sbom_1_5_attestation, [{
-		"op": "add",
-		"path": "/statement/predicate/components/-",
-		"value": _cdx_proxy_component(
-			"pkg:maven/org.example/lib@1.0",
-			"NOASSERTION",
-		),
-	}])]
-		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
-		with ec.oci.image_referrers as []
-		with ec.oci.image_tag_refs as []
-		with data.rule_data as _proxy_rule_data
-
-	count({r | some r in results; r.code == "sbom_cyclonedx.allowed_proxy_urls"}) == 0
-}
-
 test_proxy_url_cyclonedx_multiple_distribution_refs if {
 	results := sbom_cyclonedx.deny with input.attestations as [json.patch(_sbom_1_5_attestation, [{
 		"op": "add",
@@ -980,23 +963,6 @@ test_proxy_metadata_required_cdx_non_distribution_refs_denied if {
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
 		with data.rule_data as _proxy_rule_data
-}
-
-test_proxy_metadata_required_cdx_noassertion_distribution_denied if {
-	results := sbom_cyclonedx.deny with input.attestations as [json.patch(_sbom_1_5_attestation, [{
-		"op": "add",
-		"path": "/statement/predicate/components/-",
-		"value": _cdx_hermeto_component(
-			"pkg:maven/org.example/lib@1.0",
-			[{"type": "distribution", "url": "NOASSERTION"}],
-		),
-	}])]
-		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
-		with ec.oci.image_referrers as []
-		with ec.oci.image_tag_refs as []
-		with data.rule_data as _proxy_rule_data
-
-	count({r | some r in results; r.code == "sbom_cyclonedx.proxy_metadata_required"}) == 1
 }
 
 test_proxy_metadata_required_cdx_non_proxy_purl_type_passes if {

--- a/policy/release/sbom_spdx/sbom_spdx.rego
+++ b/policy/release/sbom_spdx/sbom_spdx.rego
@@ -252,14 +252,15 @@ deny contains result if {
 # description: >-
 #   For packages found by Hermeto with a PURL type listed in proxy_enabled_purl_types
 #   that are registry dependencies (no download_url or vcs_url qualifier, not bundled),
-#   verify the downloadLocation matches at least one pattern from
-#   allowed_proxy_url_patterns. The "proxy_enabled_purl_types" rule data key is a list
-#   of PURL type strings (e.g. ["maven", "npm"]). The "allowed_proxy_url_patterns"
-#   rule data key is an object mapping each PURL type string to a list of regular
-#   expression patterns (e.g. {"maven": ["^https://proxy\\.example\\.com/maven/.*"]}).
-#   Packages with downloadLocation set to "NOASSERTION" are skipped. If a PURL type
-#   is listed in proxy_enabled_purl_types but has no entry in
-#   allowed_proxy_url_patterns, all packages of that type are denied.
+#   verify each proxy URL in sourceInfo matches at least one pattern from
+#   allowed_proxy_url_patterns. Hermeto records proxy URLs in the sourceInfo field,
+#   semicolon-separated when multiple proxies are used. The "proxy_enabled_purl_types"
+#   rule data key is a list of PURL type strings (e.g. ["maven", "npm"]). The
+#   "allowed_proxy_url_patterns" rule data key is an object mapping each PURL type
+#   string to a list of regular expression patterns (e.g.
+#   {"maven": ["^https://proxy\\.example\\.com/maven/.*"]}). If a PURL type is listed
+#   in proxy_enabled_purl_types but has no entry in allowed_proxy_url_patterns, all
+#   packages of that type are denied.
 # custom:
 #   short_name: allowed_proxy_urls
 #   failure_msg: >-
@@ -290,15 +291,17 @@ deny contains result if {
 
 	sbom.is_registry_dependency(parsed_purl, pkg)
 
-	download_location := object.get(pkg, "downloadLocation", "")
-	download_location != "NOASSERTION"
+	source_info := object.get(pkg, "sourceInfo", "")
+	source_info != ""
+	some url in split(source_info, ";")
+	url != ""
 
 	patterns := object.get(allowed_patterns, parsed_purl.type, [])
-	not sbom.url_matches_any_pattern(download_location, patterns)
+	not sbom.url_matches_any_pattern(url, patterns)
 
 	result := metadata.result_helper_with_term(
 		rego.metadata.chain(),
-		[purl, download_location, parsed_purl.type],
+		[purl, url, parsed_purl.type],
 		purl,
 	)
 }

--- a/policy/release/sbom_spdx/sbom_spdx.rego
+++ b/policy/release/sbom_spdx/sbom_spdx.rego
@@ -251,15 +251,15 @@ deny contains result if {
 # title: Allowed proxy URLs
 # description: >-
 #   For packages found by Hermeto with a PURL type listed in proxy_enabled_purl_types
-#   that are registry dependencies (no download_url or vcs_url qualifier), verify the
-#   downloadLocation matches at least one pattern from allowed_proxy_url_patterns.
-#   The "proxy_enabled_purl_types" rule data key is a list of PURL type strings
-#   (e.g. ["maven", "npm"]). The "allowed_proxy_url_patterns" rule data key is an
-#   object mapping each PURL type string to a list of regular expression patterns
-#   (e.g. {"maven": ["^https://proxy\\.example\\.com/maven/.*"]}). Packages with
-#   downloadLocation set to "NOASSERTION" are skipped. If a PURL type is listed in
-#   proxy_enabled_purl_types but has no entry in allowed_proxy_url_patterns, all
-#   packages of that type are denied.
+#   that are registry dependencies (no download_url or vcs_url qualifier, not bundled),
+#   verify the downloadLocation matches at least one pattern from
+#   allowed_proxy_url_patterns. The "proxy_enabled_purl_types" rule data key is a list
+#   of PURL type strings (e.g. ["maven", "npm"]). The "allowed_proxy_url_patterns"
+#   rule data key is an object mapping each PURL type string to a list of regular
+#   expression patterns (e.g. {"maven": ["^https://proxy\\.example\\.com/maven/.*"]}).
+#   Packages with downloadLocation set to "NOASSERTION" are skipped. If a PURL type
+#   is listed in proxy_enabled_purl_types but has no entry in
+#   allowed_proxy_url_patterns, all packages of that type are denied.
 # custom:
 #   short_name: allowed_proxy_urls
 #   failure_msg: >-
@@ -288,7 +288,7 @@ deny contains result if {
 	parsed_purl := ec.purl.parse(purl)
 	parsed_purl.type in proxy_enabled
 
-	sbom.is_registry_dependency(parsed_purl)
+	sbom.is_registry_dependency(parsed_purl, pkg)
 
 	download_location := object.get(pkg, "downloadLocation", "")
 	download_location != "NOASSERTION"
@@ -307,8 +307,9 @@ deny contains result if {
 # title: Proxy metadata required
 # description: >-
 #   For packages found by Hermeto with a PURL type listed in proxy_enabled_purl_types
-#   that are registry dependencies (no download_url or vcs_url qualifier), verify that
-#   proxy metadata is present. In SPDX, the sourceInfo field must be non-empty.
+#   that are registry dependencies (no download_url or vcs_url qualifier, not bundled),
+#   verify that proxy metadata is present. In SPDX, the sourceInfo field must be
+#   non-empty.
 # custom:
 #   short_name: proxy_metadata_required
 #   failure_msg: >-
@@ -336,7 +337,7 @@ deny contains result if {
 	parsed_purl := ec.purl.parse(purl)
 	parsed_purl.type in proxy_enabled
 
-	sbom.is_registry_dependency(parsed_purl)
+	sbom.is_registry_dependency(parsed_purl, pkg)
 
 	source_info := object.get(pkg, "sourceInfo", "")
 	source_info == ""

--- a/policy/release/sbom_spdx/sbom_spdx_test.rego
+++ b/policy/release/sbom_spdx/sbom_spdx_test.rego
@@ -458,13 +458,13 @@ test_proxy_url_spdx_denied if {
 	count(proxy_results) == 1
 }
 
-test_proxy_url_spdx_noassertion_skipped if {
+test_proxy_url_spdx_empty_source_info_skipped if {
 	results := sbom_spdx.deny with input.attestations as [json.patch(_sbom_attestation, [{
 		"op": "add",
 		"path": "/statement/predicate/packages/-",
 		"value": _spdx_proxy_package(
 			"pkg:maven/org.example/lib@1.0",
-			"NOASSERTION",
+			"",
 		),
 	}])]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
@@ -537,13 +537,13 @@ test_proxy_url_spdx_download_url_skipped if {
 	count({r | some r in results; r.code == "sbom_spdx.allowed_proxy_urls"}) == 0
 }
 
-test_proxy_url_spdx_empty_download_location if {
+test_proxy_url_spdx_semicolon_separated if {
 	results := sbom_spdx.deny with input.attestations as [json.patch(_sbom_attestation, [{
 		"op": "add",
 		"path": "/statement/predicate/packages/-",
 		"value": _spdx_proxy_package(
-			"pkg:maven/org.example/lib@1.0",
-			"",
+			"pkg:npm/example-lib@2.0",
+			"https://proxy.example.com/npm/example-lib-2.0.tgz;https://evil.com/lib.tgz",
 		),
 	}])]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
@@ -613,10 +613,11 @@ _spdx_bundled_package(purl) := {
 	"checksums": [{"algorithm": "SHA256", "checksumValue": "abc123"}],
 }
 
-_spdx_proxy_package(purl, download_location) := {
+_spdx_proxy_package(purl, source_info) := {
 	"name": "proxy-package",
 	"SPDXID": "SPDXRef-proxy-package",
-	"downloadLocation": download_location,
+	"downloadLocation": "NOASSERTION",
+	"sourceInfo": source_info,
 	"externalRefs": [{
 		"referenceCategory": "PACKAGE-MANAGER",
 		"referenceType": "purl",

--- a/policy/release/sbom_spdx/sbom_spdx_test.rego
+++ b/policy/release/sbom_spdx/sbom_spdx_test.rego
@@ -555,6 +555,64 @@ test_proxy_url_spdx_empty_download_location if {
 	count(proxy_results) == 1
 }
 
+test_proxy_url_spdx_bundled_skipped if {
+	att := json.patch(_sbom_attestation, [{
+		"op": "add",
+		"path": "/statement/predicate/packages/-",
+		"value": _spdx_bundled_package("pkg:npm/example-lib@2.0"),
+	}])
+
+	results := sbom_spdx.deny with input.attestations as [att]
+		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
+		with ec.oci.image_referrers as []
+		with ec.oci.image_tag_refs as []
+		with data.rule_data as _spdx_proxy_rule_data
+
+	count({r | some r in results; r.code == "sbom_spdx.allowed_proxy_urls"}) == 0
+}
+
+test_proxy_metadata_required_spdx_bundled_passes if {
+	att := json.patch(_sbom_attestation, [{
+		"op": "add",
+		"path": "/statement/predicate/packages/-",
+		"value": _spdx_bundled_package("pkg:npm/example-lib@2.0"),
+	}])
+
+	results := sbom_spdx.deny with input.attestations as [att]
+		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
+		with ec.oci.image_referrers as []
+		with ec.oci.image_tag_refs as []
+		with data.rule_data as _spdx_proxy_rule_data
+
+	count({r | some r in results; r.code == "sbom_spdx.proxy_metadata_required"}) == 0
+}
+
+_spdx_bundled_package(purl) := {
+	"name": "bundled-package",
+	"SPDXID": "SPDXRef-bundled-package",
+	"downloadLocation": "NOASSERTION",
+	"externalRefs": [{
+		"referenceCategory": "PACKAGE-MANAGER",
+		"referenceType": "purl",
+		"referenceLocator": purl,
+	}],
+	"annotations": [
+		{
+			"annotator": "Tool: hermeto:jsonencoded",
+			"comment": "{\"name\":\"hermeto:found_by\",\"value\":\"hermeto\"}",
+			"annotationDate": "2024-12-09T12:00:00Z",
+			"annotationType": "OTHER",
+		},
+		{
+			"annotator": "Tool: hermeto:jsonencoded",
+			"comment": "{\"name\":\"cdx:npm:package:bundled\",\"value\":\"true\"}",
+			"annotationDate": "2024-12-09T12:00:00Z",
+			"annotationType": "OTHER",
+		},
+	],
+	"checksums": [{"algorithm": "SHA256", "checksumValue": "abc123"}],
+}
+
 _spdx_proxy_package(purl, download_location) := {
 	"name": "proxy-package",
 	"SPDXID": "SPDXRef-proxy-package",


### PR DESCRIPTION
Hermeto produces SBOMs with a few structural differences from what the proxy rules originally expected. This PR updates the rules to handle those differences:
- **SPDX proxy URL validation**: Support Hermeto's use of sourceInfo for proxy URLs instead of downloadLocation
- **CycloneDX proxy URL validation**: Use the comment == "proxy URL" field on distribution refs to identify proxy metadata, and clean up unused NOASSERTION guards.
- **Bundled dependency handling:** Exclude bundled npm dependencies from proxy rules, since they ship inside another package's tarball rather than being fetched individually from a registry.