### PR TITLE
Merge trusted task rules instead of first-found

### DIFF
--- a/policy/lib/rule_data/rule_data.rego
+++ b/policy/lib/rule_data/rule_data.rego
@@ -179,9 +179,17 @@ defaults := {
 #   data.rule_data[key_name]
 #   defaults[key_name]
 #
-# And falls back to an empty list if the key is not found anywhere.
+# And falls back to an empty list if the key is not found anywhere
+# (or an empty map if the key is in the _merged_rule_data_keys set).
 #
 get(key_name) := value if {
+	# Special handling for rule data where we want to merge everything
+	# together rather than use the "first found" and ignore the rest.
+	key_name in _merged_rule_data_keys
+	value := _get_merged(key_name)
+}
+
+else := value if {
 	# Expected to be defined under `configuration.rule_data` in the
 	# ECP configuration data being used when EC is run.
 	value := data.rule_data__configuration__[key_name]
@@ -200,3 +208,25 @@ get(key_name) := value if {
 	# If the key is not found, default to an empty list
 	value := []
 }
+
+_get_merged(key_name) := object.union(
+	object.union(_merge_base(key_name), _merge_custom(key_name)),
+	_merge_conf(key_name),
+)
+
+_merge_base(key_name) := data.rule_data[key_name] if {
+	is_object(data.rule_data[key_name])
+} else := {}
+
+_merge_custom(key_name) := data.rule_data_custom[key_name] if {
+	is_object(data.rule_data_custom[key_name])
+} else := {}
+
+_merge_conf(key_name) := data.rule_data__configuration__[key_name] if {
+	is_object(data.rule_data__configuration__[key_name])
+} else := {}
+
+# We want trusted task rules defined in someone's ECP ruleData
+# to merged in with the main Konflux trusted task rules, not
+# replace them entirely, (and perhaps other keys in future).
+_merged_rule_data_keys := {"trusted_task_rules"}

--- a/policy/lib/rule_data/rule_data_test.rego
+++ b/policy/lib/rule_data/rule_data_test.rego
@@ -27,6 +27,69 @@ test_rule_data if {
 		with rule_data.defaults as {"key3": 10}
 }
 
+test_merged_rule_data_all_sources if {
+	assertions.assert_equal(
+		{"a": 1, "b": 2, "c": 3},
+		rule_data.get("trusted_task_rules"),
+	) with data.rule_data__configuration__ as {"trusted_task_rules": {"a": 1}}
+		with data.rule_data_custom as {"trusted_task_rules": {"b": 2}}
+		with data.rule_data as {"trusted_task_rules": {"c": 3}}
+}
+
+test_merged_rule_data_config_wins_on_conflict if {
+	# configuration > custom > rule_data, matching the regular get precedence
+	assertions.assert_equal(
+		{"key": "from_config", "custom_only": 2, "base_only": 3},
+		rule_data.get("trusted_task_rules"),
+	) with data.rule_data__configuration__ as {"trusted_task_rules": {"key": "from_config"}}
+		with data.rule_data_custom as {"trusted_task_rules": {"key": "from_custom", "custom_only": 2}}
+		with data.rule_data as {"trusted_task_rules": {"key": "from_base", "base_only": 3}}
+}
+
+test_merged_rule_data_custom_and_default_only if {
+	assertions.assert_equal(
+		{"a": 1, "b": 2},
+		rule_data.get("trusted_task_rules"),
+	) with data.rule_data_custom as {"trusted_task_rules": {"a": 1}}
+		with data.rule_data as {"trusted_task_rules": {"b": 2}}
+}
+
+test_merged_rule_data_default_only if {
+	assertions.assert_equal(
+		{"c": 3},
+		rule_data.get("trusted_task_rules"),
+	) with data.rule_data as {"trusted_task_rules": {"c": 3}}
+}
+
+test_merged_rule_data_config_only if {
+	assertions.assert_equal(
+		{"a": 1},
+		rule_data.get("trusted_task_rules"),
+	) with data.rule_data__configuration__ as {"trusted_task_rules": {"a": 1}}
+}
+
+test_merged_rule_data_base_and_config if {
+	assertions.assert_equal(
+		{"key": "from_config", "base_only": 2},
+		rule_data.get("trusted_task_rules"),
+	) with data.rule_data__configuration__ as {"trusted_task_rules": {"key": "from_config"}}
+		with data.rule_data as {"trusted_task_rules": {"key": "from_base", "base_only": 2}}
+}
+
+test_merged_rule_data_custom_only if {
+	assertions.assert_equal(
+		{"a": 1},
+		rule_data.get("trusted_task_rules"),
+	) with data.rule_data_custom as {"trusted_task_rules": {"a": 1}}
+}
+
+test_merged_rule_data_none_defined if {
+	assertions.assert_equal(
+		{},
+		rule_data.get("trusted_task_rules"),
+	)
+}
+
 # Need this for 100% coverage
 test_rule_data_defaults if {
 	assertions.assert_not_empty(rule_data.defaults)


### PR DESCRIPTION
For keys in _merged_rule_data_keys (currently just "trusted_task_rules"), merge values from all rule data sources using object.union instead of returning only the highest-priority source. This allows users to extend trusted task rules via ECP ruleData without replacing the base set.

Ref: https://redhat.atlassian.net/browse/EC-2059

