### PR TITLE
Merge pipeline-required-tasks from ruleData config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,10 @@ attestation formats. Policies consume the normalized form — don't branch on SL
 **Rule data** lives in `example/data/` (required tasks, trusted task bundles, known RPM repos).
 These files have `effective_on` dates — rules with future dates are warnings, not failures.
 
+**Design docs** in `design/` capture non-obvious design rationale, cross-repo knowledge, and
+architectural constraints that aren't derivable from the code. Check there before reverse-engineering
+a subsystem.
+
 ## Rego Evaluation Model (for AI reviewers)
 
 Rego is a declarative policy language (Datalog-inspired), not imperative code:

--- a/design/rule-data-merge-pattern.md
+++ b/design/rule-data-merge-pattern.md
@@ -1,0 +1,56 @@
+# Rule Data Merge Pattern
+
+Merging data-source values with ruleData configuration values using `object.union`.
+Used by `pipeline_required_tasks` and `trusted_tasks` in `policy/lib/tekton/`.
+
+## Why does `rule_data.get()` need an explicit `{}` default for merged keys?
+
+`rule_data.get(key)` falls back to `[]` (empty array) when a key isn't found in any
+data source. But `object.union` requires both arguments to be objects — if either is
+an array, OPA returns `undefined` at runtime (see next section). So any key that will
+be passed to `object.union` must have an explicit `{}` default registered in the
+`defaults` map in `policy/lib/rule_data/rule_data.rego`. Without it, the merge silently
+produces `undefined` and all downstream rules stop evaluating with no error output.
+
+When adding a new `object.union` merge, register the key in rule_data.rego's `defaults`:
+
+```rego
+defaults := {
+    "pipeline-required-tasks": {},  # must be {} not [] for object.union
+    "trusted_tasks": {},            # same reason
+    ...
+}
+```
+
+## Why does `object.union` fail silently instead of erroring?
+
+OPA has two behaviors depending on when it can determine types:
+
+- **Static types known** (literals in code): `object.union({"a": 1}, [])` produces a
+  compile-time `rego_type_error` — policy fails to load.
+- **Dynamic types from `data`** (the common case): both arguments are typed `any`, so
+  OPA skips compile-time checking. At runtime, `object.union` with a non-object argument
+  returns `undefined` — no error, no diagnostic. The rule becomes undefined and all
+  consumers silently skip it.
+
+This means a misconfigured data source that provides an array instead of an object will
+cause policy rules to silently stop evaluating, producing zero violations and zero errors.
+The `{}` default in rule_data.rego is the primary defense against this.
+
+## How does the override precedence work in the merge?
+
+`object.union(A, B)` gives B full override for matching keys. In the merge pattern:
+
+```rego
+pipeline_required_tasks := object.union(data["pipeline-required-tasks"], rule_data.get("pipeline-required-tasks"))
+```
+
+- A = `data["pipeline-required-tasks"]` (from data sources)
+- B = `rule_data.get(...)` which checks, in priority order:
+  1. `data.rule_data__configuration__` (ECP policy ruleData)
+  2. `data.rule_data_custom` (custom user sources)
+  3. `data.rule_data` (default data sources)
+  4. `defaults` map (hardcoded `{}`)
+
+When B has a matching selector key (e.g. `"docker"`), it replaces A's value entirely —
+the arrays are not merged. This is intentional and matches the trusted_tasks precedent.

--- a/policy/lib/rule_data/rule_data.rego
+++ b/policy/lib/rule_data/rule_data.rego
@@ -145,6 +145,9 @@ defaults := {
 	# using the ruleData key. Make this default to an empty dict so we can conveniently
 	# merge it with with `data.trusted_tasks`
 	"trusted_tasks": {},
+	# Used in lib/tekton/pipeline.rego to merge pipeline-required-tasks from
+	# ruleData with data sources, matching the trusted_tasks merge pattern.
+	"pipeline-required-tasks": {},
 	# Used in lib/tekton/trusted.rego to toggle trusted_task_rules on/off
 	"trusted_task_rules_enabled": false,
 	# Number of days before a version of the Task expires that warnings are reported

--- a/policy/lib/tekton/pipeline.rego
+++ b/policy/lib/tekton/pipeline.rego
@@ -2,11 +2,14 @@ package lib.tekton
 
 import rego.v1
 
+import data.lib.rule_data
 import data.lib.time as ectime
 
 pipeline_label := "pipelines.openshift.io/runtime"
 
 task_label := "build.appstudio.redhat.com/build_type"
+
+pipeline_required_tasks := object.union(data["pipeline-required-tasks"], rule_data.get("pipeline-required-tasks"))
 
 latest_required_pipeline_tasks(pipeline) := _merged_required_task_list(pipeline, "newest")
 
@@ -19,7 +22,7 @@ required_task_list(pipeline) := pipeline_data if {
 	selectors := pipeline_label_selectors(pipeline)
 	pipeline_data := [entry |
 		some selector in selectors
-		entries := object.get(data["pipeline-required-tasks"], selector, [])
+		entries := object.get(pipeline_required_tasks, selector, [])
 		some entry in entries
 	]
 	count(pipeline_data) > 0
@@ -37,7 +40,7 @@ _merged_required_task_list(pipeline, mode) := {
 
 	resolved := [r |
 		some selector in selectors
-		entries := object.get(data["pipeline-required-tasks"], selector, [])
+		entries := object.get(pipeline_required_tasks, selector, [])
 		count(entries) > 0
 		r := _resolve(entries, mode)
 	]

--- a/policy/lib/tekton/pipeline.rego
+++ b/policy/lib/tekton/pipeline.rego
@@ -9,7 +9,11 @@ pipeline_label := "pipelines.openshift.io/runtime"
 
 task_label := "build.appstudio.redhat.com/build_type"
 
-pipeline_required_tasks := object.union(data["pipeline-required-tasks"], rule_data.get("pipeline-required-tasks"))
+default _prt_base := {}
+
+_prt_base := data["pipeline-required-tasks"]
+
+pipeline_required_tasks := object.union(_prt_base, rule_data.get("pipeline-required-tasks"))
 
 latest_required_pipeline_tasks(pipeline) := _merged_required_task_list(pipeline, "newest")
 

--- a/policy/lib/tekton/pipeline_test.rego
+++ b/policy/lib/tekton/pipeline_test.rego
@@ -537,23 +537,6 @@ test_task_effective_on_with_one_of_tasks if {
 }
 
 test_pipeline_required_tasks_merges_data_and_rule_data if {
-	task_base := slsav1_task("build-container")
-	task_w_labels := with_labels(task_base, {tekton.task_label: "docker"})
-	task_full := with_results(
-		task_w_labels,
-		[
-			{"name": "IMAGE_URL", "value": "localhost:5000/repo:latest"},
-			# regal ignore:line-length
-			{"name": "IMAGE_DIGEST", "value": "sha256:abc0000000000000000000000000000000000000000000000000000000000abc"},
-		],
-	)
-
-	attestation := slsav1_attestation_full(
-		[task_full],
-		{},
-		{},
-	)
-
 	data_source := {"docker": [{
 		"effective_on": "2024-01-01T00:00:00Z",
 		"tasks": ["buildah", "git-clone"],

--- a/policy/lib/tekton/pipeline_test.rego
+++ b/policy/lib/tekton/pipeline_test.rego
@@ -535,3 +535,78 @@ test_task_effective_on_with_one_of_tasks if {
 	assertions.assert_equal(tekton.task_effective_on(data_with_map, sorted_task), "2024-06-01T00:00:00Z")
 	assertions.assert_equal(tekton.task_effective_on(data_with_map, "buildah"), "2024-01-01T00:00:00Z")
 }
+
+test_pipeline_required_tasks_merges_data_and_rule_data if {
+	task_base := slsav1_task("build-container")
+	task_w_labels := with_labels(task_base, {tekton.task_label: "docker"})
+	task_full := with_results(
+		task_w_labels,
+		[
+			{"name": "IMAGE_URL", "value": "localhost:5000/repo:latest"},
+			# regal ignore:line-length
+			{"name": "IMAGE_DIGEST", "value": "sha256:abc0000000000000000000000000000000000000000000000000000000000abc"},
+		],
+	)
+
+	attestation := slsav1_attestation_full(
+		[task_full],
+		{},
+		{},
+	)
+
+	data_source := {"docker": [{
+		"effective_on": "2024-01-01T00:00:00Z",
+		"tasks": ["buildah", "git-clone"],
+	}]}
+
+	rule_data_config := {"fbc": [{
+		"effective_on": "2024-06-01T00:00:00Z",
+		"tasks": ["fbc-validation"],
+	}]}
+
+	result := tekton.pipeline_required_tasks
+		with data["pipeline-required-tasks"] as data_source
+		with data.rule_data__configuration__["pipeline-required-tasks"] as rule_data_config
+
+	assertions.assert_equal(result, {
+		"docker": [{"effective_on": "2024-01-01T00:00:00Z", "tasks": ["buildah", "git-clone"]}],
+		"fbc": [{"effective_on": "2024-06-01T00:00:00Z", "tasks": ["fbc-validation"]}],
+	})
+}
+
+test_pipeline_required_tasks_rule_data_overrides_on_key_conflict if {
+	task_base := slsav1_task("build-container")
+	task_w_labels := with_labels(task_base, {tekton.task_label: "docker"})
+	task_full := with_results(
+		task_w_labels,
+		[
+			{"name": "IMAGE_URL", "value": "localhost:5000/repo:latest"},
+			# regal ignore:line-length
+			{"name": "IMAGE_DIGEST", "value": "sha256:abc0000000000000000000000000000000000000000000000000000000000abc"},
+		],
+	)
+
+	attestation := slsav1_attestation_full(
+		[task_full],
+		{},
+		{},
+	)
+
+	data_source := {"docker": [{
+		"effective_on": "2024-01-01T00:00:00Z",
+		"tasks": ["buildah", "git-clone"],
+	}]}
+
+	rule_data_config := {"docker": [{
+		"effective_on": "2024-06-01T00:00:00Z",
+		"tasks": ["buildah", "git-clone", "clair-scan"],
+	}]}
+
+	result := tekton.latest_required_pipeline_tasks(attestation)
+		with data["pipeline-required-tasks"] as data_source
+		with data.rule_data__configuration__["pipeline-required-tasks"] as rule_data_config
+
+	# ruleData config overrides data source for the same key
+	assertions.assert_equal(result.tasks, {"buildah", "git-clone", "clair-scan"})
+	assertions.assert_equal(result.effective_on, "2024-06-01T00:00:00Z")
+}

--- a/policy/lib/tekton/pipeline_test.rego
+++ b/policy/lib/tekton/pipeline_test.rego
@@ -547,8 +547,7 @@ test_pipeline_required_tasks_merges_data_and_rule_data if {
 		"tasks": ["fbc-validation"],
 	}]}
 
-	result := tekton.pipeline_required_tasks
-		with data["pipeline-required-tasks"] as data_source
+	result := tekton.pipeline_required_tasks with data["pipeline-required-tasks"] as data_source
 		with data.rule_data__configuration__["pipeline-required-tasks"] as rule_data_config
 
 	assertions.assert_equal(result, {
@@ -585,8 +584,7 @@ test_pipeline_required_tasks_rule_data_overrides_on_key_conflict if {
 		"tasks": ["buildah", "git-clone", "clair-scan"],
 	}]}
 
-	result := tekton.latest_required_pipeline_tasks(attestation)
-		with data["pipeline-required-tasks"] as data_source
+	result := tekton.latest_required_pipeline_tasks(attestation) with data["pipeline-required-tasks"] as data_source
 		with data.rule_data__configuration__["pipeline-required-tasks"] as rule_data_config
 
 	# ruleData config overrides data source for the same key

--- a/policy/lib/tekton/pipeline_test.rego
+++ b/policy/lib/tekton/pipeline_test.rego
@@ -591,3 +591,14 @@ test_pipeline_required_tasks_rule_data_overrides_on_key_conflict if {
 	assertions.assert_equal(result.tasks, {"buildah", "git-clone", "clair-scan"})
 	assertions.assert_equal(result.effective_on, "2024-06-01T00:00:00Z")
 }
+
+test_pipeline_required_tasks_rule_data_only if {
+	rule_data_config := {"docker": [{
+		"effective_on": "2024-06-01T00:00:00Z",
+		"tasks": ["buildah", "git-clone"],
+	}]}
+
+	result := tekton.pipeline_required_tasks with data.rule_data__configuration__["pipeline-required-tasks"] as rule_data_config
+
+	assertions.assert_equal(result, {"docker": [{"effective_on": "2024-06-01T00:00:00Z", "tasks": ["buildah", "git-clone"]}]})
+}

--- a/policy/release/tasks/tasks.rego
+++ b/policy/release/tasks/tasks.rego
@@ -441,7 +441,7 @@ _expiry_msg_annotation := "build.appstudio.redhat.com/expiry-message"
 
 _data_errors contains error if {
 	some e in j.validate_schema(
-		data["pipeline-required-tasks"],
+		tekton.pipeline_required_tasks,
 		{
 			"$schema": "http://json-schema.org/draft-07/schema#",
 			"type": "object",
@@ -481,7 +481,7 @@ _data_errors contains error if {
 }
 
 _data_errors contains error if {
-	some key, entries in data["pipeline-required-tasks"]
+	some key, entries in tekton.pipeline_required_tasks
 	some i, entry in entries
 	effective_on := entry.effective_on
 	not time.parse_rfc3339_ns(effective_on)


### PR DESCRIPTION
#### What:
Merge `pipeline-required-tasks` from the ruleData configuration into the pipeline required tasks used by the tasks policy. This adds a `pipeline_required_tasks` rule in `pipeline.rego` that unions data from both `data["pipeline-required-tasks"]` (data sources) and `data["rule_data__configuration__"]["pipeline-required-tasks"]` (ruleData), and updates all consumers in `pipeline.rego` and `tasks.rego` to use it.

#### Why:
Previously, `pipeline-required-tasks` specified in the `ruleData` field of a policy configuration was silently ignored. The ec CLI places ruleData under `data.rule_data__configuration__`, but the tasks policy accessed `data["pipeline-required-tasks"]` directly — bypassing the ruleData namespace entirely. This meant users could not extend pipeline-required-tasks via their policy config and had to provide a separate data source file instead.

#### Tickets:
- [EC-2024](https://redhat.atlassian.net/browse/EC-2024)