### PR TITLE
feat(EC-1797): support version constraints for git resolver task references

### DIFF
--- a/policy/lib/tekton/trusted.rego
+++ b/policy/lib/tekton/trusted.rego
@@ -509,7 +509,7 @@ _trusted_task_rules_schema := {
 # This is intended for use in allow rules, where the rule is effective if all constraints match.
 # Supports constraints like: >=v2, <3, >3.1.0, <v4.2, >=1.2.3
 # Returns true if rule has no "versions" field
-# Returns false if versions field exists but no manifest version is found (don't allow by default for security)
+# Returns false if versions field exists but no task version is found (don't allow by default for security)
 # Returns true if task version satisfies all constraints
 # Returns false otherwise
 # bundle_manifests is a map of bundle_ref -> manifest from ec.oci.image_manifests
@@ -537,7 +537,7 @@ _version_satisfies_all_rule_constraints(ref, rule, bundle_manifests) if {
 # This is intended for use in deny rules, where the rule is effective if at least one constraint match.
 # Supports constraints like: >=v2, <3, >3.1.0, <v4.2, >=1.2.3
 # Returns true if rule has no "versions" field
-# Returns true if versions field exists but no manifest version is found (deny by default for security)
+# Returns true if versions field exists but no task version is found (deny by default for security)
 # Returns true if task version satisfies at least one constraint
 # Returns false otherwise
 # bundle_manifests is a map of bundle_ref -> manifest from ec.oci.image_manifests
@@ -609,6 +609,7 @@ _result_satisfies_operator(result, constraint) if {
 } else := false
 
 # Returns the task version from either OCI manifest annotations or git path conventions.
+# bundle_manifests is a map of bundle_ref -> manifest from ec.oci.image_manifests
 _get_task_version(ref, bundle_manifests) := version if {
 	version := _get_manifest_version_annotation(ref, bundle_manifests)
 } else := version if {
@@ -630,10 +631,17 @@ _get_git_path_version(ref) := version if {
 	path := ref.pathInRepo
 	path != ""
 	parts := split(path, "/")
-	count(parts) >= 3
+	count(parts) >= 4
+	parts[0] in _catalog_types
 	version := parts[2]
-	regex.match(`^v?\d+(\.\d+)*$`, version)
+	regex.match(`^v?\d+(\.\d+){0,2}$`, version)
 }
+
+# Recognized Tekton catalog top-level directory names. Version extraction
+# only applies to paths under these directories to avoid false matches on
+# non-catalog paths (e.g., docs/examples/1/readme.yaml). Extend this set
+# if new catalog resource types are introduced.
+_catalog_types := {"task", "stepaction"}
 
 # =============================================================================
 # BEGIN LEGACY SYSTEM (trusted_tasks)

--- a/policy/lib/tekton/trusted.rego
+++ b/policy/lib/tekton/trusted.rego
@@ -517,8 +517,8 @@ _version_satisfies_all_rule_constraints(ref, rule, bundle_manifests) if {
 	not "versions" in object.keys(rule)
 } else if {
 	# If versions field exists, manifest version must be found
-	manifest_version := _get_manifest_version_annotation(ref, bundle_manifests)
-	version := _normalize_version(manifest_version)
+	task_version := _get_task_version(ref, bundle_manifests)
+	version := _normalize_version(task_version)
 	semver.is_valid(version)
 
 	constraints := rule.versions
@@ -544,16 +544,16 @@ _version_satisfies_all_rule_constraints(ref, rule, bundle_manifests) if {
 _version_satisfies_any_rule_constraints(ref, rule, bundle_manifests) if {
 	not "versions" in object.keys(rule)
 } else if {
-	# If versions field exists but no manifest version found, deny the task (return true)
+	# If versions field exists but no task version found, deny the task (return true)
 	"versions" in object.keys(rule)
-	not _get_manifest_version_annotation(ref, bundle_manifests)
+	not _get_task_version(ref, bundle_manifests)
 } else if {
-	manifest_version := _get_manifest_version_annotation(ref, bundle_manifests)
-	version := _normalize_version(manifest_version)
+	task_version := _get_task_version(ref, bundle_manifests)
+	version := _normalize_version(task_version)
 	not semver.is_valid(version)
 } else if {
-	manifest_version := _get_manifest_version_annotation(ref, bundle_manifests)
-	version := _normalize_version(manifest_version)
+	task_version := _get_task_version(ref, bundle_manifests)
+	version := _normalize_version(task_version)
 	semver.is_valid(version)
 
 	constraints := rule.versions
@@ -608,6 +608,13 @@ _result_satisfies_operator(result, constraint) if {
 	result < 0
 } else := false
 
+# Returns the task version from either OCI manifest annotations or git path conventions.
+_get_task_version(ref, bundle_manifests) := version if {
+	version := _get_manifest_version_annotation(ref, bundle_manifests)
+} else := version if {
+	version := _get_git_path_version(ref)
+}
+
 # Returns the version annotation from the manifest for a bundle reference.
 # bundle_manifests is a map of bundle_ref -> manifest from ec.oci.image_manifests
 _get_manifest_version_annotation(ref, bundle_manifests) := version if {
@@ -615,6 +622,17 @@ _get_manifest_version_annotation(ref, bundle_manifests) := version if {
 	annotations := object.get(task_manifest, "annotations", {})
 	version := annotations["org.opencontainers.image.version"]
 	version != null
+}
+
+# Extracts version from git resolver pathInRepo using Tekton catalog conventions.
+# Paths follow the pattern type/name/version/filename (e.g., task/buildah/0.3/buildah.yaml).
+_get_git_path_version(ref) := version if {
+	path := ref.pathInRepo
+	path != ""
+	parts := split(path, "/")
+	count(parts) >= 3
+	version := parts[2]
+	regex.match(`^v?\d+(\.\d+)*$`, version)
 }
 
 # =============================================================================

--- a/policy/lib/tekton/trusted_test.rego
+++ b/policy/lib/tekton/trusted_test.rego
@@ -1247,7 +1247,7 @@ test_version_satisfies_any_rule_constraints if {
 	not tekton._version_satisfies_any_rule_constraints({"bundle": "example.com/task:1.0"}, {"versions": ["<1", ">=1.5.1"]}, manifests_v1_5_0)
 }
 
-test_git_version_extraction if {
+test_get_git_path_version if {
 	assertions.assert_equal("0.3", tekton._get_git_path_version({"pathInRepo": "task/buildah/0.3/buildah.yaml"}))
 	assertions.assert_equal("0.1", tekton._get_git_path_version({"pathInRepo": "task/git-clone/0.1/git-clone.yaml"}))
 	assertions.assert_equal("v2.1.0", tekton._get_git_path_version({"pathInRepo": "task/build/v2.1.0/build.yaml"}))
@@ -1257,19 +1257,22 @@ test_git_version_extraction if {
 	not tekton._get_git_path_version({"pathInRepo": "short/path"})
 	not tekton._get_git_path_version({"pathInRepo": "task/buildah/latest/buildah.yaml"})
 	not tekton._get_git_path_version({})
+	not tekton._get_git_path_version({"pathInRepo": "task/buildah/0.3"})
+	not tekton._get_git_path_version({"pathInRepo": "task/buildah/1.2.3.4/buildah.yaml"})
+	not tekton._get_git_path_version({"pathInRepo": "docs/examples/1/task.yaml"})
 }
 
 test_git_task_version_constraints_allow if {
 	rules := {
 		"allow": {"catalog": [{
-			"pattern": "git\\+https://github.com/konflux-ci/build-definitions.git//*",
+			"pattern": "git+https://github.com/konflux-ci/build-definitions.git//*",
 			"versions": [">=0.2", "<1"],
 		}]},
 		"deny": {},
 	}
 
 	# Git task with version 0.3 satisfies >=0.2 AND <1 → allowed
-	allowed_task := _git_task_with_path(
+	allowed_task := _mock_git_task(
 		"https://github.com/konflux-ci/build-definitions",
 		"task/buildah/0.3/buildah.yaml",
 		"abc123def456abc123def456abc123def456abc1",
@@ -1277,7 +1280,7 @@ test_git_task_version_constraints_allow if {
 	tekton.is_trusted_task(allowed_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as rules
 
 	# Git task with version 1.5 does NOT satisfy <1 → not allowed
-	rejected_task := _git_task_with_path(
+	rejected_task := _mock_git_task(
 		"https://github.com/konflux-ci/build-definitions",
 		"task/buildah/1.5/buildah.yaml",
 		"abc123def456abc123def456abc123def456abc1",
@@ -1285,7 +1288,7 @@ test_git_task_version_constraints_allow if {
 	not tekton.is_trusted_task(rejected_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as rules
 
 	# Git task with version 0.1 does NOT satisfy >=0.2 → not allowed
-	too_old_task := _git_task_with_path(
+	too_old_task := _mock_git_task(
 		"https://github.com/konflux-ci/build-definitions",
 		"task/buildah/0.1/buildah.yaml",
 		"abc123def456abc123def456abc123def456abc1",
@@ -1295,15 +1298,15 @@ test_git_task_version_constraints_allow if {
 
 test_git_task_version_constraints_deny if {
 	rules := {
-		"allow": {"catalog": [{"pattern": "git\\+https://github.com/konflux-ci/build-definitions.git//*"}]},
+		"allow": {"catalog": [{"pattern": "git+https://github.com/konflux-ci/build-definitions.git//*"}]},
 		"deny": {"deprecated": [{
-			"pattern": "git\\+https://github.com/konflux-ci/build-definitions.git//task/buildah/*",
+			"pattern": "git+https://github.com/konflux-ci/build-definitions.git//task/buildah/*",
 			"versions": ["<0.3"],
 		}]},
 	}
 
 	# Version 0.2 satisfies deny constraint <0.3 → denied
-	denied_task := _git_task_with_path(
+	denied_task := _mock_git_task(
 		"https://github.com/konflux-ci/build-definitions",
 		"task/buildah/0.2/buildah.yaml",
 		"abc123def456abc123def456abc123def456abc1",
@@ -1311,7 +1314,7 @@ test_git_task_version_constraints_deny if {
 	not tekton.is_trusted_task(denied_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as rules
 
 	# Version 0.3 does NOT satisfy deny constraint <0.3 → allowed
-	allowed_task := _git_task_with_path(
+	allowed_task := _mock_git_task(
 		"https://github.com/konflux-ci/build-definitions",
 		"task/buildah/0.3/buildah.yaml",
 		"abc123def456abc123def456abc123def456abc1",
@@ -1322,14 +1325,14 @@ test_git_task_version_constraints_deny if {
 test_git_task_no_version_in_path if {
 	rules := {
 		"allow": {"catalog": [{
-			"pattern": "git\\+https://github.com/konflux-ci/build-definitions.git//*",
+			"pattern": "git+https://github.com/konflux-ci/build-definitions.git//*",
 			"versions": [">=0.2"],
 		}]},
 		"deny": {},
 	}
 
 	# Path without version component → version not found → fail-closed (not allowed)
-	no_version_task := _git_task_with_path(
+	no_version_task := _mock_git_task(
 		"https://github.com/konflux-ci/build-definitions",
 		"tasks/buildah.yaml",
 		"abc123def456abc123def456abc123def456abc1",
@@ -1338,9 +1341,9 @@ test_git_task_no_version_in_path if {
 
 	# Deny rule with version + no version in path → denied (fail-closed)
 	deny_rules := {
-		"allow": {"catalog": [{"pattern": "git\\+https://github.com/konflux-ci/build-definitions.git//*"}]},
+		"allow": {"catalog": [{"pattern": "git+https://github.com/konflux-ci/build-definitions.git//*"}]},
 		"deny": {"deprecated": [{
-			"pattern": "git\\+https://github.com/konflux-ci/build-definitions.git//tasks/*",
+			"pattern": "git+https://github.com/konflux-ci/build-definitions.git//tasks/*",
 			"versions": ["<0.3"],
 		}]},
 	}
@@ -1349,12 +1352,12 @@ test_git_task_no_version_in_path if {
 
 test_git_task_without_version_constraints if {
 	rules := {
-		"allow": {"catalog": [{"pattern": "git\\+https://github.com/konflux-ci/build-definitions.git//*"}]},
+		"allow": {"catalog": [{"pattern": "git+https://github.com/konflux-ci/build-definitions.git//*"}]},
 		"deny": {},
 	}
 
 	# No version constraints in rule → allowed regardless of path version
-	task := _git_task_with_path(
+	task := _mock_git_task(
 		"https://github.com/konflux-ci/build-definitions",
 		"task/buildah/0.3/buildah.yaml",
 		"abc123def456abc123def456abc123def456abc1",
@@ -1362,7 +1365,7 @@ test_git_task_without_version_constraints if {
 	tekton.is_trusted_task(task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as rules
 }
 
-_git_task_with_path(url, path, revision) := {
+_mock_git_task(url, path, revision) := {
 	"metadata": {"labels": {"tekton.dev/task": "test-task"}},
 	"spec": {"taskRef": {"resolver": "git", "params": [
 		{"name": "url", "value": url},

--- a/policy/lib/tekton/trusted_test.rego
+++ b/policy/lib/tekton/trusted_test.rego
@@ -1247,6 +1247,130 @@ test_version_satisfies_any_rule_constraints if {
 	not tekton._version_satisfies_any_rule_constraints({"bundle": "example.com/task:1.0"}, {"versions": ["<1", ">=1.5.1"]}, manifests_v1_5_0)
 }
 
+test_git_version_extraction if {
+	assertions.assert_equal("0.3", tekton._get_git_path_version({"pathInRepo": "task/buildah/0.3/buildah.yaml"}))
+	assertions.assert_equal("0.1", tekton._get_git_path_version({"pathInRepo": "task/git-clone/0.1/git-clone.yaml"}))
+	assertions.assert_equal("v2.1.0", tekton._get_git_path_version({"pathInRepo": "task/build/v2.1.0/build.yaml"}))
+	assertions.assert_equal("1", tekton._get_git_path_version({"pathInRepo": "stepaction/eaas/1/eaas.yaml"}))
+
+	not tekton._get_git_path_version({"pathInRepo": ""})
+	not tekton._get_git_path_version({"pathInRepo": "short/path"})
+	not tekton._get_git_path_version({"pathInRepo": "task/buildah/latest/buildah.yaml"})
+	not tekton._get_git_path_version({})
+}
+
+test_git_task_version_constraints_allow if {
+	rules := {
+		"allow": {"catalog": [{
+			"pattern": "git\\+https://github.com/konflux-ci/build-definitions.git//*",
+			"versions": [">=0.2", "<1"],
+		}]},
+		"deny": {},
+	}
+
+	# Git task with version 0.3 satisfies >=0.2 AND <1 → allowed
+	allowed_task := _git_task_with_path(
+		"https://github.com/konflux-ci/build-definitions",
+		"task/buildah/0.3/buildah.yaml",
+		"abc123def456abc123def456abc123def456abc1",
+	)
+	tekton.is_trusted_task(allowed_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as rules
+
+	# Git task with version 1.5 does NOT satisfy <1 → not allowed
+	rejected_task := _git_task_with_path(
+		"https://github.com/konflux-ci/build-definitions",
+		"task/buildah/1.5/buildah.yaml",
+		"abc123def456abc123def456abc123def456abc1",
+	)
+	not tekton.is_trusted_task(rejected_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as rules
+
+	# Git task with version 0.1 does NOT satisfy >=0.2 → not allowed
+	too_old_task := _git_task_with_path(
+		"https://github.com/konflux-ci/build-definitions",
+		"task/buildah/0.1/buildah.yaml",
+		"abc123def456abc123def456abc123def456abc1",
+	)
+	not tekton.is_trusted_task(too_old_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as rules
+}
+
+test_git_task_version_constraints_deny if {
+	rules := {
+		"allow": {"catalog": [{"pattern": "git\\+https://github.com/konflux-ci/build-definitions.git//*"}]},
+		"deny": {"deprecated": [{
+			"pattern": "git\\+https://github.com/konflux-ci/build-definitions.git//task/buildah/*",
+			"versions": ["<0.3"],
+		}]},
+	}
+
+	# Version 0.2 satisfies deny constraint <0.3 → denied
+	denied_task := _git_task_with_path(
+		"https://github.com/konflux-ci/build-definitions",
+		"task/buildah/0.2/buildah.yaml",
+		"abc123def456abc123def456abc123def456abc1",
+	)
+	not tekton.is_trusted_task(denied_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as rules
+
+	# Version 0.3 does NOT satisfy deny constraint <0.3 → allowed
+	allowed_task := _git_task_with_path(
+		"https://github.com/konflux-ci/build-definitions",
+		"task/buildah/0.3/buildah.yaml",
+		"abc123def456abc123def456abc123def456abc1",
+	)
+	tekton.is_trusted_task(allowed_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as rules
+}
+
+test_git_task_no_version_in_path if {
+	rules := {
+		"allow": {"catalog": [{
+			"pattern": "git\\+https://github.com/konflux-ci/build-definitions.git//*",
+			"versions": [">=0.2"],
+		}]},
+		"deny": {},
+	}
+
+	# Path without version component → version not found → fail-closed (not allowed)
+	no_version_task := _git_task_with_path(
+		"https://github.com/konflux-ci/build-definitions",
+		"tasks/buildah.yaml",
+		"abc123def456abc123def456abc123def456abc1",
+	)
+	not tekton.is_trusted_task(no_version_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as rules
+
+	# Deny rule with version + no version in path → denied (fail-closed)
+	deny_rules := {
+		"allow": {"catalog": [{"pattern": "git\\+https://github.com/konflux-ci/build-definitions.git//*"}]},
+		"deny": {"deprecated": [{
+			"pattern": "git\\+https://github.com/konflux-ci/build-definitions.git//tasks/*",
+			"versions": ["<0.3"],
+		}]},
+	}
+	not tekton.is_trusted_task(no_version_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as deny_rules
+}
+
+test_git_task_without_version_constraints if {
+	rules := {
+		"allow": {"catalog": [{"pattern": "git\\+https://github.com/konflux-ci/build-definitions.git//*"}]},
+		"deny": {},
+	}
+
+	# No version constraints in rule → allowed regardless of path version
+	task := _git_task_with_path(
+		"https://github.com/konflux-ci/build-definitions",
+		"task/buildah/0.3/buildah.yaml",
+		"abc123def456abc123def456abc123def456abc1",
+	)
+	tekton.is_trusted_task(task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as rules
+}
+
+_git_task_with_path(url, path, revision) := {
+	"metadata": {"labels": {"tekton.dev/task": "test-task"}},
+	"spec": {"taskRef": {"resolver": "git", "params": [
+		{"name": "url", "value": url},
+		{"name": "pathInRepo", "value": path},
+		{"name": "revision", "value": revision},
+	]}},
+}
+
 test_normalize_version if {
 	# Trim operators
 	assertions.assert_equal("1.2.3", tekton._normalize_version(">=1.2.3"))


### PR DESCRIPTION
## Summary

- Extracts version from git resolver `pathInRepo` using the Tekton catalog convention (`type/name/version/filename`)
- Enables `trusted_task_rules` version constraints to work with git resolver tasks, not just OCI bundles
- Adds a unified `_get_task_version` function that chains OCI manifest annotation lookup with git path extraction
- Preserves fail-closed behavior when no version can be determined

## Test plan

- [ ] 928/928 tests pass with 100% coverage
- [ ] Git task with version in path satisfies allow rule version constraints
- [ ] Git task with version in path correctly denied by deny rule version constraints  
- [ ] Git task without version in path fails closed (not allowed / denied)
- [ ] Git task without version constraints in rule works regardless of path
- [ ] Existing bundle version constraint tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)