### PR TITLE
fix(EC-1971): set GEMINI_CLI_TRUST_WORKSPACE in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,6 +101,8 @@ jobs:
       - name: Run Gemini
         id: run_gemini
         uses: google-github-actions/run-gemini-cli@v0
+        env:
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           settings: |-


### PR DESCRIPTION
## Summary
- Fixes the broken "Run Gemini" step in the release workflow by setting `GEMINI_CLI_TRUST_WORKSPACE=true`
- The Gemini CLI now rejects untrusted directories in headless/CI environments; this env var is the recommended workaround

## Jira
[EC-1971](https://redhat.atlassian.net/browse/EC-1971)

## Test plan
- [ ] Trigger the release workflow via `workflow_dispatch` and verify the Gemini step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)