### PR TITLE
feat(EC-2031): remove data.trusted_task_rules in favor of rule_data only

### DIFF
--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -95,8 +95,6 @@ rules:
         - data.rule_data_custom
         - data.trusted_tasks
         - data.trusted_tasks.*
-        - data.trusted_task_rules
-        - data.trusted_task_rules.*
     # To fix this rule, in the policy/lib folder we need to remove the imports
     # from data.lib and use the fully qualified name when using function calls.
     # E.g.: from `lib.assert_equal` to `data.lib.assert_equal`

--- a/policy/lib/intoto/trust_test.rego
+++ b/policy/lib/intoto/trust_test.rego
@@ -235,7 +235,7 @@ test_verified_statement_happy_path if {
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.blob as _mock_blob
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(result) == 1
@@ -277,7 +277,7 @@ test_untrusted_tasks if {
 		with ec.sigstore.verify_attestation as _mock_verify_success
 		with ec.oci.blob as _mock_blob
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as no_matching_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as no_matching_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(result) == 0
@@ -293,7 +293,7 @@ test_denied_tasks if {
 		with ec.sigstore.verify_attestation as _mock_verify_success
 		with ec.oci.blob as _mock_blob
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as deny_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as deny_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(result) == 0
@@ -305,7 +305,7 @@ test_empty_tasks_vacuous_truth_guard if {
 		with ec.sigstore.verify_attestation as _mock_verify_empty_tasks
 		with ec.oci.blob as _mock_blob
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(result) == 0
@@ -317,7 +317,7 @@ test_bundleless_tasks if {
 		with ec.sigstore.verify_attestation as _mock_verify_bundleless_tasks
 		with ec.oci.blob as _mock_blob
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(result) == 0
@@ -330,7 +330,7 @@ test_multiple_statements_mixed if {
 		with ec.oci.image_manifest as _mock_image_manifest_multi
 		with ec.oci.blob as _mock_blob_multi
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(result) == 1
@@ -345,7 +345,7 @@ test_verified_statements_by_predicate if {
 		with ec.oci.image_manifest as _mock_image_manifest_multi
 		with ec.oci.blob as _mock_blob_multi
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(result) == 1
@@ -359,7 +359,7 @@ test_mixed_bundle_and_inline_tasks if {
 		with ec.sigstore.verify_attestation as _mock_verify_mixed_bundle_inline
 		with ec.oci.blob as _mock_blob
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(result) == 0
@@ -372,7 +372,7 @@ test_existential_attestation_matching if {
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.blob as _mock_blob
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(result) == 1
@@ -385,7 +385,7 @@ test_unrecognized_statement_type if {
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.blob as _mock_blob_unknown_type
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(result) == 0
@@ -398,7 +398,7 @@ test_malformed_blob if {
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.blob as _mock_blob_malformed
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(result) == 0
@@ -410,7 +410,7 @@ test_provenance_subject_digest_mismatch if {
 		with ec.sigstore.verify_attestation as _mock_verify_wrong_subject
 		with ec.oci.blob as _mock_blob
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(result) == 0

--- a/policy/lib/tekton/trusted.rego
+++ b/policy/lib/tekton/trusted.rego
@@ -135,43 +135,11 @@ is_trusted_task_rules(task, bundle_manifests) if {
 	_task_matches_allow_rule(ref, bundle_manifests)
 }
 
-# Merging in the trusted_task_rules rule data
 _trusted_task_rules_data := {
-	"allow": array.concat(
-		_data_allow_array, # add effective allow rules
-		_rule_data_allow_array,
-	),
-	"deny": array.concat(
-		_data_deny_array, # add effective deny rules
-		_rule_data_deny_array,
-	),
+	"allow": _rule_data_allow_array,
+	"deny": _rule_data_deny_array,
 }
 
-# Safely extract allow rules from data.trusted_task_rules.
-# Each key maps to an array of rule objects; we flatten all arrays into one list.
-default _data_allow_array := []
-
-_data_allow_array := [rule |
-	some rules in data.trusted_task_rules.allow
-	some rule in rules
-] if {
-	is_object(data.trusted_task_rules)
-	is_object(data.trusted_task_rules.allow)
-}
-
-# Safely extract deny rules from data.trusted_task_rules.
-default _data_deny_array := []
-
-_data_deny_array := [rule |
-	some rules in data.trusted_task_rules.deny
-	some rule in rules
-] if {
-	is_object(data.trusted_task_rules)
-	is_object(data.trusted_task_rules.deny)
-}
-
-# Safely extract allow rules from rule_data.
-# Each key maps to an array of rule objects; we flatten all arrays into one list.
 default _rule_data_allow_array := []
 
 _rule_data_allow_array := [rule |
@@ -183,7 +151,6 @@ _rule_data_allow_array := [rule |
 	is_object(_rule_data_obj.allow)
 }
 
-# Safely extract deny rules from rule_data.
 default _rule_data_deny_array := []
 
 _rule_data_deny_array := [rule |
@@ -287,21 +254,6 @@ data_errors contains error if {
 	error := {
 		"message": sprintf("trusted_task_rules data has unexpected format: %s", [e.message]),
 		"severity": e.severity,
-	}
-}
-
-data_errors contains error if {
-	some rule_type in ["allow", "deny"]
-	some group, rules in data.trusted_task_rules[rule_type]
-	some i, rule in rules
-	"effective_on" in object.keys(rule)
-	not time.parse_rfc3339_ns(rule.effective_on)
-	error := {
-		"message": sprintf(
-			"trusted_task_rules.%s.%s[%d].effective_on is not valid RFC3339 format: %q",
-			[rule_type, group, i, rule.effective_on],
-		),
-		"severity": "failure",
 	}
 }
 

--- a/policy/lib/tekton/trusted_test.rego
+++ b/policy/lib/tekton/trusted_test.rego
@@ -485,43 +485,6 @@ test_rule_data_merging if {
 		with data.rule_data.trusted_tasks as {"foo": "bar"}
 }
 
-test_data_trusted_task_rules_extraction if {
-	# Test extraction from data.trusted_task_rules (covers lines 144-156)
-	# Test when data.trusted_task_rules is provided with allow rules
-	data_rules_allow := {"allow": {"local-tasks": [{"pattern": "oci://registry.local/*"}]}}
-
-	# Task matching allow from data.trusted_task_rules should be trusted
-	allowed_task := {"spec": {"taskRef": {"resolver": "bundles", "params": [
-		# regal ignore:line-length
-		{"name": "bundle", "value": "registry.local/trusty:1.0@sha256:d19e5700000000000000000000000000000000000000000000000000d19e5700"},
-		{"name": "name", "value": "trusty"},
-		{"name": "kind", "value": "task"},
-	]}}}
-	tekton.is_trusted_task(allowed_task, _empty_bundle_manifests) with data.trusted_task_rules as data_rules_allow
-		with data.rule_data.trusted_task_rules as null
-		with data.rule_data.trusted_task_rules_enabled as true
-
-	# Test when data.trusted_task_rules is provided with deny rules
-	data_rules_deny := {"deny": {"blocked": [{"pattern": "oci://registry.local/crook/*"}]}}
-
-	# Task matching deny from data.trusted_task_rules should not be trusted
-	denied_task := {"spec": {"taskRef": {"resolver": "bundles", "params": [
-		# regal ignore:line-length
-		{"name": "bundle", "value": "registry.local/crook:1.0@sha256:d19e5700000000000000000000000000000000000000000000000000d19e5700"},
-		{"name": "name", "value": "crook"},
-		{"name": "kind", "value": "task"},
-	]}}}
-	not tekton.is_trusted_task(denied_task, _empty_bundle_manifests) with data.trusted_task_rules as data_rules_deny
-		with data.rule_data.trusted_task_rules as null
-		with data.rule_data.trusted_task_rules_enabled as true
-
-	# Test when data.trusted_task_rules is not provided (covers default cases 145, 152)
-	# Should fall back to empty arrays, so task won't be trusted via rules
-	not tekton.is_trusted_task(allowed_task, _empty_bundle_manifests) with data.trusted_task_rules as null
-		with data.rule_data.trusted_task_rules as null
-		with data.rule_data.trusted_task_rules_enabled as true
-}
-
 test_rule_data_trusted_task_rules_extraction if {
 	# Test extraction from lib_rule_data("trusted_task_rules") (covers lines 158-172)
 	# Test when lib_rule_data returns an object
@@ -843,17 +806,24 @@ test_trusted_task_rules_data_errors if {
 	assertions.assert_equal(tekton.data_errors, expected_structure) with data.rule_data.trusted_task_rules as invalid_structure
 		with data.rule_data.trusted_task_rules_enabled as true
 
-	# effective_on that fails time.parse_rfc3339_ns (via data.trusted_task_rules to bypass schema validation)
 	unparseable_date_rules := {"deny": {"blocked": [{
 		"pattern": "oci://quay.io/konflux-ci/tekton-catalog/*",
 		"effective_on": "2025-13-01T00:00:00Z",
 	}]}}
-	expected_unparseable := {{
-		# regal ignore:line-length
-		"message": "trusted_task_rules.deny.blocked[0].effective_on is not valid RFC3339 format: \"2025-13-01T00:00:00Z\"",
-		"severity": "failure",
-	}}
-	assertions.assert_equal(tekton.data_errors, expected_unparseable) with data.trusted_task_rules as unparseable_date_rules
+	expected_unparseable := {
+		{
+			# regal ignore:line-length
+			"message": "trusted_task_rules data has unexpected format: deny.blocked.0.effective_on: Does not match format 'date-time'",
+			"severity": "failure",
+		},
+		{
+			# regal ignore:line-length
+			"message": "trusted_task_rules.deny.blocked[0].effective_on is not valid RFC3339 format: \"2025-13-01T00:00:00Z\"",
+			"severity": "failure",
+		},
+	}
+	assertions.assert_equal(tekton.data_errors, expected_unparseable) with data.rule_data.trusted_task_rules as unparseable_date_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 }
 
 # Test denying_pattern with invalid task (covers else branch at line 337)

--- a/policy/release/test_attestation/test_attestation_test.rego
+++ b/policy/release/test_attestation/test_attestation_test.rego
@@ -291,7 +291,7 @@ test_all_passed_no_violations if {
 		with ec.oci.blob as _mock_blob_passed
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 
 	assertions.assert_empty(test_attestation.warn) with input.image.ref as _image_ref
@@ -300,7 +300,7 @@ test_all_passed_no_violations if {
 		with ec.oci.blob as _mock_blob_passed
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 }
 
@@ -317,7 +317,7 @@ test_failed_with_details if {
 		with ec.oci.blob as _mock_blob_failed_with_details
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 }
 
@@ -334,7 +334,7 @@ test_failed_no_details if {
 		with ec.oci.blob as _mock_blob_failed_no_details
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 }
 
@@ -347,7 +347,7 @@ test_warned_with_details if {
 		with ec.oci.blob as _mock_blob_warned
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 
 	assertions.assert_equal_results(test_attestation.warn, {{
@@ -360,7 +360,7 @@ test_warned_with_details if {
 		with ec.oci.blob as _mock_blob_warned
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 }
 
@@ -377,7 +377,7 @@ test_unknown_result_value if {
 		with ec.oci.blob as _mock_blob_unknown_result
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 }
 
@@ -392,7 +392,7 @@ test_erred_result if {
 		with ec.oci.blob as _mock_blob_erred_result
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 }
 
@@ -409,7 +409,7 @@ test_missing_result_field if {
 		with ec.oci.blob as _mock_blob_missing_result
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 }
 
@@ -426,7 +426,7 @@ test_mixed_passed_and_failed if {
 		with ec.oci.blob as _mock_blob_mixed
 		with ec.oci.image_manifest as _mock_image_manifest_multi
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 
 	assertions.assert_empty(test_attestation.warn) with input.image.ref as _image_ref
@@ -435,7 +435,7 @@ test_mixed_passed_and_failed if {
 		with ec.oci.blob as _mock_blob_mixed
 		with ec.oci.image_manifest as _mock_image_manifest_multi
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 }
 
@@ -458,7 +458,7 @@ test_test_name_from_configuration if {
 		with ec.oci.blob as _mock_blob_custom_config
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 
 	some r in results
@@ -474,7 +474,7 @@ test_test_name_fallback if {
 		with ec.oci.blob as _mock_blob_no_config
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 
 	some r in results
@@ -494,7 +494,7 @@ test_warned_and_failed_coexist if {
 		with ec.oci.blob as _mock_blob_warned_and_failed
 		with ec.oci.image_manifest as _mock_image_manifest_multi
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 
 	assertions.assert_equal_results(test_attestation.warn, {{
@@ -507,7 +507,7 @@ test_warned_and_failed_coexist if {
 		with ec.oci.blob as _mock_blob_warned_and_failed
 		with ec.oci.image_manifest as _mock_image_manifest_multi
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 }
 
@@ -520,7 +520,7 @@ test_multiple_failures_deny if {
 		with ec.oci.blob as _mock_blob_multi_failed
 		with ec.oci.image_manifest as _mock_image_manifest_multi
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(results) == 2
@@ -543,7 +543,7 @@ test_multiple_failures_no_warn if {
 		with ec.oci.blob as _mock_blob_multi_failed
 		with ec.oci.image_manifest as _mock_image_manifest_multi
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 }
 
@@ -556,7 +556,7 @@ test_non_string_result if {
 		with ec.oci.blob as _mock_blob_non_string_result
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(results) == 1
@@ -580,7 +580,7 @@ test_missing_predicate if {
 		with ec.oci.blob as _mock_blob_missing_predicate
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(results) == 1
@@ -608,7 +608,7 @@ test_failures_count_only if {
 		with ec.oci.blob as _mock_blob_failures_count_only
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 }
 
@@ -629,7 +629,7 @@ test_warnings_count_only if {
 		with ec.oci.blob as _mock_blob_warnings_count_only
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 }
 
@@ -647,7 +647,7 @@ test_false_result_value if {
 		with ec.oci.blob as _mock_blob_false_result
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(results) == 1
@@ -667,7 +667,7 @@ test_null_result_value if {
 		with ec.oci.blob as _mock_blob_null_result
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(results) == 1
@@ -689,7 +689,7 @@ test_empty_string_result_value if {
 		with ec.oci.blob as _mock_blob_empty_string_result
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 
 	count(results) == 1
@@ -717,7 +717,7 @@ test_count_triggers_deny if {
 		with ec.oci.blob as _mock_blob_count_triggers_deny
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 
 	some r in results
@@ -747,7 +747,7 @@ test_skipped_result if {
 		with ec.oci.blob as _mock_blob_skipped
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 }
 
@@ -761,7 +761,7 @@ test_informative_test_warns_instead_of_denies if {
 		with ec.oci.blob as _mock_blob_failed_with_details
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 		with data.rule_data.informative_test_attestations as ["clair-scan"]
 
@@ -771,7 +771,7 @@ test_informative_test_warns_instead_of_denies if {
 		with ec.oci.blob as _mock_blob_failed_with_details
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 		with data.rule_data.informative_test_attestations as ["clair-scan"]
 
@@ -787,7 +787,7 @@ test_non_informative_test_still_denies if {
 		with ec.oci.blob as _mock_blob_failed_with_details
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 		with data.rule_data.informative_test_attestations as ["some-other-test"]
 
@@ -814,7 +814,7 @@ test_subject_mismatch_denied if {
 		with ec.oci.blob as _mock_blob_wrong_subject
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 
 	_has_code(results, "test_attestation.subject_mismatch")
@@ -828,7 +828,7 @@ test_subject_match_passes if {
 		with ec.oci.blob as _mock_blob_passed
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 
 	not _has_code(results, "test_attestation.subject_mismatch")
@@ -850,7 +850,7 @@ test_missing_subject_triggers_mismatch if {
 		with ec.oci.blob as _mock_blob_no_subject
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 
 	_has_code(results, "test_attestation.subject_mismatch")
@@ -870,7 +870,7 @@ test_rule_data_valid_no_errors if {
 		with ec.oci.blob as _mock_blob_passed
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 
 	not _has_code(results, "test_attestation.rule_data_provided")
@@ -883,7 +883,7 @@ test_rule_data_invalid_triggers_error if {
 		with ec.oci.blob as _mock_blob_passed
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 		with data.rule_data.supported_test_attestation_results as ["INVALID_VALUE"]
 
@@ -901,7 +901,7 @@ test_custom_failed_results if {
 		with ec.oci.blob as _mock_blob_warned
 		with ec.oci.image_manifest as _mock_image_manifest
 		with ec.oci.image_manifests as _mock_manifests
-		with data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
 		with data.rule_data.trusted_task_rules_enabled as true
 		with data.rule_data.failed_test_attestation_results as ["WARNED"]
 


### PR DESCRIPTION
## Summary

- Remove the unvalidated `data.trusted_task_rules` input path — all trusted task rules now flow exclusively through `lib_rule_data("trusted_task_rules")` which receives JSON schema validation
- Simplify `_trusted_task_rules_data` by removing the `array.concat` merge logic
- Delete the dedicated `data_errors` validator for the old path
- Remove `.regal/config.yaml` exemptions for `data.trusted_task_rules`
- Update all tests to supply data via `data.rule_data.trusted_task_rules`

Resolves [EC-2031](https://redhat.atlassian.net/browse/EC-2031)