### PR TITLE
Update quay.io references from enterprise-contract to conforma

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ contributing to the definition of policy rules.
 
 * [Policy rule documentation][policydocs]
 * ["Verify Enterprise Contract" task definition][taskdef]
-* [github.com/enterprise-contract][contract]
+* [github.com/conforma][contract]
 * [github.com/konflux-ci][konflux-ci]
 
 [asdf]: https://asdf-vm.com/
@@ -167,7 +167,7 @@ contributing to the definition of policy rules.
 [docs]: https://conforma.dev/
 [policydocs]: https://conforma.dev/docs/policy/release_policy.html
 [taskdef]: https://github.com/conforma/cli/blob/main/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
-[contract]: https://github.com/enterprise-contract
+[contract]: https://github.com/conforma
 [ec]: https://github.com/conforma/cli
 [konflux-ci]: https://github.com/konflux-ci
 [builddefs]: https://github.com/konflux-ci/build-definitions

--- a/antora/docs/modules/ROOT/pages/authoring.adoc
+++ b/antora/docs/modules/ROOT/pages/authoring.adoc
@@ -17,7 +17,7 @@ rule.
   the `foo` annotation nested under this object.
 * `custom.short_name`: (required) unique name of the policy rule. This is used as the value of the
   `code` attribute when reporting failures and warnings. It is also the value used for skipping
-  the policy rule via the https://github.com/enterprise-contract/enterprise-contract-controller[EnterpriseContractPolicy]. It must not contain spaces. Words must be
+  the policy rule via the https://github.com/conforma/crds[EnterpriseContractPolicy]. It must not contain spaces. Words must be
   joined by `_`, e.g. `snake_case`.
 * `custom.failure_msg`: (required) message indicating the exact cause a policy rule did not pass.
   It should be as informative as possible to guide users towards remediation. The message can be

--- a/antora/docs/modules/ROOT/pages/index.adoc
+++ b/antora/docs/modules/ROOT/pages/index.adoc
@@ -20,5 +20,5 @@ xref:pipeline_policy.adoc[Pipeline Policy].
 
 * https://github.com/conforma/policy[github.com/conforma/policy]
 * https://github.com/conforma/cli[github.com/conforma/cli]
-* https://github.com/enterprise-contract[github.com/enterprise-contract]
+* https://github.com/conforma[github.com/conforma]
 * https://github.com/konflux-ci[github.com/konflux-ci]

--- a/antora/docs/modules/ROOT/pages/policy_bundles.adoc
+++ b/antora/docs/modules/ROOT/pages/policy_bundles.adoc
@@ -9,14 +9,14 @@ compatible with the `conftest pull` command.
 
 The latest versions of the bundles can be found in the following repos:
 
-https://quay.io/repository/enterprise-contract/ec-release-policy?tab=tags[`quay.io/enterprise-contract/ec-release-policy`]::
+https://quay.io/repository/conforma/release-policy?tab=tags[`quay.io/conforma/release-policy`]::
 
 Used for validating attestations created by Tekton Chains. Contains the
 contents of https://github.com/conforma/policy/tree/main/policy/release[`policy/release`]
 and https://github.com/conforma/policy/tree/main/policy/lib[`policy/lib`]
 in this repo.
 
-https://quay.io/repository/enterprise-contract/ec-pipeline-policy?tab=tags[`quay.io/enterprise-contract/ec-pipeline-policy`]::
+https://quay.io/repository/conforma/pipeline-policy?tab=tags[`quay.io/conforma/pipeline-policy`]::
 
 Used for validating Tekton Pipeline definitions. Contains the contents of
 https://github.com/conforma/policy/tree/main/policy/pipeline[`policy/pipeline`]
@@ -24,7 +24,7 @@ and https://github.com/conforma/policy/tree/main/policy/lib[`policy/lib`].
 
 == Artifact Hub entries
 
-The bundles mentioned above are also listed in https://artifacthub.io/packages/search?org=enterprise-contract[Artifact Hub].
+The bundles mentioned above are also listed in https://artifacthub.io/packages/search?org=conforma[Artifact Hub].
 
 == Example usage
 
@@ -34,6 +34,6 @@ attestations for the image being validated. For example:
 
 ```
 cosign download attestation quay.io/konflux-ci/ec-golden-image:latest | jq --slurp '{"attestations":[.[].payload|@base64d|fromjson]}' > input.json
-conftest pull -p . quay.io/enterprise-contract/ec-release-policy quay.io/enterprise-contract/ec-policy-data
+conftest pull -p . quay.io/conforma/release-policy quay.io/conforma/policy-data
 conftest test input.json -d data -p policy --all-namespaces -o json | yq -P
 ```

--- a/policy/pipeline/artifacthub-pkg.yml
+++ b/policy/pipeline/artifacthub-pkg.yml
@@ -25,7 +25,7 @@ readme: |
   OPA policies enforcing standards on a tekton pipeline definition. These policies
   are a work in progress and not yet production ready.
 install: |
-  `conftest pull oci::quay.io/enterprise-contracttract/ec-pipeline-policy:latest`
+  `conftest pull oci::quay.io/conforma/pipeline-policy:latest`
 homeURL: https://conforma.dev/docs/policy/
 keywords:
   - opa

--- a/policy/release/artifacthub-pkg.yml
+++ b/policy/release/artifacthub-pkg.yml
@@ -25,7 +25,7 @@ readme: |
   OPA policies enforcing releasable build standards. These policies
   are a work in progress and not yet production ready.
 install: |
-  `conftest pull oci::quay.io/enterprise-contracttract/ec-release-policy:latest`
+  `conftest pull oci::quay.io/conforma/release-policy:latest`
 
   Configure your org-specific `--data` as necessary from [data/](https://github.com/conforma/policy/tree/main/data)
 


### PR DESCRIPTION
Replace references to the old quay.io/enterprise-contract org with the new quay.io/conforma org in policy bundle documentation:

- ec-release-policy -> conforma/release-policy
- ec-pipeline-policy -> conforma/pipeline-policy
- ec-policy-data -> conforma/policy-data
- ArtifactHub org: enterprise-contract -> conforma

Ref: https://issues.redhat.com/browse/EC-1914