### PR TITLE
Deduplicate test-result attestations by test name

### DIFF
--- a/antora/docs/modules/ROOT/pages/packages/release_test_attestation.adoc
+++ b/antora/docs/modules/ROOT/pages/packages/release_test_attestation.adoc
@@ -18,7 +18,7 @@ Produce a violation if any test result attestation has an erred result. The resu
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Test attestation %q has an erred result`
 * Code: `test_attestation.no_erred_test_attestations`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/test_attestation/test_attestation.rego#L211[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/test_attestation/test_attestation.rego#L236[Source, window="_blank"]
 
 [#test_attestation__no_failed_informative_test_attestations]
 === link:#test_attestation__no_failed_informative_test_attestations[No failed informative test attestations]
@@ -30,7 +30,7 @@ Produce a warning if any informative test attestation has a failed result. Infor
 * Rule type: [rule-type-indicator warning]#WARNING#
 * WARNING message: `Informative test attestation %q has a failed result, failures: %s`
 * Code: `test_attestation.no_failed_informative_test_attestations`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/test_attestation/test_attestation.rego#L63[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/test_attestation/test_attestation.rego#L88[Source, window="_blank"]
 
 [#test_attestation__no_failed_tests]
 === link:#test_attestation__no_failed_tests[No failed test attestations]
@@ -42,7 +42,7 @@ Produce a violation if any non-informative test result attestation has a failed 
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Test attestation %q has a failed result, failures: %s`
 * Code: `test_attestation.no_failed_tests`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/test_attestation/test_attestation.rego#L122[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/test_attestation/test_attestation.rego#L147[Source, window="_blank"]
 
 [#test_attestation__no_skipped_test_attestations]
 === link:#test_attestation__no_skipped_test_attestations[No skipped test attestations]
@@ -54,7 +54,7 @@ Produce a violation if any test result attestation has a skipped result. A skipp
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Test attestation %q has a skipped result`
 * Code: `test_attestation.no_skipped_test_attestations`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/test_attestation/test_attestation.rego#L241[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/test_attestation/test_attestation.rego#L266[Source, window="_blank"]
 
 [#test_attestation__no_test_warnings]
 === link:#test_attestation__no_test_warnings[No test attestation warnings]
@@ -66,7 +66,7 @@ Produce a warning if any test result attestation has a warned result. Warned tes
 * Rule type: [rule-type-indicator warning]#WARNING#
 * WARNING message: `Test attestation %q has warnings, warnings: %s`
 * Code: `test_attestation.no_test_warnings`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/test_attestation/test_attestation.rego#L94[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/test_attestation/test_attestation.rego#L119[Source, window="_blank"]
 
 [#test_attestation__test_result_known]
 === link:#test_attestation__test_result_known[No unsupported test attestation result values]
@@ -78,7 +78,7 @@ Ensure the result field of each test result attestation is a recognized value. V
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Test attestation %q has an unsupported result value %q`
 * Code: `test_attestation.test_result_known`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/test_attestation/test_attestation.rego#L154[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/test_attestation/test_attestation.rego#L179[Source, window="_blank"]
 
 [#test_attestation__rule_data_provided]
 === link:#test_attestation__rule_data_provided[Rule data provided]
@@ -90,7 +90,7 @@ Confirm the expected rule data keys have been provided in the expected format. T
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `test_attestation.rule_data_provided`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/test_attestation/test_attestation.rego#L305[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/test_attestation/test_attestation.rego#L330[Source, window="_blank"]
 
 [#test_attestation__test_data_found]
 === link:#test_attestation__test_data_found[Test attestation data includes result]
@@ -102,7 +102,7 @@ Each test result attestation must include a result field in its predicate. Verif
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Test attestation %q is missing the required result field`
 * Code: `test_attestation.test_data_found`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/test_attestation/test_attestation.rego#L184[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/test_attestation/test_attestation.rego#L209[Source, window="_blank"]
 
 [#test_attestation__subject_mismatch]
 === link:#test_attestation__subject_mismatch[Test attestation subject matches image]
@@ -114,4 +114,4 @@ Verify that each test-result attestation's subject includes the digest of the im
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Test attestation %q subject does not match image digest %q`
 * Code: `test_attestation.subject_mismatch`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/test_attestation/test_attestation.rego#L273[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/test_attestation/test_attestation.rego#L298[Source, window="_blank"]

--- a/policy/release/test_attestation/test_attestation.rego
+++ b/policy/release/test_attestation/test_attestation.rego
@@ -34,7 +34,32 @@ import data.lib.json as j
 import data.lib.metadata
 import data.lib.rule_data
 
-_test_attestations := intoto.verified_statements_by_predicate(intoto.predicate_test_result)
+_all_test_attestations := intoto.verified_statements_by_predicate(intoto.predicate_test_result)
+
+_attestation_timestamp(statement) := ts if {
+	ts := statement.predicate.timestamp
+	is_string(ts)
+	ts != ""
+}
+
+_test_attestations contains statement if {
+	# Group statements by name first (avoids re-scanning for each attestation)
+	grouped := {name: statements |
+		some name in {_test_name(s) | some s in _all_test_attestations}
+		statements := {s |
+			some s in _all_test_attestations
+			_test_name(s) == name
+		}
+	}
+
+	# For each group, find max timestamp once
+	some name, statements in grouped
+	max_ts := max({_attestation_timestamp(s) | some s in statements})
+
+	# Filter to latest
+	some statement in statements
+	_attestation_timestamp(statement) == max_ts
+}
 
 _test_name(statement) := name if {
 	predicate := object.get(statement, "predicate", {})

--- a/policy/release/test_attestation/test_attestation_test.rego
+++ b/policy/release/test_attestation/test_attestation_test.rego
@@ -106,11 +106,13 @@ _mock_image_manifest_multi(ref) := {"layers": [{"digest": _layer_digest_2}]} if 
 	contains(ref, "stmt000000000000000000000000000000000000000000000000000000000002")
 }
 
+_default_timestamp := "2025-01-01T00:00:00Z"
+
 _make_statement(predicate) := json.marshal({
 	"_type": "https://in-toto.io/Statement/v1",
 	"predicateType": "https://in-toto.io/attestation/test-result/v0.1",
 	"subject": [{"name": "registry.io/repo/image", "digest": {"sha256": "abc123"}}],
-	"predicate": predicate,
+	"predicate": object.union(predicate, {"timestamp": _default_timestamp}),
 })
 
 # Package-level mock blob functions for each test scenario
@@ -279,6 +281,7 @@ _mock_blob_non_string_result(_) := json.marshal({
 	"predicate": {
 		"result": 42,
 		"configuration": [{"name": "bad-producer"}],
+		"timestamp": _default_timestamp,
 	},
 })
 
@@ -571,6 +574,7 @@ _mock_blob_missing_predicate(_) := json.marshal({
 	"_type": "https://in-toto.io/Statement/v1",
 	"predicateType": "https://in-toto.io/attestation/test-result/v0.1",
 	"subject": [{"name": "registry.io/repo/image", "digest": {"sha256": "abc123"}}],
+	"predicate": {"timestamp": _default_timestamp},
 })
 
 test_missing_predicate if {
@@ -804,6 +808,7 @@ _mock_blob_wrong_subject(_) := json.marshal({
 	"predicate": {
 		"result": "PASSED",
 		"configuration": [{"name": "mismatched-test"}],
+		"timestamp": _default_timestamp,
 	},
 })
 
@@ -840,6 +845,7 @@ _mock_blob_no_subject(_) := json.marshal({
 	"predicate": {
 		"result": "PASSED",
 		"configuration": [{"name": "no-subject-test"}],
+		"timestamp": _default_timestamp,
 	},
 })
 
@@ -907,4 +913,194 @@ test_custom_failed_results if {
 
 	some r in results
 	r.code == "test_attestation.no_failed_tests"
+}
+
+# =============================================================================
+# DEDUP TESTS: EC-2082
+# =============================================================================
+
+_make_statement_with_ts(predicate, ts) := json.marshal({
+	"_type": "https://in-toto.io/Statement/v1",
+	"predicateType": "https://in-toto.io/attestation/test-result/v0.1",
+	"subject": [{"name": "registry.io/repo/image", "digest": {"sha256": "abc123"}}],
+	"predicate": object.union(predicate, {"timestamp": ts}),
+})
+
+_make_statement_no_ts(predicate) := json.marshal({
+	"_type": "https://in-toto.io/Statement/v1",
+	"predicateType": "https://in-toto.io/attestation/test-result/v0.1",
+	"subject": [{"name": "registry.io/repo/image", "digest": {"sha256": "abc123"}}],
+	"predicate": predicate,
+})
+
+# --- Dedup: latest PASSED supersedes older FAILED (same test name) ---
+
+_mock_blob_dedup_latest_passed(ref) := _make_statement_with_ts(
+	{
+		"result": "FAILED",
+		"configuration": [{"name": "clair-scan"}],
+		"failures": 1,
+	},
+	"2025-01-01T00:00:00Z",
+) if {
+	contains(ref, "1a0e000000000000000000000000000000000000000000000000000000000001")
+}
+
+_mock_blob_dedup_latest_passed(ref) := _make_statement_with_ts(
+	{
+		"result": "PASSED",
+		"configuration": [{"name": "clair-scan"}],
+		"successes": 1,
+		"failures": 0,
+	},
+	"2025-01-02T00:00:00Z",
+) if {
+	contains(ref, "1a0e000000000000000000000000000000000000000000000000000000000002")
+}
+
+test_dedup_latest_passed_supersedes_older_failed if {
+	assertions.assert_empty(test_attestation.deny) with input.image.ref as _image_ref
+		with ec.oci.image_referrers as _mock_referrers_two
+		with ec.sigstore.verify_attestation as _mock_verify_two
+		with ec.oci.blob as _mock_blob_dedup_latest_passed
+		with ec.oci.image_manifest as _mock_image_manifest_multi
+		with ec.oci.image_manifests as _mock_manifests
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
+
+	assertions.assert_empty(test_attestation.warn) with input.image.ref as _image_ref
+		with ec.oci.image_referrers as _mock_referrers_two
+		with ec.sigstore.verify_attestation as _mock_verify_two
+		with ec.oci.blob as _mock_blob_dedup_latest_passed
+		with ec.oci.image_manifest as _mock_image_manifest_multi
+		with ec.oci.image_manifests as _mock_manifests
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
+}
+
+# --- Dedup: latest FAILED supersedes older PASSED (same test name) ---
+
+_mock_blob_dedup_latest_failed(ref) := _make_statement_with_ts(
+	{
+		"result": "PASSED",
+		"configuration": [{"name": "clair-scan"}],
+		"successes": 1,
+		"failures": 0,
+	},
+	"2025-01-01T00:00:00Z",
+) if {
+	contains(ref, "1a0e000000000000000000000000000000000000000000000000000000000001")
+}
+
+_mock_blob_dedup_latest_failed(ref) := _make_statement_with_ts(
+	{
+		"result": "FAILED",
+		"configuration": [{"name": "clair-scan"}],
+		"failures": 1,
+	},
+	"2025-01-02T00:00:00Z",
+) if {
+	contains(ref, "1a0e000000000000000000000000000000000000000000000000000000000002")
+}
+
+test_dedup_latest_failed_supersedes_older_passed if {
+	assertions.assert_equal_results(test_attestation.deny, {{
+		"code": "test_attestation.no_failed_tests",
+		"msg": "Test attestation \"clair-scan\" has a failed result, failures: 1",
+		"term": "clair-scan",
+	}}) with input.image.ref as _image_ref
+		with ec.oci.image_referrers as _mock_referrers_two
+		with ec.sigstore.verify_attestation as _mock_verify_two
+		with ec.oci.blob as _mock_blob_dedup_latest_failed
+		with ec.oci.image_manifest as _mock_image_manifest_multi
+		with ec.oci.image_manifests as _mock_manifests
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
+}
+
+# --- Dedup: different test names are independent ---
+
+_mock_blob_dedup_diff_names(ref) := _make_statement_with_ts(
+	{
+		"result": "FAILED",
+		"configuration": [{"name": "clair-scan"}],
+		"failures": 1,
+	},
+	"2025-01-01T00:00:00Z",
+) if {
+	contains(ref, "1a0e000000000000000000000000000000000000000000000000000000000001")
+}
+
+_mock_blob_dedup_diff_names(ref) := _make_statement_with_ts(
+	{
+		"result": "FAILED",
+		"configuration": [{"name": "sanity-check"}],
+		"failures": 1,
+	},
+	"2025-01-02T00:00:00Z",
+) if {
+	contains(ref, "1a0e000000000000000000000000000000000000000000000000000000000002")
+}
+
+test_dedup_different_test_names_independent if {
+	results := test_attestation.deny with input.image.ref as _image_ref
+		with ec.oci.image_referrers as _mock_referrers_two
+		with ec.sigstore.verify_attestation as _mock_verify_two
+		with ec.oci.blob as _mock_blob_dedup_diff_names
+		with ec.oci.image_manifest as _mock_image_manifest_multi
+		with ec.oci.image_manifests as _mock_manifests
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
+
+	count(results) == 2
+	deny_terms := {r.term | some r in results}
+	assertions.assert_equal(deny_terms, {"clair-scan", "sanity-check"})
+}
+
+# --- Dedup: attestation without timestamp is excluded ---
+
+_mock_blob_dedup_no_ts(_) := _make_statement_no_ts({
+	"result": "FAILED",
+	"configuration": [{"name": "clair-scan"}],
+	"failures": 1,
+})
+
+test_dedup_no_timestamp_excluded if {
+	assertions.assert_empty(test_attestation.deny) with input.image.ref as _image_ref
+		with ec.oci.image_referrers as _mock_referrers
+		with ec.sigstore.verify_attestation as _mock_verify_success
+		with ec.oci.blob as _mock_blob_dedup_no_ts
+		with ec.oci.image_manifest as _mock_image_manifest
+		with ec.oci.image_manifests as _mock_manifests
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
+}
+
+# --- Dedup: all attestations for a test name lack timestamps ---
+
+_mock_blob_dedup_all_no_ts(ref) := _make_statement_no_ts({
+	"result": "FAILED",
+	"configuration": [{"name": "clair-scan"}],
+	"failures": 1,
+}) if {
+	contains(ref, "1a0e000000000000000000000000000000000000000000000000000000000001")
+}
+
+_mock_blob_dedup_all_no_ts(ref) := _make_statement_no_ts({
+	"result": "PASSED",
+	"configuration": [{"name": "clair-scan"}],
+	"successes": 1,
+}) if {
+	contains(ref, "1a0e000000000000000000000000000000000000000000000000000000000002")
+}
+
+test_dedup_all_missing_timestamps_excluded if {
+	assertions.assert_empty(test_attestation.deny) with input.image.ref as _image_ref
+		with ec.oci.image_referrers as _mock_referrers_two
+		with ec.sigstore.verify_attestation as _mock_verify_two
+		with ec.oci.blob as _mock_blob_dedup_all_no_ts
+		with ec.oci.image_manifest as _mock_image_manifest_multi
+		with ec.oci.image_manifests as _mock_manifests
+		with data.rule_data.trusted_task_rules as _trusted_task_rules.trusted_task_rules
+		with data.rule_data.trusted_task_rules_enabled as true
 }


### PR DESCRIPTION
When a test task is re-run, each execution produces a separate test-result attestation. Previously all attestations were evaluated, so a stale FAILED result would block even after a successful re-run.

Group attestations by test name (predicate.configuration[0].name) and keep only the one with the latest predicate.timestamp. Attestations without a timestamp are excluded from evaluation entirely.

[EC-2082](https://redhat.atlassian.net/browse/EC-2082)

