### PR TITLE
docs(EC-1954): add effective_on review checklist to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,19 @@ These files have `effective_on` dates — rules with future dates are warnings, 
 - **Fetch and parse an OCI blob:** use `oci.parsed_blob(ref)` from `data.lib.oci`, not `json.unmarshal(ec.oci.blob(ref))` directly. A Regal lint rule (`prefer-parsed-blob`) enforces this
 - **Add a new collection:** follow the pattern in `policy/release/collection/` — import specific policy packages
 
+## Review Checklist for New Policy Rules
+
+- **`effective_on` date required:** New deny/warn rules MUST include an `effective_on` date in their
+  METADATA annotation (under `custom:`) to provide a migration window before enforcement begins.
+  Rules without `effective_on` enforce immediately on deployment, which can break existing builds
+  without warning. Look for the annotation block above each new `deny contains` or `warn contains`
+  rule and verify it includes `effective_on: <future RFC 3339 date>`. See existing rules in
+  `policy/release/` for the pattern.
+- **Collection membership:** New rules must be added to the appropriate collection(s) in
+  `policy/*/collection/` or they won't be evaluated.
+- **Test coverage:** Every new rule needs tests in a corresponding `_test.rego` file. CI enforces
+  100% coverage.
+
 ## PR Conventions
 
 Conventional commits are encouraged. Run `make ci` before pushing. CI runs on every PR via

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,8 @@ These files have `effective_on` dates — rules with future dates are warnings, 
   Rules without `effective_on` enforce immediately on deployment, which can break existing builds
   without warning. Look for the annotation block above each new `deny contains` or `warn contains`
   rule and verify it includes `effective_on: <future RFC 3339 date>`. See existing rules in
-  `policy/release/` for the pattern.
+  `policy/release/` for the pattern. Rule data entries in `example/data/` YAML files (e.g.,
+  `required_tasks.yml`, `trusted_tekton_tasks.yml`) also use `effective_on` for data-driven rules.
 - **Collection membership:** New rules must be added to the appropriate collection(s) in
   `policy/*/collection/` or they won't be evaluated.
 - **Test coverage:** Every new rule needs tests in a corresponding `_test.rego` file. CI enforces

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,9 +47,9 @@ Every policy rule requires METADATA annotations. Missing or malformed annotation
 
 ## Architecture (design rationale and non-obvious parts)
 
-**Collections** (`policy/*/collection/`) group related rules. Each collection imports specific policy
-packages. Examples: `minimal` (basic validation), `slsa3` (SLSA Level 3), `redhat` (Red Hat-specific).
-When adding a new rule, you must add it to the appropriate collection(s) or it won't be evaluated.
+**Collections** (`policy/*/collection/`) group related rules. Examples: `minimal` (basic validation),
+`slsa3` (SLSA Level 3), `redhat` (Red Hat-specific). New rules declare membership via the
+`collections:` key in their METADATA annotation — see existing rules in `policy/release/` for the pattern.
 
 **SLSA dual-format:** The library in `policy/lib/tekton/` normalizes both SLSA v0.2 and v1.0
 attestation formats. Policies consume the normalized form — don't branch on SLSA version in rules.
@@ -74,8 +74,9 @@ These files have `effective_on` dates — rules with future dates are warnings, 
   rule and verify it includes `effective_on: <future RFC 3339 date>`. See existing rules in
   `policy/release/` for the pattern. Rule data entries in `example/data/` YAML files (e.g.,
   `required_tasks.yml`, `trusted_tekton_tasks.yml`) also use `effective_on` for data-driven rules.
-- **Collection membership:** New rules must be added to the appropriate collection(s) in
-  `policy/*/collection/` or they won't be evaluated.
+- **Collection membership:** New rules must declare membership in the appropriate collection(s) via
+  the `collections:` key in their METADATA annotation. See existing rules in `policy/release/` for
+  the pattern.
 - **Test coverage:** Every new rule needs tests in a corresponding `_test.rego` file. CI enforces
   100% coverage.
 


### PR DESCRIPTION
## Summary
- Add a "Review Checklist for New Policy Rules" section to AGENTS.md
- Ensures AI review agents flag new deny/warn rules missing `effective_on` dates, which would otherwise enforce immediately on deployment
- Also includes checklist items for collection membership and test coverage

Ref: EC-1954
Upstream: https://github.com/conforma/policy/issues/1760

## Test plan
- [ ] Verify the next PRs adding new deny/warn rules get flagged by review agents if `effective_on` is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)