### PR TITLE
feat: add unless conditions to disallowed_attributes rule data

### DIFF
--- a/antora/docs/modules/ROOT/pages/packages/release_sbom_cyclonedx.adoc
+++ b/antora/docs/modules/ROOT/pages/packages/release_sbom_cyclonedx.adoc
@@ -30,7 +30,7 @@ Confirm the CycloneDX SBOM contains only packages with explicitly allowed extern
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Package %s has reference %q of type %q which is not explicitly allowed%s`
 * Code: `sbom_cyclonedx.allowed_package_external_references`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego#L161[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego#L164[Source, window="_blank"]
 
 [#sbom_cyclonedx__allowed_package_sources]
 === link:#sbom_cyclonedx__allowed_package_sources[Allowed package sources]
@@ -43,7 +43,7 @@ For each of the components fetched by Hermeto which define externalReferences of
 * FAILURE message: `Package %s fetched by Hermeto was sourced from %q which is not allowed`
 * Code: `sbom_cyclonedx.allowed_package_sources`
 * Effective from: `2024-12-15T00:00:00Z`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego#L225[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego#L228[Source, window="_blank"]
 
 [#sbom_cyclonedx__allowed_proxy_urls]
 === link:#sbom_cyclonedx__allowed_proxy_urls[Allowed proxy URLs]
@@ -56,7 +56,7 @@ For components found by Hermeto with a PURL type listed in proxy_enabled_purl_ty
 * FAILURE message: `Package %s has proxy URL %q which does not match any allowed pattern for PURL type %q`
 * Code: `sbom_cyclonedx.allowed_proxy_urls`
 * Effective from: `2026-06-01T00:00:00Z`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego#L265[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego#L268[Source, window="_blank"]
 
 [#sbom_cyclonedx__disallowed_package_attributes]
 === link:#sbom_cyclonedx__disallowed_package_attributes[Disallowed package attributes]
@@ -82,7 +82,7 @@ Confirm the CycloneDX SBOM contains only packages without disallowed external re
 * FAILURE message: `Package %s has reference %q of type %q which is disallowed%s`
 * Code: `sbom_cyclonedx.disallowed_package_external_references`
 * Effective from: `2024-07-31T00:00:00Z`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego#L193[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego#L196[Source, window="_blank"]
 
 [#sbom_cyclonedx__proxy_metadata_required]
 === link:#sbom_cyclonedx__proxy_metadata_required[Proxy metadata required]
@@ -95,7 +95,7 @@ For components found by Hermeto with a PURL type listed in proxy_enabled_purl_ty
 * FAILURE message: `Package %s is missing proxy metadata (no externalReference of type "distribution" with comment "proxy URL")`
 * Code: `sbom_cyclonedx.proxy_metadata_required`
 * Effective from: `2026-05-13T00:00:00Z`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego#L320[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego#L323[Source, window="_blank"]
 
 [#sbom_cyclonedx__cdx_supported_version]
 === link:#sbom_cyclonedx__cdx_supported_version[Supported Version]

--- a/antora/docs/modules/ROOT/pages/packages/release_sbom_spdx.adoc
+++ b/antora/docs/modules/ROOT/pages/packages/release_sbom_spdx.adoc
@@ -56,7 +56,7 @@ For packages found by Hermeto with a PURL type listed in proxy_enabled_purl_type
 * FAILURE message: `Package %s has proxy URL %q which does not match any allowed pattern for PURL type %q`
 * Code: `sbom_spdx.allowed_proxy_urls`
 * Effective from: `2026-06-01T00:00:00Z`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_spdx/sbom_spdx.rego#L250[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_spdx/sbom_spdx.rego#L253[Source, window="_blank"]
 
 [#sbom_spdx__contains_files]
 === link:#sbom_spdx__contains_files[Contains files]
@@ -131,7 +131,7 @@ For packages found by Hermeto with a PURL type listed in proxy_enabled_purl_type
 * FAILURE message: `Package %s is missing proxy metadata (sourceInfo is empty or missing)`
 * Code: `sbom_spdx.proxy_metadata_required`
 * Effective from: `2026-05-13T00:00:00Z`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_spdx/sbom_spdx.rego#L309[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_spdx/sbom_spdx.rego#L312[Source, window="_blank"]
 
 [#sbom_spdx__valid]
 === link:#sbom_spdx__valid[Valid]

--- a/policy/lib/sbom/sbom.rego
+++ b/policy/lib/sbom/sbom.rego
@@ -258,6 +258,15 @@ rule_data_errors contains error if {
 				"name": {"type": "string"},
 				"value": {"type": "string"},
 				"effective_on": {"type": "string", "format": "date-time"},
+				"unless": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {"purl": {"type": "string", "format": "regex"}},
+						"additionalProperties": false,
+						"required": ["purl"],
+					},
+				},
 			},
 			"additionalProperties": false,
 			"required": ["name"],
@@ -465,3 +474,9 @@ rule_data_allowed_external_references_key := "allowed_external_references"
 rule_data_disallowed_external_references_key := "disallowed_external_references"
 
 rule_data_allowed_package_sources_key := "allowed_package_sources"
+
+attribute_excluded(purls, disallowed) if {
+	some condition in object.get(disallowed, "unless", [])
+	some purl in purls
+	regex.match(condition.purl, purl)
+}

--- a/policy/release/sbom/sbom_test.rego
+++ b/policy/release/sbom/sbom_test.rego
@@ -65,6 +65,8 @@ test_rule_data_validation if {
 			# ok
 			{"name": "some_attr", "value": "some_val"},
 			{"name": "no_val_attr"},
+			# ok with unless
+			{"name": "some_attr", "unless": [{"purl": "^pkg:pypi/.*"}]},
 			# Missing required attributes
 			{},
 			# Additional properties not allowed
@@ -76,6 +78,12 @@ test_rule_data_validation if {
 			{"name": "_name_", "value": "_value_"},
 			# Invalid effective on format
 			{"name": "_name_", "effective_on": "not-a-date"},
+			# Invalid unless format
+			{"name": "_name_", "unless": "not-an-array"},
+			# Invalid unless item
+			{"name": "_name_", "unless": [{"not_purl": "value"}]},
+			# Invalid unless purl regex
+			{"name": "_name_", "unless": [{"purl": "[invalid"}]},
 		],
 		lib.sbom.rule_data_allowed_external_references_key: [
 			{"type": "distribution", "url": "example.com"},
@@ -160,34 +168,59 @@ test_rule_data_validation if {
 		},
 		{
 			"code": "sbom.disallowed_packages_provided",
-			"msg": "Rule data disallowed_attributes has unexpected format: 2: name is required",
+			"msg": "Rule data disallowed_attributes has unexpected format: 3: name is required",
 			"severity": "failure",
 		},
 		{
 			"code": "sbom.disallowed_packages_provided",
-			"msg": "Rule data disallowed_attributes has unexpected format: 3: Additional property something is not allowed",
+			# regal ignore:line-length
+			"msg": "Rule data disallowed_attributes has unexpected format: 4: Additional property something is not allowed",
 			"severity": "warning",
 		},
 		{
 			"code": "sbom.disallowed_packages_provided",
 			# regal ignore:line-length
-			"msg": "Rule data disallowed_attributes has unexpected format: 4.name: Invalid type. Expected: string, given: integer",
+			"msg": "Rule data disallowed_attributes has unexpected format: 5.name: Invalid type. Expected: string, given: integer",
 			"severity": "failure",
 		},
 		{
 			"code": "sbom.disallowed_packages_provided",
 			# regal ignore:line-length
-			"msg": "Rule data disallowed_attributes has unexpected format: 4.value: Invalid type. Expected: string, given: integer",
+			"msg": "Rule data disallowed_attributes has unexpected format: 5.value: Invalid type. Expected: string, given: integer",
 			"severity": "failure",
 		},
 		{
 			"code": "sbom.disallowed_packages_provided",
-			"msg": "Rule data disallowed_attributes has unexpected format: (Root): array items[5,6] must be unique",
+			"msg": "Rule data disallowed_attributes has unexpected format: (Root): array items[6,7] must be unique",
 			"severity": "failure",
 		},
 		{
 			"code": "sbom.disallowed_packages_provided",
-			"msg": "Rule data disallowed_attributes has unexpected format: 7.effective_on: Does not match format 'date-time'",
+			# regal ignore:line-length
+			"msg": "Rule data disallowed_attributes has unexpected format: 8.effective_on: Does not match format 'date-time'",
+			"severity": "failure",
+		},
+		{
+			"code": "sbom.disallowed_packages_provided",
+			# regal ignore:line-length
+			"msg": "Rule data disallowed_attributes has unexpected format: 9.unless: Invalid type. Expected: array, given: string",
+			"severity": "failure",
+		},
+		{
+			"code": "sbom.disallowed_packages_provided",
+			# regal ignore:line-length
+			"msg": "Rule data disallowed_attributes has unexpected format: 10.unless.0: Additional property not_purl is not allowed",
+			"severity": "warning",
+		},
+		{
+			"code": "sbom.disallowed_packages_provided",
+			"msg": "Rule data disallowed_attributes has unexpected format: 10.unless.0: purl is required",
+			"severity": "failure",
+		},
+		{
+			"code": "sbom.disallowed_packages_provided",
+			# regal ignore:line-length
+			"msg": "Rule data disallowed_attributes has unexpected format: 11.unless.0.purl: Does not match format 'regex'",
 			"severity": "failure",
 		},
 		{

--- a/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego
+++ b/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego
@@ -149,6 +149,9 @@ deny contains result if {
 	property.name == disallowed.name
 	object.get(property, "value", "") == object.get(disallowed, "value", "")
 
+	purls := {p | p := component.purl}
+	not sbom.attribute_excluded(purls, disallowed)
+
 	msg := regex.replace(object.get(property, "value", ""), `(.+)`, ` to "$1"`)
 
 	id := object.get(component, "purl", component.name)

--- a/policy/release/sbom_cyclonedx/sbom_cyclonedx_test.rego
+++ b/policy/release/sbom_cyclonedx/sbom_cyclonedx_test.rego
@@ -214,6 +214,41 @@ test_attributes_not_allowed_value_no_purl if {
 		with data.rule_data as {sbom.rule_data_attributes_key: [{"name": "syft:distro:id", "value": "rhel"}]}
 }
 
+test_attributes_not_allowed_unless_matching if {
+	assertions.assert_empty(sbom_cyclonedx.deny) with input.attestations as [_sbom_1_5_attestation]
+		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
+		with ec.oci.image_referrers as []
+		with ec.oci.image_tag_refs as []
+		with data.rule_data as {sbom.rule_data_attributes_key: [{"name": "attr1", "unless": [{"purl": "^pkg:rpm/.*"}]}]}
+}
+
+test_attributes_not_allowed_unless_multiple_any_matches if {
+	assertions.assert_empty(sbom_cyclonedx.deny) with input.attestations as [_sbom_1_5_attestation]
+		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
+		with ec.oci.image_referrers as []
+		with ec.oci.image_tag_refs as []
+		with data.rule_data as {sbom.rule_data_attributes_key: [{
+			"name": "attr1",
+			"unless": [{"purl": "^pkg:pypi/.*"}, {"purl": "^pkg:rpm/.*"}],
+		}]}
+}
+
+test_attributes_not_allowed_unless_not_matching if {
+	expected := {{
+		"code": "sbom_cyclonedx.disallowed_package_attributes",
+		# regal ignore:line-length
+		"term": "pkg:rpm/rhel/coreutils-single@8.32-34.el9?arch=x86_64&upstream=coreutils-8.32-34.el9.src.rpm&distro=rhel-9.3",
+		# regal ignore:line-length
+		"msg": `Package pkg:rpm/rhel/coreutils-single@8.32-34.el9?arch=x86_64&upstream=coreutils-8.32-34.el9.src.rpm&distro=rhel-9.3 has the attribute "attr1" set`,
+	}}
+
+	assertions.assert_equal_results(expected, sbom_cyclonedx.deny) with input.attestations as [_sbom_1_5_attestation]
+		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
+		with ec.oci.image_referrers as []
+		with ec.oci.image_tag_refs as []
+		with data.rule_data as {sbom.rule_data_attributes_key: [{"name": "attr1", "unless": [{"purl": "^pkg:pypi/.*"}]}]}
+}
+
 test_external_references_allowed_regex_with_no_rules_is_allowed if {
 	expected := {}
 	assertions.assert_equal_results(expected, sbom_cyclonedx.deny) with input.attestations as [_sbom_1_5_attestation]

--- a/policy/release/sbom_spdx/sbom_spdx.rego
+++ b/policy/release/sbom_spdx/sbom_spdx.rego
@@ -238,6 +238,9 @@ deny contains result if {
 
 	object.get(properties, "value", "") == object.get(disallowed, "value", "")
 
+	purls := {ref.referenceLocator | some ref in pkg.externalRefs; ref.referenceType == "purl"}
+	not sbom.attribute_excluded(purls, disallowed)
+
 	msg := regex.replace(object.get(properties, "value", ""), `(.+)`, ` to "$1"`)
 
 	id := object.get(externalref, "referenceLocator", pkg.name)

--- a/policy/release/sbom_spdx/sbom_spdx_test.rego
+++ b/policy/release/sbom_spdx/sbom_spdx_test.rego
@@ -367,6 +367,41 @@ test_attributes_multiple_external_refs if {
 		with data.rule_data as {sbom.rule_data_attributes_key: [{"name": "attr2", "value": "value2"}]}
 }
 
+test_attributes_not_allowed_unless_matching if {
+	assertions.assert_empty(sbom_spdx.deny) with input.attestations as [_sbom_attestation]
+		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
+		with ec.oci.image_referrers as []
+		with ec.oci.image_tag_refs as []
+		with data.rule_data as {sbom.rule_data_attributes_key: [{"name": "attr1", "unless": [{"purl": "^pkg:oci/.*"}]}]}
+}
+
+test_attributes_not_allowed_unless_multiple_any_matches if {
+	assertions.assert_empty(sbom_spdx.deny) with input.attestations as [_sbom_attestation]
+		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
+		with ec.oci.image_referrers as []
+		with ec.oci.image_tag_refs as []
+		with data.rule_data as {sbom.rule_data_attributes_key: [{
+			"name": "attr1",
+			"unless": [{"purl": "^pkg:pypi/.*"}, {"purl": "^pkg:oci/.*"}],
+		}]}
+}
+
+test_attributes_not_allowed_unless_not_matching if {
+	expected := {{
+		"code": "sbom_spdx.disallowed_package_attributes",
+		# regal ignore:line-length
+		"term": "pkg:oci/kernel-module-management-rhel9-operator@sha256%3Ad845f0bd93dad56c92c47e8c116a11a0cc5924c0b99aed912b4f8b54178efa98",
+		# regal ignore:line-length
+		"msg": `Package pkg:oci/kernel-module-management-rhel9-operator@sha256%3Ad845f0bd93dad56c92c47e8c116a11a0cc5924c0b99aed912b4f8b54178efa98 has the attribute "attr1" set`,
+	}}
+
+	assertions.assert_equal_results(expected, sbom_spdx.deny) with input.attestations as [_sbom_attestation]
+		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
+		with ec.oci.image_referrers as []
+		with ec.oci.image_tag_refs as []
+		with data.rule_data as {sbom.rule_data_attributes_key: [{"name": "attr1", "unless": [{"purl": "^pkg:pypi/.*"}]}]}
+}
+
 _sbom_attestation := {"statement": {
 	"predicateType": "https://spdx.dev/Document",
 	"predicate": {


### PR DESCRIPTION
Allow exempting packages from disallowed attribute checks based on PURL patterns. Each disallowed_attributes entry now accepts an optional "unless" array of objects with a "purl" regex field. When a package's PURL matches any pattern, the attribute is permitted. Multiple unless entries are OR'd — any match exempts the package.