### PR TITLE
feat: add trusted_task_rules_enabled toggle to rule_data

### DIFF
--- a/acceptance/testdata/trusted-task-rules/rule_data.yml
+++ b/acceptance/testdata/trusted-task-rules/rule_data.yml
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 rule_data:
+  trusted_task_rules_enabled: true
   trusted_task_rules:
     allow:
       konflux-tasks:

--- a/policy/lib/intoto/trust_test.rego
+++ b/policy/lib/intoto/trust_test.rego
@@ -265,6 +265,7 @@ test_verified_statement_happy_path if {
 		with ec.oci.blob as _mock_blob
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(result) == 1
 	some statement in result
@@ -306,6 +307,7 @@ test_untrusted_tasks if {
 		with ec.oci.blob as _mock_blob
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as no_matching_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(result) == 0
 }
@@ -321,6 +323,7 @@ test_denied_tasks if {
 		with ec.oci.blob as _mock_blob
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as deny_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(result) == 0
 }
@@ -332,6 +335,7 @@ test_empty_tasks_vacuous_truth_guard if {
 		with ec.oci.blob as _mock_blob
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(result) == 0
 }
@@ -343,6 +347,7 @@ test_bundleless_tasks if {
 		with ec.oci.blob as _mock_blob
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(result) == 0
 }
@@ -354,6 +359,7 @@ test_multiple_statements_mixed if {
 		with ec.oci.blob as _mock_blob_multi
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(result) == 1
 	some statement in result
@@ -367,6 +373,7 @@ test_verified_statements_by_predicate if {
 		with ec.oci.blob as _mock_blob_multi
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(result) == 1
 	some statement in result
@@ -380,6 +387,7 @@ test_mixed_bundle_and_inline_tasks if {
 		with ec.oci.blob as _mock_blob
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(result) == 0
 }
@@ -391,6 +399,7 @@ test_existential_attestation_matching if {
 		with ec.oci.blob as _mock_blob
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(result) == 1
 }
@@ -402,6 +411,7 @@ test_unrecognized_statement_type if {
 		with ec.oci.blob as _mock_blob_unknown_type
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(result) == 0
 }
@@ -413,6 +423,7 @@ test_malformed_blob if {
 		with ec.oci.blob as _mock_blob_malformed
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(result) == 0
 }
@@ -424,6 +435,7 @@ test_provenance_subject_digest_mismatch if {
 		with ec.oci.blob as _mock_blob
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(result) == 0
 }

--- a/policy/lib/rule_data/rule_data.rego
+++ b/policy/lib/rule_data/rule_data.rego
@@ -136,6 +136,8 @@ defaults := {
 	# using the ruleData key. Make this default to an empty dict so we can conveniently
 	# merge it with with `data.trusted_tasks`
 	"trusted_tasks": {},
+	# Used in lib/tekton/trusted.rego to toggle trusted_task_rules on/off
+	"trusted_task_rules_enabled": false,
 	# Number of days before a version of the Task expires that warnings are reported
 	"task_expiry_warning_days": 0,
 	# Number of days before a volatile config rule expires that warnings are reported

--- a/policy/lib/tekton/trusted.rego
+++ b/policy/lib/tekton/trusted.rego
@@ -63,6 +63,11 @@ missing_trusted_task_rules_data if {
 	count(_trusted_task_rules_data.allow) + count(_trusted_task_rules_data.deny) == 0
 }
 
+# Returns true if trusted_task_rules is explicitly disabled via rule_data
+missing_trusted_task_rules_data if {
+	lib_rule_data("trusted_task_rules_enabled") == false
+}
+
 default missing_trusted_tasks_data := false
 
 # Returns true if legacy trusted_tasks data is missing
@@ -255,6 +260,17 @@ data_errors contains error if {
 				"type": "integer",
 				"minimum": 0,
 			}},
+		},
+	)
+}
+
+data_errors contains error if {
+	some error in j.validate_schema(
+		{"trusted_task_rules_enabled": lib_rule_data("trusted_task_rules_enabled")},
+		{
+			"$schema": "http://json-schema.org/draft-07/schema#",
+			"type": "object",
+			"properties": {"trusted_task_rules_enabled": {"type": "boolean"}},
 		},
 	)
 }

--- a/policy/lib/tekton/trusted_test.rego
+++ b/policy/lib/tekton/trusted_test.rego
@@ -179,6 +179,64 @@ test_untrusted_task_refs_routes_to_rules if {
 
 	# regal ignore:line-length
 	assertions.assert_equal(expected, tekton.untrusted_task_refs(tasks, _empty_bundle_manifests)) with data.rule_data.trusted_task_rules as task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
+}
+
+test_trusted_task_rules_enabled_toggle if {
+	task_rules := {
+		"allow": {"trusty-tasks": [{"pattern": "oci://registry.local/*"}]},
+		"deny": {},
+	}
+
+	# With toggle true, rules system is active
+	assertions.assert_equal(false, tekton.missing_trusted_task_rules_data) with data.rule_data.trusted_task_rules as task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
+
+	# With toggle false (default), rules system is disabled even when rules data is present
+	assertions.assert_equal(true, tekton.missing_trusted_task_rules_data) with data.rule_data.trusted_task_rules as task_rules
+
+	# With toggle explicitly false, rules system is disabled
+	assertions.assert_equal(true, tekton.missing_trusted_task_rules_data) with data.rule_data.trusted_task_rules as task_rules
+		with data.rule_data.trusted_task_rules_enabled as false
+}
+
+test_trusted_task_rules_enabled_routing if {
+	task_rules := {
+		"allow": {"trusty-tasks": [{"pattern": "oci://registry.local/*"}]},
+		"deny": {},
+	}
+
+	# With rules enabled, trusted_bundle_task matches via rules system
+	tekton.is_trusted_task(trusted_bundle_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
+
+	# With rules disabled, falls back to legacy trusted_tasks
+	tekton.is_trusted_task(trusted_bundle_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
+		with data.rule_data.trusted_task_rules_enabled as false
+		with data.trusted_tasks as trusted_tasks
+
+	# With rules disabled and no legacy data, task is untrusted
+	not tekton.is_trusted_task(trusted_bundle_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
+		with data.rule_data.trusted_task_rules_enabled as false
+}
+
+test_trusted_task_rules_enabled_data_errors if {
+	# Valid boolean values should pass
+	assertions.assert_empty(tekton.data_errors) with data.rule_data.trusted_task_rules_enabled as true
+	assertions.assert_empty(tekton.data_errors) with data.rule_data.trusted_task_rules_enabled as false
+
+	# Non-boolean values should fail
+	assertions.assert_equal(tekton.data_errors, {{
+		"message": "trusted_task_rules_enabled: Invalid type. Expected: boolean, given: string",
+		"severity": "failure",
+	}}) with data.rule_data.trusted_task_rules_enabled as "false"
+
+	assertions.assert_equal(tekton.data_errors, {{
+		"message": "trusted_task_rules_enabled: Invalid type. Expected: boolean, given: integer",
+		"severity": "failure",
+	}}) with data.rule_data.trusted_task_rules_enabled as 0
 }
 
 test_is_trusted_task if {
@@ -232,6 +290,7 @@ test_is_trusted_task_with_rules if {
 
 	# regal ignore:line-length
 	tekton.is_trusted_task(allowed_task, allowed_task_manifests) with data.rule_data.trusted_task_rules as trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	# Task that matches deny rule should not be trusted (deny takes precedence)
 	denied_task := {"spec": {"taskRef": {"resolver": "bundles", "params": [
@@ -247,6 +306,7 @@ test_is_trusted_task_with_rules if {
 
 	# regal ignore:line-length
 	not tekton.is_trusted_task(denied_task, denied_task_manifests) with data.rule_data.trusted_task_rules as trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	# Task that matches allow pattern (registry.local) should be trusted
 	# Note: The key format is oci://registry.local/trusty:1.0 (with tag), so pattern oci://registry.local/* matches
@@ -260,6 +320,7 @@ test_is_trusted_task_with_rules if {
 
 	# regal ignore:line-length
 	tekton.is_trusted_task(registry_local_task, registry_local_manifests) with data.rule_data.trusted_task_rules as trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	# Task that doesn't match any allow rule should not be trusted
 	# Note: This task uses a different path (untrusted) that doesn't match the pattern
@@ -273,6 +334,7 @@ test_is_trusted_task_with_rules if {
 
 	# regal ignore:line-length
 	not tekton.is_trusted_task(not_allowed_task, not_allowed_manifests) with data.rule_data.trusted_task_rules as trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	# Tasks satisfying at least one deny rule version constraints should be denied
 	deny_constrained_task_denied_version := {"spec": {"taskRef": {"resolver": "bundles", "params": [
@@ -287,6 +349,7 @@ test_is_trusted_task_with_rules if {
 
 	# regal ignore:line-length
 	not tekton.is_trusted_task(deny_constrained_task_denied_version, deny_constrained_denied_manifests) with data.rule_data.trusted_task_rules as trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	# Task not satisfying any deny rule version constraints should not be denied
 	deny_constrained_task_valid_version := {"spec": {"taskRef": {"resolver": "bundles", "params": [
@@ -299,6 +362,7 @@ test_is_trusted_task_with_rules if {
 	# regal ignore:line-length
 	deny_constrained_valid_manifests := _mock_bundle_manifests("quay.io/konflux-ci/tekton-catalog/deny-task-constrained:1.2.3@sha256:d19e5700000000000000000000000000000000000000000000000000d19e5700", "1.2.3")
 	tekton.is_trusted_task(deny_constrained_task_valid_version, deny_constrained_valid_manifests) with data.rule_data.trusted_task_rules as trusted_task_rules # regal ignore:line-length
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	# Tasks satisfying all the allow-rule version constraints should be allowed
 	allow_constrained_task_valid_version := {"spec": {"taskRef": {"resolver": "bundles", "params": [
@@ -311,6 +375,7 @@ test_is_trusted_task_with_rules if {
 	# regal ignore:line-length
 	allow_constrained_valid_manifests := _mock_bundle_manifests("quay.io/konflux-ci/another-catalog/allow-task-constrained:1.5@sha256:d19e5700000000000000000000000000000000000000000000000000d19e5700", "1.5")
 	tekton.is_trusted_task(allow_constrained_task_valid_version, allow_constrained_valid_manifests) with data.rule_data.trusted_task_rules as trusted_task_rules # regal ignore:line-length
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	# Tasks *NOT* satisfying all the allow-rule version constraints should be denied
 	allow_constrained_task_denied_version := {"spec": {"taskRef": {"resolver": "bundles", "params": [
@@ -323,6 +388,7 @@ test_is_trusted_task_with_rules if {
 	# regal ignore:line-length
 	allow_constrained_denied_manifests := _mock_bundle_manifests("quay.io/konflux-ci/another-catalog/allow-task-constrained:1.2.3@sha256:d19e5700000000000000000000000000000000000000000000000000d19e5700", "1.2.3")
 	not tekton.is_trusted_task(allow_constrained_task_denied_version, allow_constrained_denied_manifests) with data.rule_data.trusted_task_rules as trusted_task_rules # regal ignore:line-length
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	# Task with mismatching versions between ref and manifest annotations.
 	# Only the manifest annotation is taken into consideration
@@ -337,6 +403,7 @@ test_is_trusted_task_with_rules if {
 	# regal ignore:line-length
 	mismatch_manifests_1 := _mock_bundle_manifests("quay.io/konflux-ci/another-catalog/allow-task-constrained:1.5@sha256:d19e5700000000000000000000000000000000000000000000000000d19e5700", "1.2.3")
 	not tekton.is_trusted_task(allow_constrained_task_denied_version_mismatching_1, mismatch_manifests_1) with data.rule_data.trusted_task_rules as trusted_task_rules # regal ignore:line-length
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	# Task with mismatching versions between ref and manifest annotations.
 	# Only the manifest annotation is taken into consideration
@@ -351,6 +418,7 @@ test_is_trusted_task_with_rules if {
 	# regal ignore:line-length
 	mismatch_manifests_2 := _mock_bundle_manifests("quay.io/konflux-ci/another-catalog/allow-task-constrained:1.2.3@sha256:d19e5700000000000000000000000000000000000000000000000000d19e5700", "1.5")
 	tekton.is_trusted_task(allow_constrained_task_denied_version_mismatching_2, mismatch_manifests_2) with data.rule_data.trusted_task_rules as trusted_task_rules # regal ignore:line-length
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	# Digest-only bundle reference (no tag). The key becomes "oci://repo" without tag or digest.
 	# Pattern must match the repo without tag/digest components.
@@ -367,6 +435,7 @@ test_is_trusted_task_with_rules if {
 		{"name": "kind", "value": "task"},
 	]}}}
 	tekton.is_trusted_task(digest_only_allowed, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as digest_only_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	# Digest-only task matching deny: key is "oci://registry.local/crook" (no tag)
 	digest_only_denied := {"spec": {"taskRef": {"resolver": "bundles", "params": [
@@ -376,6 +445,7 @@ test_is_trusted_task_with_rules if {
 		{"name": "kind", "value": "task"},
 	]}}}
 	not tekton.is_trusted_task(digest_only_denied, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as digest_only_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 }
 
 test_trusted_task_records if {
@@ -429,6 +499,7 @@ test_data_trusted_task_rules_extraction if {
 	]}}}
 	tekton.is_trusted_task(allowed_task, _empty_bundle_manifests) with data.trusted_task_rules as data_rules_allow
 		with data.rule_data.trusted_task_rules as null
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	# Test when data.trusted_task_rules is provided with deny rules
 	data_rules_deny := {"deny": {"blocked": [{"pattern": "oci://registry.local/crook/*"}]}}
@@ -442,11 +513,13 @@ test_data_trusted_task_rules_extraction if {
 	]}}}
 	not tekton.is_trusted_task(denied_task, _empty_bundle_manifests) with data.trusted_task_rules as data_rules_deny
 		with data.rule_data.trusted_task_rules as null
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	# Test when data.trusted_task_rules is not provided (covers default cases 145, 152)
 	# Should fall back to empty arrays, so task won't be trusted via rules
 	not tekton.is_trusted_task(allowed_task, _empty_bundle_manifests) with data.trusted_task_rules as null
 		with data.rule_data.trusted_task_rules as null
+		with data.rule_data.trusted_task_rules_enabled as true
 }
 
 test_rule_data_trusted_task_rules_extraction if {
@@ -465,6 +538,7 @@ test_rule_data_trusted_task_rules_extraction if {
 		{"name": "kind", "value": "task"},
 	]}}}
 	tekton.is_trusted_task(allowed_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as rule_data_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	# Task matching deny from rule_data should not be trusted
 	denied_task := {"spec": {"taskRef": {"resolver": "bundles", "params": [
@@ -476,10 +550,12 @@ test_rule_data_trusted_task_rules_extraction if {
 
 	# regal ignore:line-length
 	not tekton.is_trusted_task(denied_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as rule_data_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	# Test when lib_rule_data returns [] (not an object) - covers default cases
 	# When rule_data returns [], it's not an object, so defaults are used
 	not tekton.is_trusted_task(allowed_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as []
+		with data.rule_data.trusted_task_rules_enabled as true
 }
 
 test_data_errors if {
@@ -569,6 +645,7 @@ test_denying_pattern if {
 	# Should return a list with the pattern that denied it
 	# regal ignore:line-length
 	patterns := tekton.denying_pattern(denied_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 	assertions.assert_equal(["oci://quay.io/konflux-ci/tekton-catalog/task-buildah*"], patterns)
 
 	# Task that doesn't match any deny rule should return empty list
@@ -581,6 +658,7 @@ test_denying_pattern if {
 
 	# regal ignore:line-length
 	patterns_empty := tekton.denying_pattern(non_matching_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 	assertions.assert_equal([], patterns_empty)
 }
 
@@ -604,6 +682,7 @@ test_denying_pattern_multiple_rules if {
 
 	# regal ignore:line-length
 	patterns_multi := tekton.denying_pattern(buildah_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as multiple_deny_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	# Should contain both patterns (order may vary)
 	assertions.assert_equal(2, count(patterns_multi))
@@ -635,6 +714,7 @@ test_denial_reason if {
 
 	# regal ignore:line-length
 	reason_deny := tekton.denial_reason(denied_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 	assertions.assert_equal("deny_rule", reason_deny.type)
 	assertions.assert_equal(["oci://quay.io/konflux-ci/tekton-catalog/task-buildah*"], reason_deny.pattern)
 	assertions.assert_equal(["This version is deprecated"], reason_deny.messages)
@@ -649,6 +729,7 @@ test_denial_reason if {
 
 	# regal ignore:line-length
 	reason_not_allowed := tekton.denial_reason(not_allowed_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 	assertions.assert_equal("not_allowed", reason_not_allowed.type)
 	assertions.assert_equal([], reason_not_allowed.pattern)
 	assertions.assert_equal([], reason_not_allowed.messages)
@@ -663,11 +744,13 @@ test_denial_reason if {
 
 	# regal ignore:line-length
 	not tekton.denial_reason(allowed_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	# Task in legacy trusted_tasks but doesn't match allow rules should return "not_allowed"
 	# (denial_reason only works with trusted_task_rules, not legacy)
 	# regal ignore:line-length
 	reason_legacy := tekton.denial_reason(trusted_bundle_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 		with data.trusted_tasks as trusted_tasks
 	assertions.assert_equal("not_allowed", reason_legacy.type)
 	assertions.assert_equal([], reason_legacy.pattern)
@@ -692,6 +775,7 @@ test_denial_reason_no_allow_rules if {
 
 	# regal ignore:line-length
 	not tekton.denial_reason(untrusted_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as rules_no_allow
+		with data.rule_data.trusted_task_rules_enabled as true
 }
 
 test_trusted_task_rules_data_errors if {
@@ -711,6 +795,7 @@ test_trusted_task_rules_data_errors if {
 		}]},
 	}
 	assertions.assert_empty(tekton.data_errors) with data.rule_data.trusted_task_rules as valid_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	# Missing required fields - array entry without pattern
 	invalid_rules := {"allow": {"bad-group": [{}]}}
@@ -720,6 +805,7 @@ test_trusted_task_rules_data_errors if {
 		"severity": "failure",
 	}}
 	assertions.assert_equal(tekton.data_errors, expected) with data.rule_data.trusted_task_rules as invalid_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	# Invalid effective_on date format (both schema and parse validation fire)
 	invalid_date_rules := {"allow": {"bad-date": [{
@@ -739,6 +825,7 @@ test_trusted_task_rules_data_errors if {
 		},
 	}
 	assertions.assert_equal(tekton.data_errors, expected_date) with data.rule_data.trusted_task_rules as invalid_date_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	# Invalid structure - not an object
 	assertions.assert_empty(tekton.data_errors) with data.rule_data.trusted_task_rules as [] # Empty list is skipped
@@ -754,6 +841,7 @@ test_trusted_task_rules_data_errors if {
 		"severity": "failure",
 	}}
 	assertions.assert_equal(tekton.data_errors, expected_structure) with data.rule_data.trusted_task_rules as invalid_structure
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	# effective_on that fails time.parse_rfc3339_ns (via data.trusted_task_rules to bypass schema validation)
 	unparseable_date_rules := {"deny": {"blocked": [{
@@ -782,6 +870,7 @@ test_denying_pattern_invalid_task if {
 	# Should return empty list (else branch) since task_ref fails
 	# regal ignore:line-length
 	patterns := tekton.denying_pattern(invalid_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as rules
+		with data.rule_data.trusted_task_rules_enabled as true
 	assertions.assert_equal([], patterns)
 }
 
@@ -804,10 +893,12 @@ test_denying_rules_info_empty if {
 
 	# denial_reason returns nothing for allowed tasks (internally calls _denying_rules_info which returns empty)
 	not tekton.denial_reason(allowed_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as rules_no_deny
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	# denying_pattern should also return empty list (covers line 337)
 	# regal ignore:line-length
 	patterns := tekton.denying_pattern(allowed_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as rules_no_deny
+		with data.rule_data.trusted_task_rules_enabled as true
 	assertions.assert_equal([], patterns)
 }
 
@@ -839,6 +930,7 @@ test_pattern_matches_git_resolved_tasks if {
 
 	# regal ignore:line-length
 	tekton.is_trusted_task(github_git_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as git_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	# Task resolved via git from gitlab.cee.redhat.com rpmbuild
 	gitlab_git_task := {
@@ -852,6 +944,7 @@ test_pattern_matches_git_resolved_tasks if {
 
 	# regal ignore:line-length
 	tekton.is_trusted_task(gitlab_git_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as git_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	# Task from a different repo should NOT be trusted
 	untrusted_git_task_other := {
@@ -865,6 +958,7 @@ test_pattern_matches_git_resolved_tasks if {
 
 	# regal ignore:line-length
 	not tekton.is_trusted_task(untrusted_git_task_other, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as git_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 }
 
 test_pattern_matches_git_deny_rules if {
@@ -886,6 +980,7 @@ test_pattern_matches_git_deny_rules if {
 
 	# regal ignore:line-length
 	tekton.is_trusted_task(allowed_git, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as git_deny_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	# Denied git task (matches deny pattern)
 	denied_git := {
@@ -899,6 +994,7 @@ test_pattern_matches_git_deny_rules if {
 
 	# regal ignore:line-length
 	not tekton.is_trusted_task(denied_git, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as git_deny_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 }
 
 test_pattern_matches_dots_are_literal if {
@@ -918,6 +1014,7 @@ test_pattern_matches_dots_are_literal if {
 
 	# regal ignore:line-length
 	tekton.is_trusted_task(quay_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as dot_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	# Task from quayXio (dot replaced with X) — must NOT be trusted
 	spoofed_task := {"spec": {"taskRef": {"resolver": "bundles", "params": [
@@ -929,6 +1026,7 @@ test_pattern_matches_dots_are_literal if {
 
 	# regal ignore:line-length
 	not tekton.is_trusted_task(spoofed_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as dot_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 }
 
 test_pattern_matches_anchored if {
@@ -948,6 +1046,7 @@ test_pattern_matches_anchored if {
 
 	# regal ignore:line-length
 	not tekton.is_trusted_task(prefix_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as anchored_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 }
 
 test_pattern_matches_mixed_oci_and_git if {
@@ -970,6 +1069,7 @@ test_pattern_matches_mixed_oci_and_git if {
 
 	# regal ignore:line-length
 	tekton.is_trusted_task(oci_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as mixed_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	# Git task — trusted
 	git_task := {
@@ -983,6 +1083,7 @@ test_pattern_matches_mixed_oci_and_git if {
 
 	# regal ignore:line-length
 	tekton.is_trusted_task(git_task, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as mixed_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	# Neither OCI nor git from a trusted source — not trusted
 	untrusted_oci := {"spec": {"taskRef": {"resolver": "bundles", "params": [
@@ -994,6 +1095,7 @@ test_pattern_matches_mixed_oci_and_git if {
 
 	# regal ignore:line-length
 	not tekton.is_trusted_task(untrusted_oci, _empty_bundle_manifests) with data.rule_data.trusted_task_rules as mixed_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 }
 
 trusted_bundle_task := {"spec": {"taskRef": {"resolver": "bundles", "params": [

--- a/policy/release/test_attestation/test_attestation_test.rego
+++ b/policy/release/test_attestation/test_attestation_test.rego
@@ -281,6 +281,7 @@ test_all_passed_no_violations if {
 		with ec.oci.blob as _mock_blob_passed
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	assertions.assert_empty(test_attestation.warn) with input.image.ref as _image_ref
 		with ec.oci.image_referrers as _mock_referrers
@@ -288,6 +289,7 @@ test_all_passed_no_violations if {
 		with ec.oci.blob as _mock_blob_passed
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 }
 
 # --- Test Case 2: FAILED with failedTests array ---
@@ -303,6 +305,7 @@ test_failed_with_details if {
 		with ec.oci.blob as _mock_blob_failed_with_details
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 }
 
 # --- Test Case 3: FAILED without failedTests array ---
@@ -318,6 +321,7 @@ test_failed_no_details if {
 		with ec.oci.blob as _mock_blob_failed_no_details
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 }
 
 # --- Test Case 4: WARNED with warnedTests array ---
@@ -329,6 +333,7 @@ test_warned_with_details if {
 		with ec.oci.blob as _mock_blob_warned
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	assertions.assert_equal_results(test_attestation.warn, {{
 		"code": "test_attestation.no_test_warnings",
@@ -340,6 +345,7 @@ test_warned_with_details if {
 		with ec.oci.blob as _mock_blob_warned
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 }
 
 # --- Test Case 6: Unknown result value ---
@@ -355,6 +361,7 @@ test_unknown_result_value if {
 		with ec.oci.blob as _mock_blob_unknown_result
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 }
 
 # --- Test Case 7: Missing result field ---
@@ -370,6 +377,7 @@ test_missing_result_field if {
 		with ec.oci.blob as _mock_blob_missing_result
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 }
 
 # --- Test Case 5: Mixed PASSED and FAILED ---
@@ -385,6 +393,7 @@ test_mixed_passed_and_failed if {
 		with ec.oci.blob as _mock_blob_mixed
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	assertions.assert_empty(test_attestation.warn) with input.image.ref as _image_ref
 		with ec.oci.image_referrers as _mock_referrers_two
@@ -392,6 +401,7 @@ test_mixed_passed_and_failed if {
 		with ec.oci.blob as _mock_blob_mixed
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 }
 
 # --- Test Case 8: No test attestations at all ---
@@ -413,6 +423,7 @@ test_test_name_from_configuration if {
 		with ec.oci.blob as _mock_blob_custom_config
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	some r in results
 	contains(r.msg, "\"my-custom-test\"")
@@ -427,6 +438,7 @@ test_test_name_fallback if {
 		with ec.oci.blob as _mock_blob_no_config
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	some r in results
 	contains(r.msg, "\"unknown test\"")
@@ -445,6 +457,7 @@ test_warned_and_failed_coexist if {
 		with ec.oci.blob as _mock_blob_warned_and_failed
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	assertions.assert_equal_results(test_attestation.warn, {{
 		"code": "test_attestation.no_test_warnings",
@@ -456,6 +469,7 @@ test_warned_and_failed_coexist if {
 		with ec.oci.blob as _mock_blob_warned_and_failed
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 }
 
 # --- Test Case 12: Multiple FAILEDs across attestations ---
@@ -467,6 +481,7 @@ test_multiple_failures_deny if {
 		with ec.oci.blob as _mock_blob_multi_failed
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(results) == 2
 
@@ -488,6 +503,7 @@ test_multiple_failures_no_warn if {
 		with ec.oci.blob as _mock_blob_multi_failed
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 }
 
 # --- Test Case 13: Non-string result value ---
@@ -499,6 +515,7 @@ test_non_string_result if {
 		with ec.oci.blob as _mock_blob_non_string_result
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(results) == 1
 	some r in results
@@ -521,6 +538,7 @@ test_missing_predicate if {
 		with ec.oci.blob as _mock_blob_missing_predicate
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(results) == 1
 	some r in results
@@ -547,6 +565,7 @@ test_non_array_failed_tests if {
 		with ec.oci.blob as _mock_blob_non_array_failed_tests
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 }
 
 _mock_blob_non_array_warned_tests(_) := _make_statement({
@@ -566,6 +585,7 @@ test_non_array_warned_tests if {
 		with ec.oci.blob as _mock_blob_non_array_warned_tests
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 }
 
 # --- Test Case 16: Empty failedTests array boundary ---
@@ -587,6 +607,7 @@ test_empty_failed_tests_array if {
 		with ec.oci.blob as _mock_blob_empty_failed_tests
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 }
 
 _mock_blob_empty_warned_tests(_) := _make_statement({
@@ -606,6 +627,7 @@ test_empty_warned_tests_array if {
 		with ec.oci.blob as _mock_blob_empty_warned_tests
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 }
 
 # --- Test Case 17: Falsy result values ---
@@ -622,6 +644,7 @@ test_false_result_value if {
 		with ec.oci.blob as _mock_blob_false_result
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(results) == 1
 	some r in results
@@ -640,6 +663,7 @@ test_null_result_value if {
 		with ec.oci.blob as _mock_blob_null_result
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(results) == 1
 	some r in results
@@ -658,6 +682,7 @@ test_empty_string_result_value if {
 		with ec.oci.blob as _mock_blob_empty_string_result
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(results) == 1
 	some r in results
@@ -683,4 +708,5 @@ test_non_string_test_list_elements if {
 		with ec.oci.blob as _mock_blob_non_string_tests
 		with ec.oci.image_manifests as _mock_manifests
 		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 }

--- a/policy/release/trusted_task/trusted_task_test.rego
+++ b/policy/release/trusted_task/trusted_task_test.rego
@@ -285,6 +285,7 @@ test_trusted_artifact_denied_by_rules if {
 
 	assertions.assert_equal_results(trusted_task.deny, expected) with data.trusted_tasks as trusted_tasks_data
 		with data.rule_data.trusted_task_rules as task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 		with input.attestations as [attestation_ta]
 		with ec.oci.image_manifests as _mock_image_manifests
 		with ec.oci.image_manifest as _mock_image_manifest
@@ -317,6 +318,7 @@ test_future_deny_rule_warning if {
 	}}
 
 	assertions.assert_equal_results(trusted_task.warn, expected) with data.rule_data.trusted_task_rules as task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 		with input.attestations as [att]
 		with ec.oci.image_manifests as _mock_image_manifests
 		with ec.oci.image_manifest as _mock_image_manifest
@@ -340,6 +342,7 @@ test_future_deny_rule_no_warning_when_already_effective if {
 
 	# No future_deny_rule warning expected (the deny itself will fire, but not the warning)
 	results := trusted_task.warn with data.rule_data.trusted_task_rules as task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 		with input.attestations as [att]
 		with ec.oci.image_manifests as _mock_image_manifests
 		with ec.oci.image_manifest as _mock_image_manifest
@@ -883,6 +886,7 @@ test_on_trusted_tasks_no_rules_trusted if {
 	assertions.assert_empty(trusted_task.deny) with input.attestations as [att]
 		with data.trusted_tasks as rules_trusted_tasks_data
 		with data.rule_data.trusted_task_rules as trusted_task_rules_data
+		with data.rule_data.trusted_task_rules_enabled as true
 }
 
 # A2 — On trusted_tasks, but expired → untrusted
@@ -916,6 +920,7 @@ test_on_trusted_tasks_expired_untrusted if {
 	assertions.assert_equal_results(trusted_task.deny, expected) with input.attestations as [att]
 		with data.trusted_tasks as rules_trusted_tasks_data
 		with data.rule_data.trusted_task_rules as trusted_task_rules_data
+		with data.rule_data.trusted_task_rules_enabled as true
 		with data.config.policy.when_ns as time.parse_rfc3339_ns("2025-01-10T00:00:00Z")
 }
 
@@ -944,6 +949,7 @@ test_not_on_trusted_tasks_no_rules_untrusted if {
 	assertions.assert_equal_results(trusted_task.deny, expected) with input.attestations as [att]
 		with data.trusted_tasks as rules_trusted_tasks_data
 		with data.rule_data.trusted_task_rules as trusted_task_rules_data
+		with data.rule_data.trusted_task_rules_enabled as true
 }
 
 #####################################################
@@ -970,6 +976,7 @@ test_allow_by_location if {
 	assertions.assert_empty(trusted_task.deny) with input.attestations as [att]
 		with data.trusted_tasks as {}
 		with data.rule_data.trusted_task_rules as trusted_task_rules_data
+		with data.rule_data.trusted_task_rules_enabled as true
 		with ec.oci.image_manifests as _mock_image_manifests
 		with ec.oci.image_manifest as _mock_image_manifest
 }
@@ -999,6 +1006,7 @@ test_outside_pattern_not_trusted if {
 	assertions.assert_equal_results(trusted_task.deny, expected) with input.attestations as [att]
 		with data.trusted_tasks as {}
 		with data.rule_data.trusted_task_rules as trusted_task_rules_data
+		with data.rule_data.trusted_task_rules_enabled as true
 		with ec.oci.image_manifests as _mock_image_manifests
 		with ec.oci.image_manifest as _mock_image_manifest
 }
@@ -1037,6 +1045,7 @@ test_deny_takes_precedence_over_allow if {
 	assertions.assert_equal_results(trusted_task.deny, expected) with input.attestations as [att]
 		with data.trusted_tasks as {}
 		with data.rule_data.trusted_task_rules as task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 		with data.config.policy.when_ns as time.parse_rfc3339_ns("2025-01-10T00:00:00Z")
 		with ec.oci.image_manifests as _mock_image_manifests
 		with ec.oci.image_manifest as _mock_image_manifest
@@ -1074,6 +1083,7 @@ test_allow_rule_not_yet_effective if {
 	assertions.assert_equal_results(trusted_task.deny, expected) with input.attestations as [att]
 		with data.trusted_tasks as {}
 		with data.rule_data.trusted_task_rules as trusted_task_rules_data
+		with data.rule_data.trusted_task_rules_enabled as true
 		with data.config.policy.when_ns as time.parse_rfc3339_ns("2025-01-15T00:00:00Z")
 		with ec.oci.image_manifests as _mock_image_manifests
 		with ec.oci.image_manifest as _mock_image_manifest
@@ -1101,6 +1111,7 @@ test_allow_rule_effective_trusted if {
 	assertions.assert_empty(trusted_task.deny) with input.attestations as [att]
 		with data.trusted_tasks as {}
 		with data.rule_data.trusted_task_rules as trusted_task_rules_data
+		with data.rule_data.trusted_task_rules_enabled as true
 		with data.config.policy.when_ns as time.parse_rfc3339_ns("2025-02-10T00:00:00Z")
 		with ec.oci.image_manifests as _mock_image_manifests
 		with ec.oci.image_manifest as _mock_image_manifest
@@ -1128,6 +1139,7 @@ test_deny_rule_not_yet_effective if {
 	assertions.assert_empty(trusted_task.deny) with input.attestations as [att]
 		with data.trusted_tasks as {}
 		with data.rule_data.trusted_task_rules as trusted_task_rules_data
+		with data.rule_data.trusted_task_rules_enabled as true
 		with data.config.policy.when_ns as time.parse_rfc3339_ns("2025-02-15T00:00:00Z")
 		with ec.oci.image_manifests as _mock_image_manifests
 		with ec.oci.image_manifest as _mock_image_manifest
@@ -1161,6 +1173,7 @@ test_deny_rule_becomes_effective if {
 	assertions.assert_equal_results(trusted_task.deny, expected) with input.attestations as [att]
 		with data.trusted_tasks as {}
 		with data.rule_data.trusted_task_rules as trusted_task_rules_data
+		with data.rule_data.trusted_task_rules_enabled as true
 		with data.config.policy.when_ns as time.parse_rfc3339_ns("2025-03-15T00:00:00Z")
 		with ec.oci.image_manifests as _mock_image_manifests
 		with ec.oci.image_manifest as _mock_image_manifest
@@ -1192,6 +1205,7 @@ test_multiple_allow_rules if {
 	assertions.assert_empty(trusted_task.deny) with input.attestations as [att]
 		with data.trusted_tasks as {}
 		with data.rule_data.trusted_task_rules as trusted_task_rules_data
+		with data.rule_data.trusted_task_rules_enabled as true
 		with ec.oci.image_manifests as _mock_image_manifests
 		with ec.oci.image_manifest as _mock_image_manifest
 }
@@ -1229,6 +1243,7 @@ test_deny_with_message if {
 	assertions.assert_equal_results(trusted_task.deny, expected) with input.attestations as [att]
 		with data.trusted_tasks as {}
 		with data.rule_data.trusted_task_rules as task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 		with data.config.policy.when_ns as time.parse_rfc3339_ns("2025-11-01T00:00:00Z")
 		with ec.oci.image_manifests as _mock_image_manifests
 		with ec.oci.image_manifest as _mock_image_manifest
@@ -1264,6 +1279,7 @@ test_rules_allow_trusted_tasks_expiry_ignored if {
 	assertions.assert_empty(trusted_task.deny) with input.attestations as [att]
 		with data.trusted_tasks as rules_trusted_tasks_data
 		with data.rule_data.trusted_task_rules as trusted_task_rules_data
+		with data.rule_data.trusted_task_rules_enabled as true
 		with data.config.policy.when_ns as time.parse_rfc3339_ns("2025-02-01T00:00:00Z")
 		with ec.oci.image_manifests as _mock_image_manifests
 		with ec.oci.image_manifest as _mock_image_manifest
@@ -1296,6 +1312,7 @@ test_unknown_fields_ignored if {
 	assertions.assert_empty(trusted_task.deny) with input.attestations as [att]
 		with data.trusted_tasks as {}
 		with data.rule_data.trusted_task_rules as trusted_task_rules_data
+		with data.rule_data.trusted_task_rules_enabled as true
 		with ec.oci.image_manifests as _mock_image_manifests
 		with ec.oci.image_manifest as _mock_image_manifest
 }
@@ -1336,6 +1353,7 @@ test_mixed_trusted_and_untrusted_tasks if {
 	assertions.assert_equal_results(trusted_task.deny, expected) with input.attestations as [att]
 		with data.trusted_tasks as {}
 		with data.rule_data.trusted_task_rules as trusted_task_rules_data
+		with data.rule_data.trusted_task_rules_enabled as true
 		with ec.oci.image_manifests as _mock_image_manifests
 		with ec.oci.image_manifest as _mock_image_manifest
 }


### PR DESCRIPTION
## Summary
- Adds a `trusted_task_rules_enabled` key to `rule_data` (default: `false`) that controls whether the `trusted_task_rules` system is active
- When set to `false`, the routing layer treats rules data as missing and falls back to legacy `trusted_tasks`
- Includes schema validation (must be boolean) and comprehensive tests

## Test plan
- [x] `make test` — all 964 tests pass
- [x] `make fmt` — clean
- [x] Targeted tests: `ec opa test ./policy -r trusted -v` — 66/66 pass
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://redhat.atlassian.net/browse/EC-1933